### PR TITLE
feat: 开放接口支持按密钥下载文件

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Free serverless backend with a limit of 100,000 invocation requests per day.
 - WebDAV Class 1/2
 - Drag and drop upload
 - Share links with expiry and trash
-- API keys for scripted uploads
+- API keys for scripted uploads and downloads
 
 ## Usage
 
@@ -71,6 +71,30 @@ curl -X POST "https://<your-domain.com>/api/upload?path=docs/" \
 ```
 
 Single-request uploads are limited to about 100MB (HTTP 413 otherwise). Larger files still need the web chunked uploader. Manage keys via session-authenticated `GET/POST/DELETE /api/keys`. Usage docs are also shown on the API settings page.
+
+The same keys can download a single object (folders are not a zip; fetch each file):
+
+```bash
+curl -L "https://<your-domain.com>/api/download?path=DBX/sync/snapshot.json" \
+  -H "Authorization: Bearer <apiKey>" \
+  -o snapshot.json
+
+# also accepts X-Api-Key
+curl -L "https://<your-domain.com>/api/download?path=DBX/sync/snapshot.json" \
+  -H "X-Api-Key: <apiKey>" \
+  -o snapshot.json
+```
+
+`path` is the object key. HTTP 200 streams the file (`Content-Type` from R2 or `application/octet-stream`, `Content-Disposition: attachment`). Missing/empty path or a directory/prefix folder returns 400; unknown object 404; bad/expired key 401. Internal `_$flaredrive$/` keys are rejected.
+
+Optional Depth-1 listing:
+
+```bash
+curl "https://<your-domain.com>/api/list?path=folder/" \
+  -H "Authorization: Bearer <apiKey>"
+```
+
+Returns `{ items: [{ key, name, size, isDir }] }`.
 
 ## Acknowledgments
 

--- a/functions/api/_apikey.ts
+++ b/functions/api/_apikey.ts
@@ -1,0 +1,155 @@
+export const KEYS_PREFIX = "_$flaredrive$/apikeys/";
+export const INTERNAL_PREFIX = "_$flaredrive$/";
+
+export interface StoredApiKey {
+  id: string;
+  name: string;
+  prefix: string;
+  keyHash: string;
+  createdAt: string;
+  expiresAt: string | null;
+  createdBy?: string;
+  lastUsedAt?: string | null;
+}
+
+export function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json; charset=utf-8" },
+  });
+}
+
+export function textResponse(message: string, status: number) {
+  return new Response(message, {
+    status,
+    headers: { "Content-Type": "text/plain; charset=utf-8" },
+  });
+}
+
+function extractApiKey(request: Request): string {
+  const xKey = (request.headers.get("X-Api-Key") || "").trim();
+  if (xKey) return xKey;
+  const authorization = request.headers.get("Authorization") || "";
+  if (authorization.startsWith("Bearer ")) {
+    return authorization.slice(7).trim();
+  }
+  return "";
+}
+
+async function sha256Hex(value: string) {
+  const digest = await crypto.subtle.digest(
+    "SHA-256",
+    new TextEncoder().encode(value)
+  );
+  return Array.from(new Uint8Array(digest))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+function timingSafeEqual(a: string, b: string) {
+  if (a.length !== b.length) return false;
+  let diff = 0;
+  for (let i = 0; i < a.length; i++) {
+    diff |= a.charCodeAt(i) ^ b.charCodeAt(i);
+  }
+  return diff === 0;
+}
+
+function isExpired(expiresAt: string | null | undefined) {
+  if (!expiresAt) return false;
+  const ts = Date.parse(expiresAt);
+  return Number.isFinite(ts) && ts <= Date.now();
+}
+
+async function listStoredKeys(bucket: R2Bucket): Promise<StoredApiKey[]> {
+  const records: StoredApiKey[] = [];
+  let cursor: string | undefined;
+  do {
+    const listing = await bucket.list({
+      prefix: KEYS_PREFIX,
+      cursor,
+    });
+    for (const object of listing.objects) {
+      if (!object.key.endsWith(".json")) continue;
+      const data = await bucket.get(object.key);
+      if (data === null) continue;
+      try {
+        records.push((await data.json()) as StoredApiKey);
+      } catch {
+        // skip corrupt metadata
+      }
+    }
+    if (!listing.truncated) break;
+    cursor = listing.cursor;
+  } while (true);
+  return records;
+}
+
+export async function authorizeApiKey(
+  request: Request,
+  bucket: R2Bucket
+): Promise<StoredApiKey | Response> {
+  const rawKey = extractApiKey(request);
+  if (!rawKey) {
+    return textResponse("缺少 API 密钥", 401);
+  }
+  const incomingHash = await sha256Hex(rawKey);
+  const records = await listStoredKeys(bucket);
+  let matched: StoredApiKey | null = null;
+  for (const record of records) {
+    if (record.keyHash && timingSafeEqual(record.keyHash, incomingHash)) {
+      matched = record;
+      break;
+    }
+  }
+  if (!matched) {
+    return textResponse("无效的 API 密钥", 401);
+  }
+  if (isExpired(matched.expiresAt)) {
+    return textResponse("API 密钥已过期", 401);
+  }
+  return matched;
+}
+
+export async function touchLastUsed(bucket: R2Bucket, record: StoredApiKey) {
+  try {
+    const next = { ...record, lastUsedAt: new Date().toISOString() };
+    await bucket.put(`${KEYS_PREFIX}${record.id}.json`, JSON.stringify(next), {
+      httpMetadata: { contentType: "application/json" },
+    });
+  } catch {
+    // last-used is best-effort
+  }
+}
+
+export function isInternalKey(key: string) {
+  return key.startsWith(INTERNAL_PREFIX) || key.includes("/_$flaredrive$/");
+}
+
+export function isCollectionObject(
+  object: { httpMetadata?: R2HTTPMetadata; customMetadata?: Record<string, string> } | null
+) {
+  if (!object) return false;
+  return (
+    object.customMetadata?.resourcetype === "<collection />" ||
+    object.httpMetadata?.contentType === "application/x-directory"
+  );
+}
+
+export function decodeRawPath(raw: string | null): string {
+  let path = (raw || "").trim();
+  try {
+    path = decodeURIComponent(path);
+  } catch {
+    // keep raw
+  }
+  return path.replace(/\\/g, "/").replace(/^\/+/, "");
+}
+
+export function splitSafeParts(path: string): string[] | Response {
+  const parts = path.split("/").filter((part) => part && part !== ".");
+  if (parts.some((part) => part === "..")) {
+    return textResponse("路径不合法", 400);
+  }
+  return parts;
+}

--- a/functions/api/download.ts
+++ b/functions/api/download.ts
@@ -1,0 +1,97 @@
+import {
+  authorizeApiKey,
+  decodeRawPath,
+  isCollectionObject,
+  isInternalKey,
+  splitSafeParts,
+  textResponse,
+  touchLastUsed,
+} from "./_apikey";
+
+interface DownloadEnv {
+  BUCKET: R2Bucket;
+}
+
+function basename(key: string) {
+  const name = key.split("/").filter(Boolean).pop() || "download";
+  return name.replace(/[\u0000-\u001f]/g, "");
+}
+
+function attachmentDisposition(filename: string) {
+  const fallback = filename.replace(/["\\\r\n]/g, "_") || "download";
+  const encoded = encodeURIComponent(filename || "download").replace(
+    /['()]/g,
+    (ch) => `%${ch.charCodeAt(0).toString(16).toUpperCase()}`
+  );
+  return `attachment; filename="${fallback}"; filename*=UTF-8''${encoded}`;
+}
+
+function normalizeObjectKey(raw: string | null): string | Response {
+  const decoded = decodeRawPath(raw);
+  if (!decoded) {
+    return textResponse("缺少 path 参数", 400);
+  }
+  const parts = splitSafeParts(decoded);
+  if (parts instanceof Response) return parts;
+  if (parts.length === 0) {
+    return textResponse("缺少 path 参数", 400);
+  }
+  const key = parts.join("/");
+  if (isInternalKey(key)) {
+    return textResponse("禁止访问内部目录", 400);
+  }
+  if (decoded.endsWith("/")) {
+    return textResponse("不能下载目录，请逐个文件下载", 400);
+  }
+  return key;
+}
+
+async function isPrefixOnlyFolder(bucket: R2Bucket, key: string) {
+  const listing = await bucket.list({
+    prefix: `${key}/`,
+    limit: 1,
+  });
+  const prefixes = (listing as { delimitedPrefixes?: string[] }).delimitedPrefixes;
+  return listing.objects.length > 0 || (prefixes && prefixes.length > 0);
+}
+
+export const onRequestGet: PagesFunction<DownloadEnv> = async (context) => {
+  const { request, env } = context;
+  const auth = await authorizeApiKey(request, env.BUCKET);
+  if (auth instanceof Response) return auth;
+
+  const key = normalizeObjectKey(new URL(request.url).searchParams.get("path"));
+  if (key instanceof Response) return key;
+
+  const object = await env.BUCKET.get(key);
+  if (object === null) {
+    if (await isPrefixOnlyFolder(env.BUCKET, key)) {
+      return textResponse("不能下载目录，请逐个文件下载", 400);
+    }
+    return textResponse("文件不存在", 404);
+  }
+  if (isCollectionObject(object)) {
+    return textResponse("不能下载目录，请逐个文件下载", 400);
+  }
+  if (!("body" in object) || object.body === null) {
+    return textResponse("文件不存在", 404);
+  }
+
+  await touchLastUsed(env.BUCKET, auth);
+
+  const headers = new Headers();
+  const contentType =
+    object.httpMetadata?.contentType || "application/octet-stream";
+  headers.set("Content-Type", contentType);
+  headers.set("Content-Disposition", attachmentDisposition(basename(key)));
+  if (Number.isFinite(object.size)) {
+    headers.set("Content-Length", String(object.size));
+  }
+  headers.set("Cache-Control", "no-store");
+  if (object.httpEtag) headers.set("ETag", object.httpEtag);
+  if (object.uploaded) {
+    headers.set("Last-Modified", object.uploaded.toUTCString());
+  }
+
+  return new Response(object.body, { status: 200, headers });
+};

--- a/functions/api/list.ts
+++ b/functions/api/list.ts
@@ -1,0 +1,106 @@
+import {
+  authorizeApiKey,
+  decodeRawPath,
+  isCollectionObject,
+  isInternalKey,
+  jsonResponse,
+  splitSafeParts,
+  textResponse,
+  touchLastUsed,
+} from "./_apikey";
+
+interface ListEnv {
+  BUCKET: R2Bucket;
+}
+
+interface ListItem {
+  key: string;
+  name: string;
+  size: number;
+  isDir: boolean;
+}
+
+function normalizeFolder(raw: string | null): string | Response {
+  const decoded = decodeRawPath(raw);
+  if (!decoded) return "";
+  const parts = splitSafeParts(decoded);
+  if (parts instanceof Response) return parts;
+  if (parts.length === 0) return "";
+  const joined = parts.join("/");
+  if (isInternalKey(joined)) {
+    return textResponse("禁止访问内部目录", 400);
+  }
+  return `${joined}/`;
+}
+
+export const onRequestGet: PagesFunction<ListEnv> = async (context) => {
+  const { request, env } = context;
+  const auth = await authorizeApiKey(request, env.BUCKET);
+  if (auth instanceof Response) return auth;
+
+  const folder = normalizeFolder(new URL(request.url).searchParams.get("path"));
+  if (folder instanceof Response) return folder;
+
+  if (folder) {
+    const parentKey = folder.replace(/\/$/, "");
+    const head = await env.BUCKET.head(parentKey);
+    if (head !== null && !isCollectionObject(head)) {
+      return textResponse("path 不是目录", 400);
+    }
+  }
+
+  const itemsByKey = new Map<string, ListItem>();
+  let cursor: string | undefined;
+  do {
+    const listing = await env.BUCKET.list({
+      prefix: folder,
+      delimiter: "/",
+      cursor,
+      // @ts-ignore `include` is supported by R2 but missing from this types version.
+      include: ["httpMetadata", "customMetadata"],
+    });
+
+    for (const object of listing.objects) {
+      if (isInternalKey(object.key)) continue;
+      const name = object.key.slice(folder.length);
+      if (!name || name.includes("/")) continue;
+      const isDir = isCollectionObject(object);
+      itemsByKey.set(object.key, {
+        key: object.key,
+        name,
+        size: isDir ? 0 : object.size,
+        isDir,
+      });
+    }
+
+    const prefixes = (listing as { delimitedPrefixes?: string[] })
+      .delimitedPrefixes;
+    if (prefixes) {
+      for (const prefix of prefixes) {
+        if (isInternalKey(prefix)) continue;
+        const name = prefix.slice(folder.length).replace(/\/$/, "");
+        if (!name) continue;
+        const key = prefix.replace(/\/$/, "");
+        if (itemsByKey.has(key)) {
+          const existing = itemsByKey.get(key)!;
+          existing.isDir = true;
+          existing.size = 0;
+        } else {
+          itemsByKey.set(key, { key, name, size: 0, isDir: true });
+        }
+      }
+    }
+
+    if (!listing.truncated) break;
+    cursor = listing.cursor;
+  } while (true);
+
+  await touchLastUsed(env.BUCKET, auth);
+
+  const items = Array.from(itemsByKey.values()).sort((a, b) => {
+    if (a.isDir !== b.isDir) return a.isDir ? -1 : 1;
+    return a.name.localeCompare(b.name, "zh");
+  });
+
+  return jsonResponse({ items });
+};

--- a/src/ApiKeysPanel.tsx
+++ b/src/ApiKeysPanel.tsx
@@ -25,6 +25,7 @@ import VpnKeyIcon from "@mui/icons-material/VpnKey";
 
 import {
   createApiKey,
+  downloadCurlExample,
   formatApiUsage,
   listApiKeys,
   revokeApiKey,
@@ -345,6 +346,22 @@ function ApiKeysPanel({
                   }
                 >
                   复制 curl
+                </Button>
+                <Button
+                  size="small"
+                  startIcon={<ContentCopyIcon />}
+                  onClick={() =>
+                    copy(
+                      downloadCurlExample(
+                        origin,
+                        usageKey,
+                        "DBX/sync/snapshot.json"
+                      ),
+                      "下载 curl"
+                    )
+                  }
+                >
+                  复制下载 curl
                 </Button>
               </Stack>
             </Box>

--- a/src/app/apikeys.ts
+++ b/src/app/apikeys.ts
@@ -38,6 +38,14 @@ export function uploadCurlExample(origin: string, apiKey = "<apiKey>", path = "f
   return `curl -X POST "${origin}/api/upload?path=${path}" -H "Authorization: Bearer ${apiKey}" -F "file=@photo.jpg"`;
 }
 
+export function downloadCurlExample(
+  origin: string,
+  apiKey = "<apiKey>",
+  path = "DBX/sync/snapshot.json"
+) {
+  return `curl -L "${origin}/api/download?path=${path}" -H "Authorization: Bearer ${apiKey}" -o snapshot.json`;
+}
+
 export function formatApiUsage(origin: string, apiKey = "<apiKey>") {
   const key = apiKey || "<apiKey>";
   return [
@@ -80,5 +88,48 @@ export function formatApiUsage(origin: string, apiKey = "<apiKey>") {
     `  headers: { Authorization: "Bearer ${key}" },`,
     `  body: form,`,
     `});`,
+    "",
+    "—— 下载 ——",
+    "",
+    `接口：GET ${origin}/api/download`,
+    "鉴权与上传相同（Authorization: Bearer 或 X-Api-Key），无需网页登录。",
+    "查询参数：path=对象键（必填，须为文件，不能是目录）",
+    "成功：200，返回文件内容",
+    "  Content-Type：对象元数据或 application/octet-stream",
+    "  Content-Disposition：attachment; filename=文件名",
+    "  Content-Length：已知时带上",
+    "密钥无效或已过期：401",
+    "缺少 path、path 为空，或目标是目录：400",
+    "文件不存在：404",
+    "文件夹不能整包下载，请逐个文件下载（与上传相同，一次一个文件）。",
+    "",
+    "示例（curl）：",
+    `curl -L "${origin}/api/download?path=DBX/sync/snapshot.json" \\`,
+    `  -H "Authorization: Bearer ${key}" \\`,
+    `  -o snapshot.json`,
+    "",
+    "示例（X-Api-Key）：",
+    `curl -L "${origin}/api/download?path=DBX/sync/snapshot.json" \\`,
+    `  -H "X-Api-Key: ${key}" \\`,
+    `  -o snapshot.json`,
+    "",
+    "示例（fetch）：",
+    `const res = await fetch("${origin}/api/download?path=DBX/sync/snapshot.json", {`,
+    `  headers: { Authorization: "Bearer ${key}" },`,
+    `});`,
+    `if (!res.ok) throw new Error(await res.text());`,
+    `const blob = await res.blob();`,
+    "",
+    "—— 列出目录（Depth 1）——",
+    "",
+    `接口：GET ${origin}/api/list`,
+    "鉴权与上传相同。",
+    "查询参数：path=目录/ （可空，表示根目录）",
+    "成功：200，JSON { items: [{ key, name, size, isDir }] }",
+    "密钥无效或已过期：401；path 不是目录：400",
+    "",
+    "示例：",
+    `curl "${origin}/api/list?path=folder/" \\`,
+    `  -H "Authorization: Bearer ${key}"`,
   ].join("\n");
 }

--- a/src/app/strings.ts
+++ b/src/app/strings.ts
@@ -68,7 +68,7 @@ export const strings = {
   copyWebDavGuide: "复制完整说明",
   api: "API",
   apiKeys: "开放接口",
-  apiKeysHint: "用密钥通过接口上传文件，完整密钥只显示一次",
+  apiKeysHint: "用密钥通过接口上传或下载文件，完整密钥只显示一次",
   createApiKey: "创建密钥",
   revokeApiKey: "作废",
   apiKeyName: "名称",


### PR DESCRIPTION
## 摘要
- 新增 `GET /api/download?path=对象键`：鉴权与上传相同（`Authorization: Bearer` 或 `X-Api-Key`，哈希比对，过期/未知返回 401），无需网页登录。
- 成功 200 流式返回 R2 对象；`Content-Type` 取自元数据或 `application/octet-stream`；`Content-Disposition: attachment` 带文件名；已知时带 `Content-Length`。
- 缺少/空 path、目录或仅前缀文件夹返回 400；对象不存在返回 404；拒绝 `_$flaredrive$/` 内部路径。
- 可选 `GET /api/list?path=目录/`：Depth-1 JSON `{ items: [{ key, name, size, isDir }] }`，同一套密钥。
- 开放接口面板「调用说明」补充下载 curl / fetch 示例（使用当前 origin），并注明文件夹不能整包下载。上传接口与 WebDAV 未改。

## 测试计划
- [ ] 有效密钥下载已有文件，检查正文与响应头
- [ ] 缺 path / 目录 path / 内部路径 → 400
- [ ] 不存在的对象 → 404；错误或过期密钥 → 401
- [ ] 无需网页 session 即可调用
- [ ] 上传与 WebDAV 行为不变