### PR TITLE
文本预览：JSON/TXT/HTML/MD/代码在应用内打开

### DIFF
--- a/src/ExplorerBar.tsx
+++ b/src/ExplorerBar.tsx
@@ -90,8 +90,8 @@ function ExplorerBar({
         display: "flex",
         flexWrap: "wrap",
         alignItems: "center",
-        gap: 1,
-        padding: "6px 8px",
+        gap: 1.25,
+        padding: "8px 12px",
         borderBottom: "1px solid",
         borderColor: "divider",
         backgroundColor: "background.paper",
@@ -211,7 +211,7 @@ function ExplorerBar({
       )}
 
       {inFolder && (
-        <Box sx={{ display: "flex", alignItems: "center", marginLeft: "auto", gap: 1, flexWrap: "wrap" }}>
+        <Box sx={{ display: "flex", alignItems: "center", marginLeft: "auto", gap: 1.25, flexWrap: "wrap" }}>
           <ToggleButtonGroup
             exclusive
             size="small"

--- a/src/FileGrid.tsx
+++ b/src/FileGrid.tsx
@@ -183,7 +183,7 @@ function FileGrid({
       onDragStart={(event) => beginDrag(event, file)}
       {...folderDrop(file)}
       sx={{
-        userSelect: "none",
+        userSelect: "none", py: 1.25, mx: 0.5, borderRadius: 1,
         opacity: dimmedKeys?.has(file.key) ? 0.5 : 1,
       }}
     >
@@ -231,9 +231,9 @@ function FileGrid({
         overflow: "visible",
         width: "100%",
         height: "100%",
-        minHeight: 128,
+        minHeight: 140,
         boxSizing: "border-box",
-        padding: 1,
+        padding: 1.25,
         paddingTop: '44px',
         cursor: "pointer",
         border: (theme) =>
@@ -247,7 +247,7 @@ function FileGrid({
         flexDirection: "column",
         alignItems: "center",
         justifyContent: "center",
-        gap: 0.5,
+        gap: 0.75,
         userSelect: "none",
         transition: "background-color 0.2s ease, box-shadow 0.2s ease",
         "&:hover": { backgroundColor: "whitesmoke", boxShadow: 1 },
@@ -267,7 +267,7 @@ function FileGrid({
       </Box>
       <Typography
         variant="body2"
-        sx={{
+        sx={{ fontWeight: 500,
           width: "100%",
           textAlign: "center",
           display: "-webkit-box",
@@ -314,8 +314,8 @@ function FileGrid({
   return (
     <Grid
       container
-      spacing={1.5}
-      sx={{ padding: 1, paddingBottom: "72px", overflow: "visible" }}
+      spacing={2}
+      sx={{ padding: 1.5, paddingBottom: "72px", overflow: "visible" }}
     >
       {files.map((file) => (
         <Grid
@@ -347,7 +347,7 @@ function thumbnail(file: FileItem, size: number) {
       }}
     />
   ) : (
-    <MimeIcon contentType={file.contentType} />
+    <MimeIcon contentType={file.contentType} name={file.name} />
   );
 }
 

--- a/src/Main.tsx
+++ b/src/Main.tsx
@@ -1,3 +1,4 @@
+import { isPreviewable } from "./app/preview";
 import React, {
   useCallback,
   useEffect,
@@ -83,7 +84,7 @@ function PathBar({
   return (
     <Box
       sx={{
-        padding: "4px 8px 8px",
+        padding: "8px 12px 10px",
         borderBottom: "1px solid",
         borderColor: "divider",
       }}
@@ -457,12 +458,6 @@ function Main({
     });
   }, [visibleFiles]);
 
-  const isPreviewable = (file: FileItem) =>
-    !file.isDir &&
-    (file.contentType.startsWith("image/") ||
-      file.contentType.startsWith("video/") ||
-      file.contentType.startsWith("audio/") ||
-      file.contentType === "application/pdf");
 
   const handleOpenMenu = useCallback(
     (position: { clientX: number; clientY: number }, file: FileItem) => {

--- a/src/MimeIcon.tsx
+++ b/src/MimeIcon.tsx
@@ -1,33 +1,52 @@
+import ArticleIcon from "@mui/icons-material/Article";
 import AudioFileIcon from "@mui/icons-material/AudioFile";
 import CodeIcon from "@mui/icons-material/Code";
+import CssIcon from "@mui/icons-material/Css";
+import DataObjectIcon from "@mui/icons-material/DataObject";
 import FolderIcon from "@mui/icons-material/Folder";
 import FolderZipOutlinedIcon from "@mui/icons-material/FolderZipOutlined";
+import HtmlIcon from "@mui/icons-material/Html";
 import ImageIcon from "@mui/icons-material/Image";
 import InsertDriveFileOutlinedIcon from "@mui/icons-material/InsertDriveFileOutlined";
+import JavascriptIcon from "@mui/icons-material/Javascript";
 import PdfIcon from "@mui/icons-material/PictureAsPdf";
+import TableChartIcon from "@mui/icons-material/TableChart";
+import TerminalIcon from "@mui/icons-material/Terminal";
 import VideoFileIcon from "@mui/icons-material/VideoFile";
 
-function MimeIcon({ contentType }: { contentType: string }) {
-  const fallbackIcon = <InsertDriveFileOutlinedIcon fontSize="large" />;
-  if (typeof contentType !== "string") return fallbackIcon;
+import { fileIconKind } from "./app/preview";
 
-  return contentType.startsWith("image/") ? (
-    <ImageIcon fontSize="large" />
-  ) : contentType.startsWith("audio/") ? (
-    <AudioFileIcon fontSize="large" />
-  ) : contentType.startsWith("video/") ? (
-    <VideoFileIcon fontSize="large" />
-  ) : contentType === "application/pdf" ? (
-    <PdfIcon fontSize="large" />
-  ) : ["application/zip", "application/gzip"].includes(contentType) ? (
-    <FolderZipOutlinedIcon fontSize="large" />
-  ) : contentType.startsWith("text/") ? (
-    <CodeIcon fontSize="large" />
-  ) : contentType === "application/x-directory" ? (
-    <FolderIcon fontSize="large" />
-  ) : (
-    fallbackIcon
-  );
+const KIND_COLOR: Record<string, string> = {
+  folder: "#f38020",
+  json: "#c47b1a",
+  html: "#d35426",
+  css: "#3b6ea8",
+  js: "#b8860b",
+  code: "#3d6b99",
+  text: "#5c6b7a",
+  csv: "#3d7a4a",
+  shell: "#4a5560",
+};
+
+function MimeIcon({ contentType, name, fontSize = "large" }: { contentType: string; name?: string; fontSize?: "inherit" | "large" | "medium" | "small"; }) {
+  const kind = fileIconKind({ contentType, name });
+  const color = KIND_COLOR[kind];
+  const sx = color ? { color } : undefined;
+  if (kind === "folder") return <FolderIcon fontSize={fontSize} sx={sx} />;
+  if (kind === "image") return <ImageIcon fontSize={fontSize} sx={sx} />;
+  if (kind === "audio") return <AudioFileIcon fontSize={fontSize} sx={sx} />;
+  if (kind === "video") return <VideoFileIcon fontSize={fontSize} sx={sx} />;
+  if (kind === "pdf") return <PdfIcon fontSize={fontSize} sx={sx} />;
+  if (kind === "zip") return <FolderZipOutlinedIcon fontSize={fontSize} sx={sx} />;
+  if (kind === "json") return <DataObjectIcon fontSize={fontSize} sx={sx} />;
+  if (kind === "html") return <HtmlIcon fontSize={fontSize} sx={sx} />;
+  if (kind === "css") return <CssIcon fontSize={fontSize} sx={sx} />;
+  if (kind === "js") return <JavascriptIcon fontSize={fontSize} sx={sx} />;
+  if (kind === "csv") return <TableChartIcon fontSize={fontSize} sx={sx} />;
+  if (kind === "shell") return <TerminalIcon fontSize={fontSize} sx={sx} />;
+  if (kind === "text") return <ArticleIcon fontSize={fontSize} sx={sx} />;
+  if (kind === "code") return <CodeIcon fontSize={fontSize} sx={sx} />;
+  return <InsertDriveFileOutlinedIcon fontSize={fontSize} />;
 }
 
 export default MimeIcon;

--- a/src/PreviewDialog.tsx
+++ b/src/PreviewDialog.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable react-hooks/exhaustive-deps */
 import React, { useEffect, useState } from "react";
 import {
+  Alert,
   Box,
   Button,
   CircularProgress,
@@ -9,7 +10,9 @@ import {
   DialogContent,
   DialogTitle,
   Typography,
+  useMediaQuery,
 } from "@mui/material";
+import ContentCopyIcon from "@mui/icons-material/ContentCopy";
 import DeleteIcon from "@mui/icons-material/Delete";
 import DownloadIcon from "@mui/icons-material/Download";
 import EditIcon from "@mui/icons-material/Edit";
@@ -17,8 +20,18 @@ import ShareIcon from "@mui/icons-material/Share";
 
 import { authFetch } from "./app/auth";
 import { NotifyFn } from "./app/notify";
+import {
+  isJsonFile,
+  isMediaPreviewable,
+  isTextPreviewable,
+  mimeType,
+  prettyJsonOrRaw,
+  readResponseTextCapped,
+  TEXT_PREVIEW_MAX_BYTES,
+} from "./app/preview";
 import { FileItem } from "./app/types";
-import { encodeKey } from "./app/utils";
+import { downloadFile } from "./app/transfer";
+import { encodeKey, humanReadableSize } from "./app/utils";
 
 function PreviewDialog({
   file,
@@ -35,118 +48,189 @@ function PreviewDialog({
   onRename: () => void;
   onDelete: () => void;
 }) {
+  const isPhone = useMediaQuery("(max-width:600px)");
   const [url, setUrl] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
   const [zoomed, setZoomed] = useState(false);
+  const [text, setText] = useState<string | null>(null);
+  const [tooLarge, setTooLarge] = useState(false);
+  const [largeSize, setLargeSize] = useState(0);
+  const [jsonError, setJsonError] = useState(false);
 
-  // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(() => {
     if (!file) {
       setUrl(null);
+      setText(null);
       setZoomed(false);
+      setTooLarge(false);
+      setLargeSize(0);
+      setJsonError(false);
       return;
     }
-
     let objectUrl: string | null = null;
     let canceled = false;
+    const controller = new AbortController();
     setLoading(true);
     setUrl(null);
+    setText(null);
+    setTooLarge(false);
+    setLargeSize(0);
+    setJsonError(false);
+    setZoomed(false);
 
-    authFetch(`/webdav/${encodeKey(file.key)}`)
-      .then(async (response) => {
+    const media = isMediaPreviewable(file);
+    const asText = !media && isTextPreviewable(file);
+    const listedSize = file.size || 0;
+    const run = async () => {
+      try {
+        if (asText && listedSize > TEXT_PREVIEW_MAX_BYTES) {
+          if (!canceled) { setTooLarge(true); setLargeSize(listedSize); }
+          return;
+        }
+        const response = await authFetch("/webdav/" + encodeKey(file.key), { signal: controller.signal });
         if (!response.ok) throw new Error("打开文件失败");
+        if (asText) {
+          const result = await readResponseTextCapped(response);
+          if (canceled) return;
+          if (!result.ok) { setTooLarge(true); setLargeSize(result.size); return; }
+          if (isJsonFile(file)) {
+            const pretty = prettyJsonOrRaw(result.text);
+            setText(pretty.text);
+            setJsonError(pretty.parseError);
+          } else {
+            setText(result.text);
+          }
+          return;
+        }
         const blob = await response.blob();
         if (canceled) return;
         objectUrl = URL.createObjectURL(blob);
         setUrl(objectUrl);
-      })
-      .catch((error) => {
-        if (!canceled) onNotify((error as Error).message, "error");
-      })
-      .finally(() => {
+      } catch (error) {
+        if (canceled || (error as Error).name === "AbortError") return;
+        onNotify((error as Error).message, "error");
+      } finally {
         if (!canceled) setLoading(false);
-      });
-
+      }
+    };
+    run();
     return () => {
       canceled = true;
+      controller.abort();
       if (objectUrl) URL.revokeObjectURL(objectUrl);
     };
   }, [file]);
 
-  const download = () => {
+  const download = async () => {
     if (!file) return;
-    const a = document.createElement("a");
-    a.href = url || `/webdav/${encodeKey(file.key)}`;
-    a.download = file.name;
-    document.body.appendChild(a);
-    a.click();
-    a.remove();
+    try {
+      if (text != null) {
+        const blob = new Blob([text], { type: "text/plain;charset=utf-8" });
+        const href = URL.createObjectURL(blob);
+        const a = document.createElement("a");
+        a.href = href;
+        a.download = file.name;
+        document.body.appendChild(a);
+        a.click();
+        a.remove();
+        setTimeout(() => URL.revokeObjectURL(href), 60_000);
+        return;
+      }
+      if (url) {
+        const a = document.createElement("a");
+        a.href = url;
+        a.download = file.name;
+        document.body.appendChild(a);
+        a.click();
+        a.remove();
+        return;
+      }
+      await downloadFile(file.key);
+    } catch (error) {
+      onNotify((error as Error).message, "error");
+    }
   };
 
-  const contentType = file?.contentType || "";
-  const isImage = contentType.startsWith("image/");
+  const copyAll = async () => {
+    if (text == null) return;
+    try {
+      await navigator.clipboard.writeText(text);
+      onNotify("已复制全文", "success");
+    } catch {
+      onNotify("复制失败", "error");
+    }
+  };
+
+  const contentType = mimeType(file?.contentType);
+  const isImage = contentType.startsWith("image/") && contentType !== "image/svg+xml";
   const isVideo = contentType.startsWith("video/");
   const isAudio = contentType.startsWith("audio/");
   const isPdf = contentType === "application/pdf";
+  const showText = Boolean(file) && !isImage && !isVideo && !isAudio && !isPdf && (tooLarge || text != null || (file ? isTextPreviewable(file) : false));
 
   return (
     <Dialog
       open={Boolean(file)}
       onClose={onClose}
       fullWidth
-      maxWidth="lg"
-      PaperProps={{ sx: { height: "90vh" } }}
+      fullScreen={isPhone}
+      maxWidth="xl"
+      PaperProps={{
+        sx: {
+          display: "flex",
+          flexDirection: "column",
+          height: isPhone ? "100%" : "92vh",
+          maxHeight: isPhone ? "100%" : "92vh",
+          width: isPhone ? "100%" : "96vw",
+          maxWidth: isPhone ? "100%" : 1280,
+        },
+      }}
     >
-      <DialogTitle sx={{ display: "flex", justifyContent: "space-between" }}>
+      <DialogTitle sx={{ overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap", pr: 2, fontWeight: 600 }}>
         {file?.name}
       </DialogTitle>
-      <DialogContent sx={{ overflow: "auto", textAlign: "center" }}>
+      <DialogContent sx={{ display: "flex", flexDirection: "column", overflow: "hidden", textAlign: showText ? "left" : "center", px: showText ? 0 : 2, py: showText ? 0 : 2, flex: 1 }}>
         {loading ? (
-          <Box sx={{ display: "flex", justifyContent: "center", padding: 4 }}>
+          <Box sx={{ display: "flex", justifyContent: "center", alignItems: "center", flex: 1, padding: 4 }}>
             <CircularProgress />
+          </Box>
+        ) : tooLarge ? (
+          <Box sx={{ display: "flex", flexDirection: "column", alignItems: "center", justifyContent: "center", flex: 1, padding: 4, gap: 1.5 }}>
+            <Typography variant="h6">文件过大，无法在线预览</Typography>
+            <Typography color="text.secondary">大小 {humanReadableSize(largeSize || file?.size || 0)}，超过 2 MB 限制。</Typography>
+            <Button startIcon={<DownloadIcon />} onClick={download} variant="contained">下载</Button>
+          </Box>
+        ) : text != null ? (
+          <Box sx={{ display: "flex", flexDirection: "column", flex: 1, minHeight: 0 }}>
+            {jsonError && (
+              <Alert severity="warning" sx={{ borderRadius: 0 }}>无法解析为 JSON，已显示原文</Alert>
+            )}
+            <Box component="pre" sx={{ flex: 1, m: 0, px: 2, py: 1.5, overflow: "auto", textAlign: "left", fontFamily: "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace", fontSize: 13, lineHeight: 1.65, color: "#1f2328", backgroundColor: "#f6f8fa", whiteSpace: "pre-wrap", overflowWrap: "normal", wordBreak: "normal", tabSize: 2 }}>
+              {text}
+            </Box>
           </Box>
         ) : url ? (
           isImage ? (
-            <img
-              src={url}
-              alt={file?.name}
-              onClick={() => setZoomed((prev) => !prev)}
-              style={{
-                maxWidth: zoomed ? "200%" : "100%",
-                maxHeight: zoomed ? "200%" : "100%",
-                objectFit: "contain",
-                cursor: zoomed ? "zoom-out" : "zoom-in",
-                transition: "max-width 0.2s ease, max-height 0.2s ease",
-              }}
-            />
+            <img src={url} alt={file?.name} onClick={() => setZoomed((prev) => !prev)} style={{ maxWidth: zoomed ? "200%" : "100%", maxHeight: zoomed ? "200%" : "100%", objectFit: "contain", cursor: zoomed ? "zoom-out" : "zoom-in", transition: "max-width 0.2s ease, max-height 0.2s ease" }} />
           ) : isVideo ? (
             <video src={url} controls style={{ maxWidth: "100%", maxHeight: "100%" }} />
           ) : isAudio ? (
             <audio src={url} controls style={{ width: "100%" }} />
           ) : isPdf ? (
-            <iframe
-              src={url}
-              title={file?.name}
-              style={{ width: "100%", height: "100%", border: "none" }}
-            />
+            <iframe src={url} title={file?.name} style={{ width: "100%", height: "100%", border: "none" }} />
           ) : (
             <Typography>该文件类型暂不支持预览</Typography>
           )
         ) : null}
       </DialogContent>
-      <DialogActions sx={{ flexWrap: "wrap", gap: 0.5 }}>
-        <Button startIcon={<ShareIcon />} onClick={onShare}>
-          分享
-        </Button>
-        <Button startIcon={<EditIcon />} onClick={onRename}>
-          重命名
-        </Button>
-        <Button color="error" startIcon={<DeleteIcon />} onClick={onDelete}>
-          删除
-        </Button>
-        <Button startIcon={<DownloadIcon />} onClick={download}>
-          下载
-        </Button>
+      <DialogActions sx={{ flexWrap: "wrap", gap: 0.5, px: 2, py: 1.25 }}>
+        {text != null && (
+          <Button startIcon={<ContentCopyIcon />} onClick={copyAll}>复制全文</Button>
+        )}
+        <Button startIcon={<ShareIcon />} onClick={onShare}>分享</Button>
+        <Button startIcon={<EditIcon />} onClick={onRename}>重命名</Button>
+        <Button color="error" startIcon={<DeleteIcon />} onClick={onDelete}>删除</Button>
+        <Button startIcon={<DownloadIcon />} onClick={download}>下载</Button>
         <Button onClick={onClose}>关闭</Button>
       </DialogActions>
     </Dialog>

--- a/src/app/preview.ts
+++ b/src/app/preview.ts
@@ -1,0 +1,36 @@
+import { FileItem } from "./types";
+
+export const TEXT_PREVIEW_MAX_BYTES = 2 * 1024 * 1024;
+
+const TEXT_EXTENSIONS = new Set("txt md markdown json jsonc html htm xml svg css scss less js jsx mjs cjs ts tsx vue svelte py rb go rs java kt c h cpp hpp cs php sh bash zsh yaml yml toml ini conf cfg env properties csv tsv log sql graphql gql proto dockerfile gitignore editorconfig lock".split(" "));
+const TEXT_CONTENT_TYPES = new Set("application/json application/xml application/javascript application/x-javascript application/ecmascript application/typescript application/yaml application/x-yaml application/toml application/graphql application/sql application/x-sh application/x-httpd-php application/xhtml+xml".split(" "));
+const TEXT_BASENAMES = new Set(["dockerfile","editorconfig"]);
+export type FileIconKind = "folder" | "image" | "video" | "audio" | "pdf" | "zip" | "json" | "html" | "css" | "js" | "code" | "text" | "csv" | "shell" | "other";
+function basenameLower(name: string) { return (name.replace(/\/$/, "").split("/").pop() ?? "").toLowerCase(); }
+export function fileExtension(name: string) { const base = basenameLower(name); if (!base) return ""; if (base.startsWith(".") && base.indexOf(".", 1) === -1) return base.slice(1); const dot = base.lastIndexOf("."); return dot > 0 ? base.slice(dot + 1) : ""; }
+export function mimeType(contentType: string | undefined) { return (contentType || "").toLowerCase().split(";")[0].trim(); }
+export function isTextPreviewable(file: { name: string; contentType?: string; isDir?: boolean }) { if (file.isDir) return false; const base = basenameLower(file.name); const ext = fileExtension(file.name); const type = mimeType(file.contentType); if (TEXT_BASENAMES.has(base)) return true; if (ext && TEXT_EXTENSIONS.has(ext)) return true; if (!type) return false; if (type.startsWith("text/")) return true; if (TEXT_CONTENT_TYPES.has(type)) return true; return type.endsWith("+xml") || type.endsWith("+json"); }
+export function isMediaPreviewable(file: { contentType?: string; isDir?: boolean }) { if (file.isDir) return false; const type = mimeType(file.contentType); return (type.startsWith("image/") && type !== "image/svg+xml") || type.startsWith("video/") || type.startsWith("audio/") || type === "application/pdf"; }
+export function isJsonFile(file: { name: string; contentType?: string }) { const ext = fileExtension(file.name); const type = mimeType(file.contentType); return ext === "json" || ext === "jsonc" || type === "application/json" || type.endsWith("+json"); }
+export function isPreviewable(file: FileItem) { return isMediaPreviewable(file) || isTextPreviewable(file); }
+export function fileIconKind(file: { name?: string; contentType?: string; isDir?: boolean }): FileIconKind { if (file.isDir || mimeType(file.contentType) === "application/x-directory") return "folder"; const type = mimeType(file.contentType); const ext = fileExtension(file.name || ""); if (type.startsWith("image/") && ext !== "svg") return "image"; if (type.startsWith("video/")) return "video"; if (type.startsWith("audio/")) return "audio"; if (type === "application/pdf" || ext === "pdf") return "pdf"; if (type === "application/zip" || type === "application/gzip" || ["zip","gz","tgz","tar","7z","rar"].includes(ext)) return "zip"; if (ext === "json" || ext === "jsonc" || type === "application/json" || type.endsWith("+json")) return "json"; if (ext === "html" || ext === "htm" || type === "text/html") return "html"; if (ext === "css" || ext === "scss" || ext === "less" || type === "text/css") return "css"; if (["js","jsx","mjs","cjs","ts","tsx"].includes(ext) || type.includes("javascript") || type.includes("typescript")) return "js"; if (["csv","tsv"].includes(ext) || type === "text/csv") return "csv"; if (["sh","bash","zsh"].includes(ext) || type === "application/x-sh") return "shell"; if (["txt","md","markdown","log"].includes(ext)) return "text"; if (isTextPreviewable({ name: file.name || "", contentType: type })) return "code"; return "other"; }
+export function prettyJsonOrRaw(raw: string): { text: string; parseError: boolean } { try { return { text: JSON.stringify(JSON.parse(raw), null, 2), parseError: false }; } catch { return { text: raw, parseError: true }; } }
+export async function readResponseTextCapped(response: Response, maxBytes = TEXT_PREVIEW_MAX_BYTES): Promise<{ ok: true; text: string; size: number } | { ok: false; tooLarge: true; size: number }> {
+  const headerLen = Number(response.headers.get("content-length") || 0);
+  if (headerLen > maxBytes) { try { await response.body?.cancel(); } catch {} return { ok: false, tooLarge: true, size: headerLen }; }
+  if (!response.body) { const blob = await response.blob(); if (blob.size > maxBytes) return { ok: false, tooLarge: true, size: blob.size }; return { ok: true, text: await blob.text(), size: blob.size }; }
+  const reader = response.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let received = 0;
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    received += value.byteLength;
+    if (received > maxBytes) { try { await reader.cancel(); } catch {} return { ok: false, tooLarge: true, size: Math.max(headerLen, received) }; }
+    chunks.push(value);
+  }
+  const all = new Uint8Array(received);
+  let offset = 0;
+  for (const chunk of chunks) { all.set(chunk, offset); offset += chunk.byteLength; }
+  return { ok: true, text: new TextDecoder("utf-8").decode(all), size: received };
+}


### PR DESCRIPTION
## 摘要
- 点击文本类文件（json、txt、html、md、代码、配置等）在 PreviewDialog 中以等宽源码预览，不再直接下载或跳转。
- JSON 合法则格式化，否则显示原文并提示「无法解析」；超过约 2 MB 只展示大小并提供下载。
- HTML / SVG / Markdown 一律显示源码，不做渲染或 iframe 预览。
- 保留图片 / 视频 / 音频 / PDF 预览；文本预览支持「复制全文」和「下载」（走现有 authFetch）。
- 区分 text / json / html / code 图标；资源管理器工具栏与文件卡片略微放宽间距。

## 测试
- [ ] 记事本保存的 `note.txt` 点击打开预览而不是下载
- [ ] `.json` 合法 / 非法、`.md`、`.html`、`.svg` 均为源码文本
- [ ] 大于 2 MB 的文本文件只显示大小 + 下载
- [ ] 复制全文、下载、分享/重命名/删除仍可用
- [ ] 图片视频音频 PDF 预览不受影响
- [ ] 手机全宽、桌面更宽；长行可横向滚动