### PR TITLE
feat: 列出目录后再逐个下载文件

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,9 +72,14 @@ curl -X POST "https://<your-domain.com>/api/upload?path=docs/" \
 
 Single-request uploads are limited to about 100MB (HTTP 413 otherwise). Larger files still need the web chunked uploader. Manage keys via session-authenticated `GET/POST/DELETE /api/keys`. Usage docs are also shown on the API settings page.
 
-The same keys can download a single object (folders are not a zip; fetch each file):
+The same keys can list a folder and download each file (folders are not a zip):
 
 ```bash
+# Depth-1 list (empty path = root). Does not recurse.
+curl "https://<your-domain.com>/api/list?path=folder/" \
+  -H "Authorization: Bearer <apiKey>"
+
+# download each item where isDir is false
 curl -L "https://<your-domain.com>/api/download?path=DBX/sync/snapshot.json" \
   -H "Authorization: Bearer <apiKey>" \
   -o snapshot.json
@@ -85,16 +90,9 @@ curl -L "https://<your-domain.com>/api/download?path=DBX/sync/snapshot.json" \
   -o snapshot.json
 ```
 
-`path` is the object key. HTTP 200 streams the file (`Content-Type` from R2 or `application/octet-stream`, `Content-Disposition: attachment`). Missing/empty path or a directory/prefix folder returns 400; unknown object 404; bad/expired key 401. Internal `_$flaredrive$/` keys are rejected.
+`GET /api/list` returns `{ items: [{ key, name, size, isDir, uploaded? }] }` for the current folder only. Nested folders: call `/api/list` again with that item's `key`. If `path` is a file, the list API returns 400 and tells you to use `/api/download`. Missing folder: 404. Bad/expired key: 401.
 
-Optional Depth-1 listing:
-
-```bash
-curl "https://<your-domain.com>/api/list?path=folder/" \
-  -H "Authorization: Bearer <apiKey>"
-```
-
-Returns `{ items: [{ key, name, size, isDir }] }`.
+`GET /api/download` `path` is the object key. HTTP 200 streams the file (`Content-Type` from R2 or `application/octet-stream`, `Content-Disposition: attachment`). Missing/empty path or a directory/prefix folder returns 400; unknown object 404; bad/expired key 401. Internal `_$flaredrive$/` keys are rejected.
 
 ## Acknowledgments
 

