### PR TITLE
fix: 修复线上资源管理器 5 个 UX 问题

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,7 +7,7 @@ import {
   Snackbar,
   Stack,
 } from "@mui/material";
-import React, { useEffect, useRef, useState } from "react";
+import React, { useCallback, useEffect, useRef, useState } from "react";
 
 import Header from "./Header";
 import LoginDialog from "./LoginDialog";
@@ -60,9 +60,9 @@ function AppContent() {
     });
   }, [transferQueue]);
 
-  const onNotify: NotifyFn = (message, severity = "info") => {
+  const onNotify: NotifyFn = useCallback((message, severity = "info") => {
     setSnackbar({ message, severity });
-  };
+  }, []);
 
   return (
     <Stack sx={{ height: "100%" }}>

--- a/src/FileActionSheet.tsx
+++ b/src/FileActionSheet.tsx
@@ -123,7 +123,10 @@ function FileActionSheet({
       open={open}
       onClose={onClose}
       anchorReference="anchorPosition"
-      anchorPosition={anchorPosition ?? undefined}
+      anchorPosition={anchorPosition ?? { top: 0, left: 0 }}
+      disableAutoFocusItem
+      onClick={(event) => event.stopPropagation()}
+      MenuListProps={{ dense: false, sx: { minWidth: 180 } }}
     >
       {file &&
         actions.map((action) => (

--- a/src/FileGrid.tsx
+++ b/src/FileGrid.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useRef } from "react";
 import {
   Box,
   Checkbox,
@@ -59,7 +59,20 @@ function FileGrid({
     onOpenMenu({ clientX: event.clientX, clientY: event.clientY }, file);
   };
 
+  const pointer = useRef({ x: 0, y: 0, dragging: false });
+
+  const markPointer = (event: { clientX: number; clientY: number }) => {
+    pointer.current = { x: event.clientX, y: event.clientY, dragging: false };
+  };
+
+  const beginDrag = (event: React.DragEvent, file: FileItem) => {
+    pointer.current.dragging = true;
+    event.dataTransfer.setData("application/x-flaredrive", file.key);
+    event.dataTransfer.effectAllowed = "move";
+  };
+
   const clickItem = (file: FileItem) => {
+    if (pointer.current.dragging) return;
     if (isDirectory(file)) onNavigate(file.key);
     else onOpen(file.key);
   };
@@ -69,6 +82,8 @@ function FileGrid({
       size="small"
       checked={isSelected(file)}
       inputProps={{ "aria-label": `选择 ${file.name}` }}
+      onPointerDown={(event) => event.stopPropagation()}
+      onMouseDown={(event) => event.stopPropagation()}
       onClick={(event) => {
         event.stopPropagation();
         onToggleSelect(file.key);
@@ -81,10 +96,21 @@ function FileGrid({
     <IconButton
       size="small"
       aria-label={`${file.name} 操作`}
-      sx={sx}
+      sx={{ zIndex: 2, ...(sx || {}) }}
+      onPointerDown={(event) => {
+        event.stopPropagation();
+      }}
+      onMouseDown={(event) => {
+        event.stopPropagation();
+        event.preventDefault();
+      }}
       onClick={(event) => {
         event.stopPropagation();
-        openMenu(event, file);
+        event.preventDefault();
+        const { clientX, clientY } = event;
+        window.setTimeout(() => {
+          onOpenMenu({ clientX, clientY }, file);
+        }, 0);
       }}
     >
       <MoreHorizIcon />
@@ -109,13 +135,11 @@ function FileGrid({
   const itemList = (file: FileItem) => (
     <ListItemButton
       selected={isSelected(file)}
+      onPointerDown={markPointer}
       onClick={() => clickItem(file)}
       onContextMenu={(event) => openMenu(event, file)}
       draggable
-      onDragStart={(event) => {
-        event.dataTransfer.setData("application/x-flaredrive", file.key);
-        event.dataTransfer.effectAllowed = "move";
-      }}
+      onDragStart={(event) => beginDrag(event, file)}
       {...folderDrop(file)}
       sx={{
         userSelect: "none",
@@ -151,16 +175,14 @@ function FileGrid({
     <Box
       role="button"
       tabIndex={0}
+      onPointerDown={markPointer}
       onClick={() => clickItem(file)}
       onKeyDown={(event) => {
         if (event.key === "Enter") clickItem(file);
       }}
       onContextMenu={(event) => openMenu(event, file)}
       draggable
-      onDragStart={(event) => {
-        event.dataTransfer.setData("application/x-flaredrive", file.key);
-        event.dataTransfer.effectAllowed = "move";
-      }}
+      onDragStart={(event) => beginDrag(event, file)}
       {...folderDrop(file)}
       sx={{
         position: "relative",
@@ -180,6 +202,7 @@ function FileGrid({
         alignItems: "center",
         justifyContent: "center",
         gap: 0.5,
+        userSelect: "none",
         transition: "background-color 0.2s ease, box-shadow 0.2s ease",
         "&:hover": { backgroundColor: "whitesmoke", boxShadow: 1 },
       }}

--- a/src/Main.tsx
+++ b/src/Main.tsx
@@ -60,16 +60,22 @@ function PathBar({
   onNavigate: (path: string) => void;
 }) {
   const parts = cwd.replace(/\/$/, "").split("/").filter(Boolean);
+  const atRoot = parts.length === 0;
 
   return (
     <Box sx={{ padding: 1, display: "flex", alignItems: "center", gap: 0.5 }}>
       <IconButton
         size="small"
         aria-label="返回上一级"
-        disabled={parts.length === 0}
+        disabled={atRoot}
         onClick={() =>
           onNavigate(parts.slice(0, -1).join("/") + (parts.length > 1 ? "/" : ""))
         }
+        sx={{
+          visibility: atRoot ? "hidden" : "visible",
+          opacity: atRoot ? 0 : 1,
+          pointerEvents: atRoot ? "none" : "auto",
+        }}
       >
         <ArrowBackIcon fontSize="small" />
       </IconButton>
@@ -190,6 +196,7 @@ function Main({
   const [confirmDelete, setConfirmDelete] = useState<string[] | null>(null);
   const [moveTarget, setMoveTarget] = useState<string[] | null>(null);
   const lastFolderPath = useRef("");
+  const loadedListingKey = useRef<string | null>(null);
 
   const cwd = route.kind === "folder" ? route.path : lastFolderPath.current;
   const section: ExplorerSection =
@@ -212,10 +219,14 @@ function Main({
     }
   }, [navigate, route.kind, search]);
 
+  const listingKey =
+    route.kind === "folder" ? `folder:${cwd}||${debouncedSearch}` : route.kind;
+
   const loadListing = useCallback(async () => {
     if (route.kind !== "folder") {
       setFiles([]);
       setLoading(false);
+      loadedListingKey.current = listingKey;
       return;
     }
     if (username === null) {
@@ -224,7 +235,10 @@ function Main({
       return;
     }
 
-    setLoading(true);
+    // Keep the current grid mounted when refreshing the same folder so a
+    // click that lands during create/rename/upload is not lost on remount.
+    const silent = loadedListingKey.current === listingKey;
+    if (!silent) setLoading(true);
     try {
       if (debouncedSearch) {
         const result = await searchFiles(debouncedSearch);
@@ -236,13 +250,14 @@ function Main({
         setSearchHasMore(false);
         setSearchCursor(undefined);
       }
+      loadedListingKey.current = listingKey;
       setSelectedKeys([]);
     } catch (error) {
       onNotify((error as Error).message, "error");
     } finally {
       setLoading(false);
     }
-  }, [cwd, debouncedSearch, onNotify, route.kind, username]);
+  }, [cwd, debouncedSearch, listingKey, onNotify, route.kind, username]);
 
   useEffect(() => {
     loadListing();
@@ -332,6 +347,17 @@ function Main({
       file.contentType.startsWith("video/") ||
       file.contentType.startsWith("audio/") ||
       file.contentType === "application/pdf");
+
+  const handleOpenMenu = useCallback(
+    (position: { clientX: number; clientY: number }, file: FileItem) => {
+      setContextMenu({
+        x: position.clientX,
+        y: position.clientY,
+        file,
+      });
+    },
+    []
+  );
 
   const handleOpen = useCallback(
     (key: string) => {
@@ -576,13 +602,7 @@ function Main({
                 onToggleSelect={toggleSelect}
                 onNavigate={navigateFolder}
                 onOpen={handleOpen}
-                onOpenMenu={(position, file) =>
-                  setContextMenu({
-                    x: position.clientX,
-                    y: position.clientY,
-                    file,
-                  })
-                }
+                onOpenMenu={handleOpenMenu}
                 onDropOnFolder={handleDropOnFolder}
                 emptyMessage={
                   <Box sx={{ textAlign: "center", padding: 4 }}>

--- a/src/TextPadDrawer.tsx
+++ b/src/TextPadDrawer.tsx
@@ -21,20 +21,24 @@ const TextPadDrawer: React.FC<TextPadDrawerProps> = ({
   open,
   setOpen,
   cwd,
-  onUpload,
 }) => {
   const [noteText, setNoteText] = useState("");
   const [noteName, setNoteName] = useState("note.txt");
   const uploadEnqueue = useUploadEnqueue();
 
   const handleSaveNote = () => {
+    const name = noteName.trim() || "note.txt";
     const fileBlob = new Blob([noteText], { type: "text/plain" });
-    const file = new File([fileBlob], noteName, { type: "text/plain" });
-    uploadEnqueue({ file, basedir: cwd });
-    onUpload();
+    const file = new File([fileBlob], name, { type: "text/plain" });
+    // Close first so the drawer unmounts cleanly. Do not refresh the listing
+    // here: the file is not on the server yet, and a loading remount during
+    // drawer teardown blanked the whole page. Main reloads when the queue drains.
     setOpen(false);
     setNoteText("");
     setNoteName("note.txt");
+    window.setTimeout(() => {
+      uploadEnqueue({ file, basedir: cwd });
+    }, 0);
   };
 
   return (

--- a/src/app/route.ts
+++ b/src/app/route.ts
@@ -36,10 +36,41 @@ function decodeRoute(hash: string): Route {
   return { kind: "folder", path: path ? `${path}/` : "" };
 }
 
+function hashIsEmpty(hash: string) {
+  return !hash || hash === "#" || hash === "#/";
+}
+
+/**
+ * Shared links may use `?p=folder` instead of `#/folder/`.
+ * Map that query onto the hash router and drop `p` so hash stays canonical.
+ */
+function applyQueryPathToHash(): Route | null {
+  const url = new URL(window.location.href);
+  if (!url.searchParams.has("p")) return null;
+
+  const queryPath = url.searchParams.get("p") ?? "";
+  const hashEmpty = hashIsEmpty(url.hash);
+
+  url.searchParams.delete("p");
+
+  if (!hashEmpty || !queryPath) {
+    const next = `${url.pathname}${url.search}${url.hash}`;
+    window.history.replaceState(null, "", next);
+    return null;
+  }
+
+  const route = decodeRoute(`#/${queryPath.replace(/^\/+/, "")}`);
+  const nextHash = encodeRoute(route);
+  window.history.replaceState(null, "", `${url.pathname}${url.search}${nextHash}`);
+  return route;
+}
+
+function resolveInitialRoute(): Route {
+  return applyQueryPathToHash() ?? decodeRoute(window.location.hash);
+}
+
 export function useHashRoute(): [Route, (route: Route) => void] {
-  const [route, setRoute] = useState<Route>(() =>
-    decodeRoute(window.location.hash)
-  );
+  const [route, setRoute] = useState<Route>(() => resolveInitialRoute());
 
   useEffect(() => {
     const onHashChange = () => setRoute(decodeRoute(window.location.hash));

--- a/src/app/utils.ts
+++ b/src/app/utils.ts
@@ -1,6 +1,7 @@
 import { FileItem } from "./types";
 
 export function humanReadableSize(size: number) {
+  if (!Number.isFinite(size) || size < 0) return "";
   const units = ["B", "KB", "MB", "GB", "TB"];
   let i = 0;
   while (size >= 1024) {


### PR DESCRIPTION
修复线上 5 个 UX 问题。1) 记事本保存不再整页空白。2) 网格三点按钮左键打开菜单。3) ?p= 映射到 hash 路由。4) 单击进入文件夹，新建后列表不卸载。5) 根目录隐藏返回按钮。 build 已通过。请合并以部署。