### PR TITLE
fix: list row menu click-through and folder name miss

### DIFF
--- a/src/ApiKeysPanel.tsx
+++ b/src/ApiKeysPanel.tsx
@@ -163,7 +163,7 @@ function ApiKeysPanel({
   };
 
   return (
-    <Dialog open={open} onClose={onClose} fullWidth maxWidth="md">
+    <Dialog open={open} onClose={onClose} fullWidth maxWidth="md" scroll="paper">
       <DialogTitle>{strings.apiKeys}</DialogTitle>
       <DialogContent>
         {loading ? (

--- a/src/FileGrid.tsx
+++ b/src/FileGrid.tsx
@@ -259,6 +259,7 @@ function FileGrid({
   const moreButton = (file: FileItem, corner?: "tile") => {
     const handle = (event: React.MouseEvent) => {
       event.stopPropagation();
+      event.preventDefault();
       onOpenMenu({ clientX: event.clientX, clientY: event.clientY }, file);
     };
 
@@ -293,7 +294,21 @@ function FileGrid({
 
     if (corner !== "tile") {
       return (
-        <Box sx={{ width: 44, height: 44, flexShrink: 0 }}>{button}</Box>
+        <Box
+          sx={{
+            width: 44,
+            height: 44,
+            flexShrink: 0,
+            position: "relative",
+            zIndex: Z_INDEX.cardOverlay,
+            pointerEvents: "auto",
+          }}
+          onPointerDown={(event) => event.stopPropagation()}
+          onMouseDown={(event) => event.stopPropagation()}
+          onClick={handle}
+        >
+          {button}
+        </Box>
       );
     }
 
@@ -395,6 +410,7 @@ function FileGrid({
 
   const itemList = (file: FileItem, index: number) => (
     <ListItemButton
+      component="div"
       selected={isSelected(file)}
       data-file-key={file.key}
       onPointerDown={markPointer}
@@ -454,6 +470,8 @@ function FileGrid({
           minWidth: 0,
           fontWeight: 600,
           fontSize: "0.875rem",
+          userSelect: "none",
+          pointerEvents: "auto",
         }}
       >
         {highlightName(file.name, highlight)}
@@ -654,6 +672,7 @@ function FileGrid({
             borderBottom: "1px solid",
             borderColor: "divider",
             color: "text.secondary",
+            pointerEvents: "none",
           }}
         >
           <Box sx={{ width: 42 }} />

--- a/src/app/__tests__/fileGrid.test.tsx
+++ b/src/app/__tests__/fileGrid.test.tsx
@@ -1,0 +1,90 @@
+import React from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { ThemeProvider, createTheme } from "@mui/material/styles";
+
+import FileGrid from "../../FileGrid";
+import { translate } from "../strings";
+import { FileItem } from "../types";
+
+jest.mock("../../AuthThumbnail", () => ({
+  __esModule: true,
+  default: () => <span data-testid="auth-thumb" />,
+}));
+
+jest.mock("../../MimeIcon", () => ({
+  __esModule: true,
+  default: () => <span data-testid="mime-icon" />,
+}));
+
+const file: FileItem = {
+  key: "notes.txt",
+  name: "notes.txt",
+  isDir: false,
+  size: 128,
+  uploaded: "2026-01-01T00:00:00.000Z",
+  contentType: "text/plain",
+};
+
+const folder: FileItem = {
+  key: "docs/",
+  name: "docs",
+  isDir: true,
+  size: 0,
+  uploaded: "2026-01-02T00:00:00.000Z",
+  contentType: "application/octet-stream",
+};
+
+function renderList(
+  overrides: Partial<React.ComponentProps<typeof FileGrid>> = {}
+) {
+  const props = {
+    files: [file, folder],
+    view: "list" as const,
+    selectedKeys: [] as string[],
+    onToggleSelect: jest.fn(),
+    onNavigate: jest.fn(),
+    onOpen: jest.fn(),
+    onOpenMenu: jest.fn(),
+    ...overrides,
+  };
+  const result = render(
+    <ThemeProvider theme={createTheme()}>
+      <FileGrid {...props} />
+    </ThemeProvider>
+  );
+  return { ...result, props };
+}
+
+describe("FileGrid list row", () => {
+  test("⋯ 菜单点击只打开操作菜单，不触发预览或进入目录", () => {
+    const { props } = renderList();
+    const more = screen.getByRole("button", {
+      name: translate("fileActionsLabel", { name: file.name }),
+    });
+    fireEvent.click(more);
+    expect(props.onOpenMenu).toHaveBeenCalledTimes(1);
+    expect(props.onOpenMenu).toHaveBeenCalledWith(
+      expect.objectContaining({
+        clientX: expect.any(Number),
+        clientY: expect.any(Number),
+      }),
+      file
+    );
+    expect(props.onOpen).not.toHaveBeenCalled();
+    expect(props.onNavigate).not.toHaveBeenCalled();
+  });
+
+  test("点击文件夹名称进入目录", () => {
+    const { props } = renderList();
+    fireEvent.click(screen.getByText(folder.name));
+    expect(props.onNavigate).toHaveBeenCalledWith(folder.key);
+    expect(props.onOpen).not.toHaveBeenCalled();
+  });
+
+  test("点击文件名称打开预览", () => {
+    const { props } = renderList();
+    fireEvent.click(screen.getByText(file.name));
+    expect(props.onOpen).toHaveBeenCalledWith(file.key);
+    expect(props.onNavigate).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Fix list-row MoreHoriz click-through (nested button) and folder name click miss. Adds FileGrid list tests.