--- a/functions/api/list.ts
+++ b/functions/api/list.ts
@@ -18,6 +18,7 @@ interface ListItem {
   name: string;
   size: number;
   isDir: boolean;
+  uploaded?: string;
 }
 
 function normalizeFolder(raw: string | null): string | Response {
@@ -41,11 +42,12 @@ export const onRequestGet: PagesFunction<ListEnv> = async (context) => {
   const folder = normalizeFolder(new URL(request.url).searchParams.get("path"));
   if (folder instanceof Response) return folder;
 
+  let folderHead: R2Object | null = null;
   if (folder) {
     const parentKey = folder.replace(/\/$/, "");
-    const head = await env.BUCKET.head(parentKey);
-    if (head !== null && !isCollectionObject(head)) {
-      return textResponse("path 不是目录", 400);
+    folderHead = await env.BUCKET.head(parentKey);
+    if (folderHead !== null && !isCollectionObject(folderHead)) {
+      return textResponse("path 是文件，请使用 /api/download 下载", 400);
     }
   }
 
@@ -65,12 +67,16 @@ export const onRequestGet: PagesFunction<ListEnv> = async (context) => {
       const name = object.key.slice(folder.length);
       if (!name || name.includes("/")) continue;
       const isDir = isCollectionObject(object);
-      itemsByKey.set(object.key, {
+      const item: ListItem = {
         key: object.key,
         name,
         size: isDir ? 0 : object.size,
         isDir,
-      });
+      };
+      if (object.uploaded) {
+        item.uploaded = object.uploaded.toISOString();
+      }
+      itemsByKey.set(object.key, item);
     }
 
     const prefixes = (listing as { delimitedPrefixes?: string[] })
@@ -94,6 +100,10 @@ export const onRequestGet: PagesFunction<ListEnv> = async (context) => {
     if (!listing.truncated) break;
     cursor = listing.cursor;
   } while (true);
+
+  if (folder && folderHead === null && itemsByKey.size === 0) {
+    return textResponse("目录不存在", 404);
+  }
 
   await touchLastUsed(env.BUCKET, auth);
 

--- a/src/ApiKeysPanel.tsx
+++ b/src/ApiKeysPanel.tsx
@@ -28,6 +28,7 @@ import {
   downloadCurlExample,
   formatApiUsage,
   listApiKeys,
+  listCurlExample,
   revokeApiKey,
   uploadCurlExample,
 } from "./app/apikeys";
@@ -362,6 +363,15 @@ function ApiKeysPanel({
                   }
                 >
                   复制下载 curl
+                </Button>
+                <Button
+                  size="small"
+                  startIcon={<ContentCopyIcon />}
+                  onClick={() =>
+                    copy(listCurlExample(origin, usageKey, "folder/"), "列出 curl")
+                  }
+                >
+                  复制列出 curl
                 </Button>
               </Stack>
             </Box>

--- a/src/app/apikeys.ts
+++ b/src/app/apikeys.ts
@@ -46,6 +46,10 @@ export function downloadCurlExample(
   return `curl -L "${origin}/api/download?path=${path}" -H "Authorization: Bearer ${apiKey}" -o snapshot.json`;
 }
 
+export function listCurlExample(origin: string, apiKey = "<apiKey>", path = "folder/") {
+  return `curl "${origin}/api/list?path=${path}" -H "Authorization: Bearer ${apiKey}"`;
+}
+
 export function formatApiUsage(origin: string, apiKey = "<apiKey>") {
   const key = apiKey || "<apiKey>";
   return [
@@ -101,7 +105,7 @@ export function formatApiUsage(origin: string, apiKey = "<apiKey>") {
     "密钥无效或已过期：401",
     "缺少 path、path 为空，或目标是目录：400",
     "文件不存在：404",
-    "文件夹不能整包下载，请逐个文件下载（与上传相同，一次一个文件）。",
+    "文件夹不能整包下载，请先 list 再逐个文件下载（与上传相同，一次一个文件）。",
     "",
     "示例（curl）：",
     `curl -L "${origin}/api/download?path=DBX/sync/snapshot.json" \\`,
@@ -120,16 +124,43 @@ export function formatApiUsage(origin: string, apiKey = "<apiKey>") {
     `if (!res.ok) throw new Error(await res.text());`,
     `const blob = await res.blob();`,
     "",
-    "—— 列出目录（Depth 1）——",
+    "—— 列出目录（Depth 1，下载前先列出）——",
     "",
     `接口：GET ${origin}/api/list`,
-    "鉴权与上传相同。",
+    "鉴权与上传/下载相同（Authorization: Bearer 或 X-Api-Key），无需网页登录。",
     "查询参数：path=目录/ （可空，表示根目录）",
-    "成功：200，JSON { items: [{ key, name, size, isDir }] }",
-    "密钥无效或已过期：401；path 不是目录：400",
+    "只返回当前层：文件 + 直接子文件夹，不会递归整桶。",
+    "成功：200，JSON { items: [{ key, name, size, isDir, uploaded? }] }",
+    "密钥无效或已过期：401",
+    "path 是文件：400（请改用 /api/download）",
+    "路径不合法或内部目录：400",
+    "目录不存在：404",
+    "下载目录：先 list，再对 isDir 为 false 的每一项调用 /api/download。",
+    "子文件夹：再对 path=<item.key> 调用 /api/list。",
     "",
-    "示例：",
+    "示例（curl 列出）：",
     `curl "${origin}/api/list?path=folder/" \\`,
     `  -H "Authorization: Bearer ${key}"`,
+    "",
+    "示例（列出后逐个下载文件）：",
+    `curl -L "${origin}/api/download?path=<item.key>" \\`,
+    `  -H "Authorization: Bearer ${key}" \\`,
+    `  -o <item.name>`,
+    "",
+    "示例（fetch：list 后下载文件，子目录再 list）：",
+    `const listRes = await fetch("${origin}/api/list?path=folder/", {`,
+    `  headers: { Authorization: "Bearer ${key}" },`,
+    `});`,
+    `if (!listRes.ok) throw new Error(await listRes.text());`,
+    `const { items } = await listRes.json();`,
+    `for (const item of items) {`,
+    `  if (item.isDir) continue; // 子目录：再 GET /api/list?path=item.key`,
+    `  const fileRes = await fetch(`,
+    `    "${origin}/api/download?path=" + encodeURIComponent(item.key),`,
+    `    { headers: { Authorization: "Bearer ${key}" } }`,
+    `  );`,
+    `  if (!fileRes.ok) throw new Error(await fileRes.text());`,
+    `  const blob = await fileRes.blob();`,
+    `}`,
   ].join("\n");
 }


### PR DESCRIPTION
## 摘要
- `GET /api/list` 为下载目录的必经接口：同一套 API 密钥（Bearer / X-Api-Key），Depth 1 只返回当前层文件和直接子文件夹。
- 成功 200：`{ items: [{ key, name, size, isDir, uploaded? }] }`，不含 `_$flaredrive$/` 内部对象，不递归整桶。
- `path` 为空表示根目录；若 path 是文件则 400（请改用 `/api/download`）；目录不存在 404；密钥无效或过期 401。
- 调用说明补充 curl / fetch：先 list，再对 `isDir === false` 的项调用 `/api/download`；子目录再对 `item.key` 调用 `/api/list`。

## 测试计划
- [ ] 列出已有目录，检查 items 形态与 uploaded
- [ ] path 指向文件 → 400 提示使用 /api/download
- [ ] 不存在的目录 → 404；错误密钥 → 401
- [ ] 根目录（空 path）可列出且不含内部目录
- [ ] 子文件夹需再次 list，不会一次递归