### PR TITLE
fix: 回收站恢复一次勾选即可生效

### DIFF
--- a/src/TrashView.tsx
+++ b/src/TrashView.tsx
@@ -5,7 +5,7 @@ import {
   Button,
   Checkbox,
   List,
-  ListItem,
+  ListItemButton,
   ListItemIcon,
   ListItemText,
   Skeleton,
@@ -168,9 +168,8 @@ function TrashView({
         <>
           <List>
             {items.map((item) => (
-              <ListItem
+              <ListItemButton
                 key={item.trashKey}
-                button
                 onClick={() => toggle(item.trashKey)}
                 sx={{
                   mx: 1,
@@ -189,10 +188,8 @@ function TrashView({
                   <Checkbox
                     size="small"
                     checked={selected.includes(item.trashKey)}
-                    onClick={(event) => {
-                      event.stopPropagation();
-                      toggle(item.trashKey);
-                    }}
+                    onClick={(e) => e.stopPropagation()}
+                    onChange={() => toggle(item.trashKey)}
                   />
                 </ListItemIcon>
                 <ListItemText
@@ -204,7 +201,7 @@ function TrashView({
                     size: humanReadableSize(item.size),
                   })}
                 />
-              </ListItem>
+              </ListItemButton>
             ))}
           </List>
           <Stack
@@ -223,6 +220,7 @@ function TrashView({
               startIcon={<RestoreIcon />}
               disabled={selected.length === 0}
               onClick={handleRestore}
+              sx={{ "&.Mui-disabled": { pointerEvents: "auto" } }}
             >
               {strings.restoreBtn}
             </Button>
@@ -231,6 +229,7 @@ function TrashView({
               startIcon={<DeleteForeverIcon />}
               disabled={selected.length === 0}
               onClick={() => setConfirm({ kind: "delete" })}
+              sx={{ "&.Mui-disabled": { pointerEvents: "auto" } }}
             >
               {strings.permanentDelete}
             </Button>


### PR DESCRIPTION
## Summary
- 回收站行与复选框不再双重 toggle
- 禁用的恢复/彻底删除不再点穿到下面的行

## Test plan
- [ ] 移入回收站后进入回收站，勾选一项，恢复应立即可点且一次成功
- [ ] 未勾选时点恢复不应改变行选中状态