### PR TITLE
迭代网盘体验：更大点击区、隐藏垃圾文件、目录统计、当前文件夹搜索

### DIFF
--- a/src/ExplorerBar.tsx
+++ b/src/ExplorerBar.tsx
@@ -3,9 +3,11 @@ import {
   Box,
   Button,
   ButtonGroup,
+  FormControlLabel,
   IconButton,
   Menu,
   MenuItem,
+  Switch,
   ToggleButton,
   ToggleButtonGroup,
   Tooltip,
@@ -46,6 +48,8 @@ function ExplorerBar({
   onOpenWebDav,
   typeFilter,
   onTypeFilterChange,
+  showHidden,
+  onShowHiddenChange,
 }: {
   section: ExplorerSection;
   onSectionChange: (section: ExplorerSection) => void;
@@ -64,6 +68,8 @@ function ExplorerBar({
   onOpenWebDav: () => void;
   typeFilter: FileTypeFilter;
   onTypeFilterChange: (filter: FileTypeFilter) => void;
+  showHidden: boolean;
+  onShowHiddenChange: (show: boolean) => void;
 }) {
   const [uploadAnchor, setUploadAnchor] = useState<null | HTMLElement>(null);
   const [sortAnchor, setSortAnchor] = useState<null | HTMLElement>(null);
@@ -221,6 +227,20 @@ function ExplorerBar({
             <ToggleButton value="doc">{strings.typeDoc}</ToggleButton>
             <ToggleButton value="other">{strings.typeOther}</ToggleButton>
           </ToggleButtonGroup>
+          <FormControlLabel
+            sx={{ marginLeft: 0.5, marginRight: 0.5, whiteSpace: "nowrap" }}
+            control={
+              <Switch
+                size="small"
+                checked={showHidden}
+                onChange={(event) => onShowHiddenChange(event.target.checked)}
+                inputProps={{ "aria-label": strings.showHidden }}
+              />
+            }
+            label={
+              <Typography variant="caption">{strings.showHidden}</Typography>
+            }
+          />
           <Tooltip title={view === "grid" ? "切换到列表视图" : "切换到网格视图"}>
             <IconButton
               size="small"

--- a/src/FileGrid.tsx
+++ b/src/FileGrid.tsx
@@ -93,54 +93,65 @@ function FileGrid({
   );
 
   const moreButton = (file: FileItem, corner?: "tile") => {
+    const openMenu = (event: React.MouseEvent) => {
+      event.stopPropagation();
+      onOpenMenu({ clientX: event.clientX, clientY: event.clientY }, file);
+    };
+
+    // One 44×44 box is both the visible ⋯ and the hit rect (no inner
+    // padding/offset that used to sit the glyph left/up of the click).
     const button = (
       <IconButton
         size="small"
         aria-label={`${file.name} 操作`}
         onPointerDown={(event) => event.stopPropagation()}
         onMouseDown={(event) => event.stopPropagation()}
-        onClick={(event) => {
-          event.stopPropagation();
-          onOpenMenu(
-            { clientX: event.clientX, clientY: event.clientY },
-            file
-          );
-        }}
+        onClick={openMenu}
         sx={{
-          width: 36,
-          height: 36,
+          width: "100%",
+          height: "100%",
+          minWidth: 0,
           padding: 0,
-          display: "inline-flex",
+          margin: 0,
+          borderRadius: 1,
+          overflow: "hidden",
+          display: "flex",
           alignItems: "center",
           justifyContent: "center",
+          "& .MuiSvgIcon-root": {
+            fontSize: 22,
+            display: "block",
+            margin: 0,
+          },
         }}
       >
-        <MoreHorizIcon fontSize="small" />
+        <MoreHorizIcon />
       </IconButton>
     );
 
-    if (corner !== "tile") return button;
+    if (corner !== "tile") {
+      return (
+        <Box sx={{ width: 44, height: 44, flexShrink: 0 }}>{button}</Box>
+      );
+    }
 
-    // Position a wrapping box, not the IconButton itself. Absolute + flex
-    // centering on the tile offset the visible SVG from the real hit target
-    // (~35px), so clicks on the glyph hit the breadcrumb instead.
     return (
       <Box
         sx={{
           position: "absolute",
-          top: 4,
-          right: 4,
+          top: 0,
+          right: 0,
           zIndex: 3,
-          width: 36,
-          height: 36,
-          display: "flex",
-          alignItems: "center",
-          justifyContent: "center",
+          width: 44,
+          height: 44,
+          boxSizing: "border-box",
           pointerEvents: "auto",
+          backgroundColor: "rgba(255,255,255,0.86)",
+          borderRadius: 1,
         }}
         onPointerDown={(event) => event.stopPropagation()}
         onMouseDown={(event) => event.stopPropagation()}
-        onClick={(event) => event.stopPropagation()}
+        onClick={openMenu}
       >
         {button}
       </Box>
@@ -223,7 +234,7 @@ function FileGrid({
         minHeight: 128,
         boxSizing: "border-box",
         padding: 1,
-        paddingTop: 4.5,
+        paddingTop: '44px',
         cursor: "pointer",
         border: (theme) =>
           isSelected(file)

--- a/src/Main.tsx
+++ b/src/Main.tsx
@@ -12,6 +12,8 @@ import {
   CircularProgress,
   IconButton,
   Link,
+  ToggleButton,
+  ToggleButtonGroup,
   Typography,
 } from "@mui/material";
 import { ArrowBack as ArrowBackIcon } from "@mui/icons-material";
@@ -33,7 +35,7 @@ import WebDavPanel from "./WebDavPanel";
 import { useClipboard } from "./app/clipboard";
 import { NotifyFn } from "./app/notify";
 import { Route } from "./app/route";
-import { FileTypeFilter, SortPref, ViewMode } from "./app/prefs";
+import { FileTypeFilter, SortPref, usePersistedState, ViewMode } from "./app/prefs";
 import { strings } from "./app/strings";
 import {
   collectFilesFromDataTransfer,
@@ -50,61 +52,122 @@ import { moveToTrash } from "./app/trash";
 import { useAuth } from "./app/auth";
 import { useTransferQueue, useUploadEnqueue } from "./app/transferQueue";
 import { FileItem } from "./app/types";
-import { basename, fileTypeCategory, isDirectory } from "./app/utils";
+import {
+  basename,
+  fileTypeCategory,
+  formatListingSize,
+  isDirectory,
+  isJunkFileName,
+} from "./app/utils";
+
+export type SearchScope = "folder" | "global";
 
 function PathBar({
   cwd,
   onNavigate,
+  stats,
+  searchScope,
+  onSearchScopeChange,
+  searchQuery,
 }: {
   cwd: string;
   onNavigate: (path: string) => void;
+  stats: string;
+  searchScope: SearchScope;
+  onSearchScopeChange: (scope: SearchScope) => void;
+  searchQuery: string;
 }) {
   const parts = cwd.replace(/\/$/, "").split("/").filter(Boolean);
   const atRoot = parts.length === 0;
 
   return (
-    <Box sx={{ padding: 1, display: "flex", alignItems: "center", gap: 0.5 }}>
-      <IconButton
-        size="small"
-        aria-label="返回上一级"
-        disabled={atRoot}
-        onClick={() =>
-          onNavigate(parts.slice(0, -1).join("/") + (parts.length > 1 ? "/" : ""))
-        }
+    <Box
+      sx={{
+        padding: "4px 8px 8px",
+        borderBottom: "1px solid",
+        borderColor: "divider",
+      }}
+    >
+      <Box sx={{ display: "flex", alignItems: "center", gap: 0.5 }}>
+        <IconButton
+          size="small"
+          aria-label="返回上一级"
+          disabled={atRoot}
+          onClick={() =>
+            onNavigate(parts.slice(0, -1).join("/") + (parts.length > 1 ? "/" : ""))
+          }
+          sx={{
+            visibility: atRoot ? "hidden" : "visible",
+            opacity: atRoot ? 0 : 1,
+            pointerEvents: atRoot ? "none" : "auto",
+          }}
+        >
+          <ArrowBackIcon fontSize="small" />
+        </IconButton>
+        <Breadcrumbs separator="›" sx={{ flexGrow: 1 }}>
+          {parts.length === 0 ? (
+            <Typography color="text.primary">{strings.allFiles}</Typography>
+          ) : (
+            <Link component="button" onClick={() => onNavigate("")}>
+              {strings.allFiles}
+            </Link>
+          )}
+          {parts.map((part, index) =>
+            index === parts.length - 1 ? (
+              <Typography key={index} color="text.primary">
+                {part}
+              </Typography>
+            ) : (
+              <Link
+                key={index}
+                component="button"
+                onClick={() =>
+                  onNavigate(parts.slice(0, index + 1).join("/") + "/")
+                }
+              >
+                {part}
+              </Link>
+            )
+          )}
+        </Breadcrumbs>
+      </Box>
+      <Box
         sx={{
-          visibility: atRoot ? "hidden" : "visible",
-          opacity: atRoot ? 0 : 1,
-          pointerEvents: atRoot ? "none" : "auto",
+          display: "flex",
+          alignItems: "center",
+          gap: 1,
+          flexWrap: "wrap",
+          paddingLeft: "40px",
+          minHeight: 32,
         }}
       >
-        <ArrowBackIcon fontSize="small" />
-      </IconButton>
-      <Breadcrumbs separator="›" sx={{ flexGrow: 1 }}>
-        {parts.length === 0 ? (
-          <Typography color="text.primary">{strings.allFiles}</Typography>
-        ) : (
-          <Link component="button" onClick={() => onNavigate("")}>
-            {strings.allFiles}
-          </Link>
-        )}
-        {parts.map((part, index) =>
-          index === parts.length - 1 ? (
-            <Typography key={index} color="text.primary">
-              {part}
-            </Typography>
-          ) : (
-            <Link
-              key={index}
-              component="button"
-              onClick={() =>
-                onNavigate(parts.slice(0, index + 1).join("/") + "/")
-              }
-            >
-              {part}
-            </Link>
-          )
-        )}
-      </Breadcrumbs>
+        <Typography variant="caption" color="text.secondary">
+          {stats}
+        </Typography>
+        <Box sx={{ flexGrow: 1 }} />
+        <ToggleButtonGroup
+          exclusive
+          size="small"
+          value={searchScope}
+          onChange={(_, value: SearchScope | null) => {
+            if (value) onSearchScopeChange(value);
+          }}
+          aria-label="搜索范围"
+        >
+          <ToggleButton value="folder">{strings.searchHere}</ToggleButton>
+          <ToggleButton value="global">{strings.searchAll}</ToggleButton>
+        </ToggleButtonGroup>
+      </Box>
+      {searchQuery ? (
+        <Typography
+          variant="body2"
+          color="text.secondary"
+          sx={{ paddingLeft: "40px", paddingTop: 0.5 }}
+        >
+          {searchScope === "global" ? strings.searchAll : strings.searchHere}：
+          {searchQuery}
+        </Typography>
+      ) : null}
     </Box>
   );
 }
@@ -185,6 +248,11 @@ function Main({
   const [showTextPadDrawer, setShowTextPadDrawer] = useState(false);
   const [showWebDav, setShowWebDav] = useState(false);
   const [typeFilter, setTypeFilter] = useState<FileTypeFilter>("all");
+  const [showHidden, setShowHidden] = usePersistedState(
+    "flaredrive.showHidden",
+    false
+  );
+  const [searchScope, setSearchScope] = useState<SearchScope>("folder");
   const [contextMenu, setContextMenu] = useState<{
     x: number;
     y: number;
@@ -207,6 +275,10 @@ function Main({
   }, [route]);
 
   useEffect(() => {
+    setSearchScope(cwd ? "folder" : "global");
+  }, [cwd]);
+
+  useEffect(() => {
     const timer = window.setTimeout(() => {
       setDebouncedSearch(search.trim());
     }, 300);
@@ -219,8 +291,13 @@ function Main({
     }
   }, [navigate, route.kind, search]);
 
+  const isGlobalSearch = Boolean(debouncedSearch) && searchScope === "global";
   const listingKey =
-    route.kind === "folder" ? `folder:${cwd}||${debouncedSearch}` : route.kind;
+    route.kind === "folder"
+      ? isGlobalSearch
+        ? `folder:${cwd}||search:${debouncedSearch}`
+        : `folder:${cwd}`
+      : route.kind;
 
   const loadListing = useCallback(async () => {
     if (route.kind !== "folder") {
@@ -240,7 +317,7 @@ function Main({
     const silent = loadedListingKey.current === listingKey;
     if (!silent) setLoading(true);
     try {
-      if (debouncedSearch) {
+      if (isGlobalSearch) {
         const result = await searchFiles(debouncedSearch);
         setFiles(result.items);
         setSearchHasMore(result.hasMore);
@@ -257,7 +334,15 @@ function Main({
     } finally {
       setLoading(false);
     }
-  }, [cwd, debouncedSearch, listingKey, onNotify, route.kind, username]);
+  }, [
+    cwd,
+    debouncedSearch,
+    listingKey,
+    onNotify,
+    route.kind,
+    isGlobalSearch,
+    username,
+  ]);
 
   useEffect(() => {
     loadListing();
@@ -278,7 +363,7 @@ function Main({
   }, [activeUploads, loadListing]);
 
   const loadMore = async () => {
-    if (!debouncedSearch || !searchCursor) return;
+    if (!isGlobalSearch || !searchCursor) return;
     try {
       const result = await searchFiles(debouncedSearch, searchCursor);
       setFiles((prev) => [...prev, ...result.items]);
@@ -310,12 +395,43 @@ function Main({
   }, [files, sort]);
 
   const visibleFiles = useMemo(() => {
-    if (typeFilter === "all") return sortedFiles;
-    return sortedFiles.filter((file) => {
-      if (file.isDir) return true;
-      return fileTypeCategory(file) === typeFilter;
-    });
-  }, [sortedFiles, typeFilter]);
+    let items = sortedFiles;
+    if (!showHidden) {
+      items = items.filter((file) => !isJunkFileName(file.name));
+    }
+    if (typeFilter !== "all") {
+      items = items.filter((file) => {
+        if (file.isDir) return true;
+        return fileTypeCategory(file) === typeFilter;
+      });
+    }
+    if (debouncedSearch && searchScope === "folder") {
+      const q = debouncedSearch.toLowerCase();
+      items = items.filter(
+        (file) =>
+          file.name.toLowerCase().includes(q) ||
+          file.key.toLowerCase().includes(q)
+      );
+    }
+    return items;
+  }, [debouncedSearch, searchScope, showHidden, sortedFiles, typeFilter]);
+
+  const listingStats = useMemo(() => {
+    let folders = 0;
+    let fileCount = 0;
+    let bytes = 0;
+    for (const file of visibleFiles) {
+      if (file.isDir) {
+        folders += 1;
+      } else {
+        fileCount += 1;
+        bytes += file.size || 0;
+      }
+    }
+    return `${folders} 个文件夹 · ${fileCount} 个文件 · 共 ${formatListingSize(
+      bytes
+    )}`;
+  }, [visibleFiles]);
 
   const navigateFolder = useCallback(
     (path: string) => {
@@ -546,6 +662,8 @@ function Main({
         onOpenWebDav={() => setShowWebDav(true)}
         typeFilter={typeFilter}
         onTypeFilterChange={setTypeFilter}
+        showHidden={showHidden}
+        onShowHiddenChange={setShowHidden}
       />
 
       {route.kind === "trash" && (
@@ -561,12 +679,14 @@ function Main({
 
       {route.kind === "folder" && (
         <>
-          <PathBar cwd={cwd} onNavigate={navigateFolder} />
-          {debouncedSearch && (
-            <Typography variant="body2" sx={{ padding: 1 }} color="text.secondary">
-              搜索：{debouncedSearch}
-            </Typography>
-          )}
+          <PathBar
+            cwd={cwd}
+            onNavigate={navigateFolder}
+            stats={listingStats}
+            searchScope={searchScope}
+            onSearchScopeChange={setSearchScope}
+            searchQuery={debouncedSearch}
+          />
 
           {loading ||
           (route.kind === "folder" && loadedListingKey.current !== listingKey) ? (

--- a/src/app/strings.ts
+++ b/src/app/strings.ts
@@ -36,6 +36,9 @@ export const strings = {
   typeVideo: "视频",
   typeDoc: "文档",
   typeOther: "其他",
+  showHidden: "显示隐藏文件",
+  searchHere: "当前文件夹",
+  searchAll: "全盘搜索",
 };
 
 export default strings;

--- a/src/app/utils.ts
+++ b/src/app/utils.ts
@@ -52,3 +52,19 @@ export function fileTypeCategory(
   if (type.startsWith("text/") || office || docName) return "doc";
   return "other";
 }
+
+const JUNK_EXACT = new Set([".ds_store", "thumbs.db", "desktop.ini"]);
+
+/** macOS/Windows junk names; hide from the grid, never delete. */
+export function isJunkFileName(name: string) {
+  const lower = name.toLowerCase();
+  if (JUNK_EXACT.has(lower)) return true;
+  if (name.startsWith("._")) return true;
+  return false;
+}
+
+export function formatListingSize(size: number) {
+  if (!Number.isFinite(size) || size <= 0) return "0 B";
+  if (size < 1024) return `${Math.round(size)} B`;
+  return humanReadableSize(size);
+}


### PR DESCRIPTION
## 改动

基于 main 上 PR 3 记事本保存已修好，做一轮小范围功能升级。未改 WebDAV、分享、回收站 API，也未动上传队列递归修复。

1. 点击区：可见的三个点和可点区域对齐为同一块 44x44 矩形，贴在磁贴右上角，避免点到面包屑。
2. 默认隐藏垃圾文件：网格默认不显示 .DS_Store、._*、Thumbs.db、desktop.ini。类型筛选旁增加「显示隐藏文件」开关，只隐藏不删除。
3. 当前目录统计：路径栏下方显示可见列表统计，例如 3 个文件夹 · 2 个文件 · 共 40 B（已套用类型筛选和隐藏文件过滤，无新接口）。
4. 当前文件夹搜索：非根目录时默认在当前列表里客户端过滤；可切到「全盘搜索」才走现有 /api/search。根目录默认全盘。

npm run build 已通过。请合并以便 Pages 部署。
