### PR TITLE
fix: 分享永久有效文案、缩略图挂起、列表失败骨架、选中被刷新清空等

### DIFF
--- a/src/FileGrid.tsx
+++ b/src/FileGrid.tsx
@@ -416,6 +416,7 @@ function FileGrid({
       onPointerDown={markPointer}
       onClick={(event) => clickItem(file, event)}
       onKeyDown={(event) => {
+        if (event.target !== event.currentTarget) return;
         if (event.key === "Enter") clickItem(file);
         if (event.key === " ") event.preventDefault();
       }}
@@ -515,6 +516,7 @@ function FileGrid({
       onPointerDown={markPointer}
       onClick={(event) => clickItem(file, event)}
       onKeyDown={(event) => {
+        if (event.target !== event.currentTarget) return;
         if (event.key === "Enter") clickItem(file);
       }}
       onContextMenu={(event) => openMenu(event, file)}
@@ -672,7 +674,6 @@ function FileGrid({
             borderBottom: "1px solid",
             borderColor: "divider",
             color: "text.secondary",
-            pointerEvents: "none",
           }}
         >
           <Box sx={{ width: 42 }} />

--- a/src/Main.tsx
+++ b/src/Main.tsx
@@ -531,9 +531,13 @@ function Main({
         setSearchHasMore(false);
         setSearchCursor(undefined);
       }
+      const listingChanged = loadedListingKey.current !== listingKey;
       loadedListingKey.current = listingKey;
-      setSelectedKeys([]);
+      if (listingChanged) setSelectedKeys([]);
     } catch (error) {
+      const alreadyLoaded = loadedListingKey.current === listingKey;
+      loadedListingKey.current = listingKey;
+      if (!alreadyLoaded) setFiles([]);
       onNotify((error as Error).message, "error", {
         duration: 8000,
         action: { label: strings.retry, onClick: () => loadListing() },
@@ -1668,7 +1672,7 @@ function Main({
         onShare={() => {
           if (selectedKeys.length !== 1) return;
           const file = files.find((item) => item.key === selectedKeys[0]);
-          if (file && !file.isDir) setShareTarget(file);
+          if (file) setShareTarget(file);
         }}
         onCopy={() => {
           copyToClipboard(selectedKeys);

--- a/src/PreviewDialog.tsx
+++ b/src/PreviewDialog.tsx
@@ -336,7 +336,7 @@ function PreviewDialog({
   const download = async () => {
     if (!file) return;
     try {
-      if (text != null) {
+      if (text != null && !isJsonFile(file)) {
         const blob = new Blob([text], { type: "text/plain;charset=utf-8" });
         const href = URL.createObjectURL(blob);
         const a = document.createElement("a");

--- a/src/ShareDialog.tsx
+++ b/src/ShareDialog.tsx
@@ -158,7 +158,7 @@ function ShareDialog({
                         [
                           share.expiresAt
                             ? translate("expiresAtLabel", { time: new Date(share.expiresAt).toLocaleString() })
-                            : "{strings.validForever}",
+                            : strings.validForever,
                           share.extractCode
                             ? `${strings.extractCode} ${share.extractCode}`
                             : "",

--- a/src/SharesView.tsx
+++ b/src/SharesView.tsx
@@ -145,7 +145,7 @@ function SharesView({
                     {[
                       share.expiresAt
                         ? translate("expiresAtLabel", { time: new Date(share.expiresAt).toLocaleString() })
-                        : "{strings.validForever}",
+                        : strings.validForever,
                       share.extractCode ? translate("extractCodeLabel", { code: share.extractCode }) : "",
                     ]
                       .filter(Boolean)

--- a/src/app/__tests__/fileGrid.test.tsx
+++ b/src/app/__tests__/fileGrid.test.tsx
@@ -87,4 +87,15 @@ describe("FileGrid list row", () => {
     expect(props.onOpen).toHaveBeenCalledWith(file.key);
     expect(props.onNavigate).not.toHaveBeenCalled();
   });
+
+  test("⋯ 菜单按 Enter 不触发预览或进入目录", () => {
+    const { props } = renderList();
+    const more = screen.getByRole("button", {
+      name: translate("fileActionsLabel", { name: file.name }),
+    });
+    more.focus();
+    fireEvent.keyDown(more, { key: "Enter" });
+    expect(props.onOpen).not.toHaveBeenCalled();
+    expect(props.onNavigate).not.toHaveBeenCalled();
+  });
 });

--- a/src/app/__tests__/strings.test.ts
+++ b/src/app/__tests__/strings.test.ts
@@ -49,6 +49,13 @@ describe("strings / translate", () => {
     expect(getLang()).toBe("en");
   });
 
+  test("validForever 文案存在中英翻译", () => {
+    setLang("zh");
+    expect(translate("validForever")).toBe("永久有效");
+    setLang("en");
+    expect(translate("validForever")).toBe("Never expires");
+  });
+
   test("setLang 通知订阅者", () => {
     const seen: string[] = [];
     const unsubscribe = subscribeLang(() => seen.push(getLang()));

--- a/src/app/transfer.ts
+++ b/src/app/transfer.ts
@@ -205,10 +205,25 @@ export async function generateThumbnail(file: File) {
   var ctx = canvas.getContext("2d")!;
 
   if (file.type.startsWith("image/")) {
-    const image = await new Promise<HTMLImageElement>((resolve) => {
+    const image = await new Promise<HTMLImageElement>((resolve, reject) => {
       const image = new Image();
-      image.onload = () => resolve(image);
-      image.src = URL.createObjectURL(file);
+      const objectUrl = URL.createObjectURL(file);
+      let settled = false;
+      const settle = (fn: () => void) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        URL.revokeObjectURL(objectUrl);
+        fn();
+      };
+      const timer = setTimeout(
+        () => settle(() => reject(new Error("Image load timeout"))),
+        2000
+      );
+      image.onload = () => settle(() => resolve(image));
+      image.onerror = () =>
+        settle(() => reject(new Error("Image load failed")));
+      image.src = objectUrl;
     });
     ctx.drawImage(image, 0, 0, THUMBNAIL_SIZE, THUMBNAIL_SIZE);
   } else if (file.type === "video/mp4") {


### PR DESCRIPTION
Fix 8 confirmed bugs: share expiry copy, image thumbnail hang, failed listing skeleton, folder share, JSON download, sticky header clicks, Enter on more menu, selection cleared on upload refresh. Tests: 48 passed. typecheck passed.