### PR TITLE
修复：文档筛选隐藏 json 等文本文件，并改进列表解析与预览 UI

### DIFF
--- a/functions/webdav/protocol.ts
+++ b/functions/webdav/protocol.ts
@@ -715,7 +715,7 @@ function fromR2Object(object: R2Object | DavObject | null | undefined): DavPrope
     getcontentlength: object.size.toString(),
     getcontenttype: isCollection
       ? "application/x-directory"
-      : object.httpMetadata?.contentType,
+      : object.httpMetadata?.contentType || "application/octet-stream",
     getetag: object.etag,
     getlastmodified: object.uploaded.toUTCString(),
     resourcetype: isCollection ? "<collection />" : "",
@@ -772,10 +772,14 @@ async function* listAll(
   do {
     // The `include` option is intentionally typed loosely here because some
     // @cloudflare/workers-types versions lag behind the Workers runtime.
+    // Paginate every page (truncated/cursor). Never drop later objects or
+    // delimited prefixes — a missing snapshot.json is a client-filter bug,
+    // not a reason to silently cap the listing.
     const r2Objects: R2Objects = await (bucket as any).list({
       prefix,
       delimiter: isRecursive ? undefined : "/",
       cursor,
+      limit: 1000,
       include: ["httpMetadata", "customMetadata"],
     });
 

--- a/src/ExplorerBar.tsx
+++ b/src/ExplorerBar.tsx
@@ -307,22 +307,31 @@ function ExplorerBar({
             flexWrap: "wrap",
           }}
         >
-          {TYPE_FILTERS.map((item) => (
+          {TYPE_FILTERS.map((item) => {
+            const active = typeFilter === item.value;
+            const filtering = typeFilter !== "all";
+            return (
             <Chip
               key={item.value}
               size="small"
               label={item.label}
               clickable
-              color={typeFilter === item.value ? "primary" : "default"}
-              variant={typeFilter === item.value ? "filled" : "outlined"}
+              color={active ? "primary" : "default"}
+              variant={active ? "filled" : "outlined"}
               onClick={() => onTypeFilterChange(item.value)}
               sx={{
                 borderRadius: "999px",
-                height: 26,
-                "& .MuiChip-label": { px: 1.1 },
+                height: 28,
+                fontWeight: 700,
+                boxShadow:
+                  active && filtering
+                    ? "0 0 0 2px rgba(243, 128, 32, 0.45)"
+                    : "none",
+                "& .MuiChip-label": { px: 1.25 },
               }}
             />
-          ))}
+            );
+          })}
           <FormControlLabel
             sx={{ marginLeft: 0.5, marginRight: 0, whiteSpace: "nowrap" }}
             control={

--- a/src/FileGrid.tsx
+++ b/src/FileGrid.tsx
@@ -328,7 +328,7 @@ function FileGrid({
         overflow: "visible",
         width: "100%",
         height: "100%",
-        minHeight: 156,
+        minHeight: 168,
         boxSizing: "border-box",
         padding: 1.5,
         paddingTop: "44px",
@@ -356,6 +356,9 @@ function FileGrid({
             : "#faf8f5",
           boxShadow: "0 6px 16px rgba(26, 23, 20, 0.08)",
           borderColor: "rgba(243, 128, 32, 0.35)",
+        },
+        "&:focus": {
+          outline: "none",
         },
         "&:focus-visible": {
           outline: "2px solid",
@@ -387,6 +390,9 @@ function FileGrid({
           WebkitBoxOrient: "vertical",
           overflow: "hidden",
           lineHeight: 1.35,
+          height: "2.7em",
+          minHeight: "2.7em",
+          wordBreak: "break-word",
         }}
         title={file.name}
       >

--- a/src/PreviewDialog.tsx
+++ b/src/PreviewDialog.tsx
@@ -236,6 +236,12 @@ function PreviewDialog({
     }
   };
 
+  const closePreview = () => {
+    onClose();
+    const active = document.activeElement;
+    if (active instanceof HTMLElement) active.blur();
+  };
+
   const contentType = mimeType(file?.contentType);
   const isImage =
     contentType.startsWith("image/") && contentType !== "image/svg+xml";
@@ -253,10 +259,12 @@ function PreviewDialog({
   return (
     <Dialog
       open={Boolean(file)}
-      onClose={onClose}
+      onClose={closePreview}
       fullWidth
       fullScreen={isPhone}
       maxWidth="xl"
+      transitionDuration={0}
+      disableRestoreFocus
       PaperProps={{
         sx: {
           display: "flex",
@@ -265,8 +273,10 @@ function PreviewDialog({
           maxHeight: isPhone ? "100%" : "92vh",
           width: isPhone ? "100%" : "96vw",
           maxWidth: isPhone ? "100%" : 1280,
+          opacity: 1,
         },
       }}
+      BackdropProps={{ transitionDuration: 0 }}
     >
       <DialogTitle
         sx={{
@@ -394,7 +404,7 @@ function PreviewDialog({
         <Button startIcon={<DownloadIcon />} onClick={download}>
           下载
         </Button>
-        <Button onClick={onClose}>关闭</Button>
+        <Button onClick={closePreview}>关闭</Button>
       </DialogActions>
     </Dialog>
   );

--- a/src/app/transfer.ts
+++ b/src/app/transfer.ts
@@ -6,6 +6,49 @@ import { basename, encodeKey } from "./utils";
 
 const WEBDAV_ENDPOINT = "/webdav/";
 
+function decodeHrefSegment(segment: string) {
+  try {
+    return decodeURIComponent(segment);
+  } catch {
+    return segment;
+  }
+}
+
+/** Object key from a PROPFIND href, whether relative (`/webdav/a/b`) or absolute. */
+export function davHrefToKey(href: string): string {
+  const raw = (href || "").trim();
+  if (!raw) return "";
+
+  let pathname = raw;
+  try {
+    if (/^[a-zA-Z][a-zA-Z0-9+.-]*:/.test(raw)) {
+      pathname = new URL(raw).pathname;
+    }
+  } catch {
+    const fallback = raw.indexOf("/webdav/");
+    if (fallback >= 0) pathname = raw.slice(fallback);
+  }
+
+  const marker = "/webdav/";
+  const at = pathname.indexOf(marker);
+  let rest: string;
+  if (at >= 0) {
+    rest = pathname.slice(at + marker.length);
+  } else if (pathname === "/webdav") {
+    rest = "";
+  } else if (pathname.startsWith("/")) {
+    rest = pathname.slice(1);
+  } else {
+    rest = pathname;
+  }
+
+  return rest.split("/").map(decodeHrefSegment).join("/").replace(/\/$/, "");
+}
+
+function firstTag(parent: Element, localName: string): Element | undefined {
+  return parent.getElementsByTagName(localName)[0];
+}
+
 export async function fetchPath(path: string) {
   const res = await authFetch(`${WEBDAV_ENDPOINT}${encodeKey(path)}`, {
     method: "PROPFIND",
@@ -19,41 +62,36 @@ export async function fetchPath(path: string) {
   const parser = new DOMParser();
   const text = await res.text();
   const document = parser.parseFromString(text, "application/xml");
-  const items: FileItem[] = Array.from(document.querySelectorAll("response"))
-    .filter(
-      (response) => {
-        const hrefPath = decodeURIComponent(
-          response.querySelector("href")?.textContent ?? ""
-        )
-          .slice(WEBDAV_ENDPOINT.length)
-          .replace(/\/$/, "");
-        return hrefPath !== path.replace(/\/$/, "");
-      }
-    )
-    .map((response) => {
-      const href = response.querySelector("href")?.textContent;
-      if (!href) throw new Error("Invalid response");
-      const contentType = response.querySelector("getcontenttype")?.textContent;
-      const size = response.querySelector("getcontentlength")?.textContent;
-      const lastModified =
-        response.querySelector("getlastmodified")?.textContent;
-      const thumbnail = response.getElementsByTagNameNS(
-        "flaredrive",
-        "thumbnail"
-      )[0]?.textContent;
-      const key = decodeURIComponent(href)
-        .replace(/^\/webdav\//, "")
-        .replace(/\/$/, "");
-      return {
-        key,
-        name: basename(key),
-        isDir: contentType === "application/x-directory",
-        size: size ? Number(size) : 0,
-        uploaded: lastModified || new Date().toUTCString(),
-        contentType: contentType || "",
-        thumbnail: thumbnail || undefined,
-      } as FileItem;
+  const cwdKey = path.replace(/\/$/, "");
+  const items: FileItem[] = [];
+
+  for (const response of Array.from(document.getElementsByTagName("response"))) {
+    const href = firstTag(response, "href")?.textContent ?? "";
+    const key = davHrefToKey(href);
+    if (!href) continue;
+    if (key === cwdKey) continue;
+
+    const contentType = firstTag(response, "getcontenttype")?.textContent || "";
+    const size = firstTag(response, "getcontentlength")?.textContent;
+    const lastModified = firstTag(response, "getlastmodified")?.textContent;
+    const thumbnail =
+      response.getElementsByTagNameNS("flaredrive", "thumbnail")[0]
+        ?.textContent || undefined;
+    const resourceType = firstTag(response, "resourcetype");
+    const isDir =
+      contentType === "application/x-directory" ||
+      Boolean(resourceType?.getElementsByTagName("collection").length);
+
+    items.push({
+      key,
+      name: basename(key),
+      isDir,
+      size: size ? Number(size) : 0,
+      uploaded: lastModified || new Date().toUTCString(),
+      contentType: contentType || (isDir ? "application/x-directory" : ""),
+      thumbnail: thumbnail || undefined,
     });
+  }
   return items;
 }
 

--- a/src/app/utils.ts
+++ b/src/app/utils.ts
@@ -1,3 +1,4 @@
+import { isTextPreviewable } from "./preview";
 import { FileItem } from "./types";
 
 export function humanReadableSize(size: number) {
@@ -28,28 +29,41 @@ export function isDirectory(file: Pick<FileItem, "isDir">) {
   return file.isDir;
 }
 
+const OFFICE_TYPES = new Set([
+  "application/pdf",
+  "application/msword",
+  "application/rtf",
+  "application/vnd.ms-excel",
+  "application/vnd.ms-powerpoint",
+]);
+
+const DOC_NAME =
+  /\.(pdf|doc|docx|xls|xlsx|ppt|pptx|txt|md|markdown|csv|tsv|rtf|json|jsonc|xml|html|htm|yaml|yml)$/;
+
 export function fileTypeCategory(
   file: FileItem
 ): "folder" | "image" | "video" | "doc" | "other" {
   if (file.isDir) return "folder";
-  const type = (file.contentType || "").toLowerCase();
+  const type = (file.contentType || "").toLowerCase().split(";")[0].trim();
   const name = file.name.toLowerCase();
-  if (type.startsWith("image/")) return "image";
   if (type.startsWith("video/")) return "video";
+  // svg+xml is text-previewable and should count as a document, not an image.
+  if (type.startsWith("image/") && type !== "image/svg+xml") return "image";
   const office =
     type.includes("wordprocessing") ||
     type.includes("spreadsheet") ||
     type.includes("presentation") ||
     type.includes("opendocument") ||
-    [
-      "application/pdf",
-      "application/msword",
-      "application/rtf",
-      "application/vnd.ms-excel",
-      "application/vnd.ms-powerpoint",
-    ].includes(type);
-  const docName = /\.(pdf|doc|docx|xls|xlsx|ppt|pptx|txt|md|csv|rtf)$/.test(name);
-  if (type.startsWith("text/") || office || docName) return "doc";
+    OFFICE_TYPES.has(type);
+  const docName = DOC_NAME.test(name);
+  if (
+    type.startsWith("text/") ||
+    office ||
+    docName ||
+    isTextPreviewable(file)
+  ) {
+    return "doc";
+  }
   return "other";
 }
 


### PR DESCRIPTION
## 原因

`DBX/sync/snapshot.json` 实际一直在 R2 / 页面列表里（「全部」「其他」可见），并不是对象丢失。

点「文档」后文件夹被筛空，是因为 `fileTypeCategory` 把 json / xml / html / yaml 等归为 `other`，只有 pdf/doc/txt/md/csv/rtf 才算文档。

## 修复

- **类型筛选**：json、xml、html、yaml/yml、md、csv 以及其它可文本预览的类型一律视为 `doc`。默认仍是「全部」；筛选非全部时文件夹继续显示，当前 chip 更醒目。
- **列表解析**：PROPFIND `href` 按 `/webdav/` 之后的路径解析（相对或绝对 URL 均可）；缺 `httpMetadata` 的对象不再被跳过。`listAll` 继续按 `truncated`/`cursor` 翻页，不静默丢文件。
- **隐藏垃圾文件**：仍只匹配 `.DS_Store` / `._*` / `Thumbs.db` / `desktop.ini`，不会藏 `*.json` 或 `snapshot*`。
- 不对用户对象做删除或改写。

## UI

- 预览对话框关闭淡入：纸面直接不透明、`transitionDuration={0}`，避免半透明遮罩上闪约 1 秒标题/页脚。
- 关闭预览后 `disableRestoreFocus` 并 blur，去掉磁贴上的橙色焦点圈（并非真实选中）。
- 网格标题固定两行高度，长文件名不再把单张卡片撑高。

未加暗色模式；文本预览仍是纯文本；上传队列递归修复保持不动。