### PR TITLE
docs: move Open API details out of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,132 +73,21 @@ The in-app WebDAV panel shows URL, username, and whether public-read is on. It d
 
 ## Open API
 
-Create keys in the web UI: ExplorerBar 「API」 or account menu 「开放接口」. Full keys are shown once; only SHA-256 hashes are stored. Auth is `Authorization: Bearer <apiKey>` or `X-Api-Key: <apiKey>` (no web session). Manage keys via session-authenticated `GET` / `POST` / `DELETE` `/api/keys`. Usage docs are also on the API settings page.
+Create keys in the web UI (「API」 / 「开放接口」). Auth: `Authorization: Bearer <apiKey>` or `X-Api-Key: <apiKey>`. Full request examples: [Open API docs](docs/API.md).
 
-Internal `_$flaredrive$/` keys are rejected. Operations covering more than 1000 objects return **400** and must be batched.
+| Method | Path | Purpose |
+| --- | --- | --- |
+| GET / POST / DELETE | `/api/keys` | Create, list, and revoke keys (session auth) |
+| POST / PUT / DELETE | `/api/upload` | Upload a file (multipart, raw body, overwrite, or chunked >100MB) |
+| GET | `/api/list` | Depth-1 folder listing (size, uploaded, etag) |
+| GET | `/api/download` | Download one file |
+| POST | `/api/mkdir` | Create a folder (parents auto-created) |
+| POST | `/api/rename` | Rename or move a file or folder |
+| POST | `/api/backup` | Rename remote to `name.conflict-<UTC>` before overwrite |
+| DELETE | `/api/delete` | Hard delete, or `soft=1` to trash |
+| POST | `/api/shares` | Share a file or folder (folder → zip) |
 
-### Upload
-
-Default `POST /api/upload` uniqueNames collisions (`name (2).ext`). Add `?overwrite=1` (or `true`) to PUT/replace the same path + filename.
-
-```bash
-# multipart
-curl -X POST "https://<your-domain.com>/api/upload?path=folder/" \
-  -H "Authorization: Bearer <apiKey>" \
-  -F "file=@photo.jpg"
-
-# also accepts X-Api-Key, or a raw body with X-File-Name
-curl -X POST "https://<your-domain.com>/api/upload?path=docs/" \
-  -H "X-Api-Key: <apiKey>" \
-  -H "X-File-Name: notes.txt" \
-  --data-binary @notes.txt
-
-# overwrite upload
-curl -X POST "https://<your-domain.com>/api/upload?path=folder/&overwrite=1" \
-  -H "Authorization: Bearer <apiKey>" \
-  -F "file=@photo.jpg"
-```
-
-Single-request uploads are limited to about 100 MB (**HTTP 413** otherwise). Larger files use the 3-step multipart API:
-
-```bash
-# 1) create
-curl -X POST "https://<your-domain.com>/api/upload?uploads&path=folder/big.bin" \
-  -H "Authorization: Bearer <apiKey>"
-# → 201 { key, uploadId }
-
-# 2) upload each part (≤100MB per request, partNumber 1..10000)
-curl -X PUT "https://<your-domain.com>/api/upload?path=folder/big.bin&uploadId=<id>&partNumber=1" \
-  -H "Authorization: Bearer <apiKey>" \
-  --data-binary @part1.bin
-# → 200 { partNumber, etag }
-
-# 3) complete with the collected parts (order matters)
-curl -X POST "https://<your-domain.com>/api/upload?path=folder/big.bin&uploadId=<id>" \
-  -H "Authorization: Bearer <apiKey>" \
-  -H "Content-Type: application/json" \
-  -d '{"parts":[{"partNumber":1,"etag":"..."},{"partNumber":2,"etag":"..."}]}'
-
-# abort an unfinished upload
-curl -X DELETE "https://<your-domain.com>/api/upload?path=folder/big.bin&uploadId=<id>" \
-  -H "Authorization: Bearer <apiKey>"
-```
-
-### List, download, mkdir
-
-The same keys can list a folder and download each file (folders are not a zip via `/api/download`; use a directory share for zip).
-
-```bash
-# Depth-1 list (empty path = root). Does not recurse.
-curl "https://<your-domain.com>/api/list?path=folder/" \
-  -H "Authorization: Bearer <apiKey>"
-
-# download each item where isDir is false
-curl -L "https://<your-domain.com>/api/download?path=folder/notes.txt" \
-  -H "Authorization: Bearer <apiKey>" \
-  -o notes.txt
-
-# also accepts X-Api-Key
-curl -L "https://<your-domain.com>/api/download?path=folder/notes.txt" \
-  -H "X-Api-Key: <apiKey>" \
-  -o notes.txt
-```
-
-`GET /api/list` returns `{ items: [{ key, name, size, isDir, uploaded, etag }] }` for the current folder only. Files always include numeric `size`, ISO `uploaded` (and alias `updated`), and R2 `etag`. Delimited-prefix folders have `isDir: true`, `size: 0`, and `uploaded: null` (unknown; no fake mtime). Nested folders: call `/api/list` again with that item's `key`. If `path` is a file, the list API returns **400** and tells you to use `/api/download`. Missing folder: **404**. Bad/expired key: **401**. Large folders: add `limit=1..1000` (plus `cursor` from the previous response) for paged reads — the response then carries `nextCursor` while more pages remain.
-
-`GET /api/download` `path` is the object key. **HTTP 200** streams the file (`Content-Type` from R2 or `application/octet-stream`, `Content-Disposition: attachment`). Missing/empty path or a directory/prefix folder returns **400**; unknown object **404**; bad/expired key **401**. Internal `_$flaredrive$/` keys are rejected.
-
-Create folders from scripts (parents are auto-created):
-
-```bash
-# JSON body or ?path= both work. 201 created / 200 already exists / 409 same-name file
-curl -X POST "https://<your-domain.com>/api/mkdir" \
-  -H "Authorization: Bearer <apiKey>" \
-  -H "Content-Type: application/json" \
-  -d '{"path":"folder/sub"}'
-```
-
-### Backup, rename, delete
-
-```bash
-# conflict backup: rename remote to name.conflict-YYYYMMDDTHHMMSS.ext (UTC)
-curl -X POST "https://<your-domain.com>/api/backup?path=folder/notes.txt" \
-  -H "Authorization: Bearer <apiKey>"
-
-# rename (409 if `to` exists unless overwrite=1; directories move recursively, no overwrite)
-curl -X POST "https://<your-domain.com>/api/rename" \
-  -H "Authorization: Bearer <apiKey>" \
-  -H "Content-Type: application/json" \
-  -d '{"from":"folder/old.txt","to":"folder/new.txt"}'
-
-# delete a file only
-curl -X DELETE "https://<your-domain.com>/api/delete?path=folder/notes.txt" \
-  -H "Authorization: Bearer <apiKey>"
-
-# soft delete (goes to the recycle bin, restorable; works for directories too)
-curl -X DELETE "https://<your-domain.com>/api/delete?path=folder/notes.txt&soft=1" \
-  -H "Authorization: Bearer <apiKey>"
-
-# delete a whole directory recursively (≤1000 objects per call)
-curl -X DELETE "https://<your-domain.com>/api/delete?path=folder/sub" \
-  -H "Authorization: Bearer <apiKey>"
-```
-
-`/api/rename` and `/api/delete` accept directories — rename moves the whole tree, delete removes it recursively (hard delete unless `soft=1`). `/api/backup` on a directory renames the whole tree to `name.conflict-<UTCstamp>`. Operations covering more than 1000 objects return **400** and must be batched.
-
-### Shares
-
-`POST /api/shares` accepts a folder key too — visiting the share link streams the whole tree as a zip download (extract code and expiry apply as usual).
-
-### Bidirectional sync recipe
-
-Local wins; backup remote on conflict. Same Bearer / `X-Api-Key` auth as upload; no web session. WebDAV protocol is unchanged.
-
-1. List with `GET /api/list` and compare local mtime/size/etag vs remote `uploaded` / `size` / `etag`.
-2. Local-only new/changed → `POST /api/upload?overwrite=1`.
-3. Remote-only new/changed → `GET /api/download`.
-4. Both changed → `POST /api/backup?path=remoteKey` then overwrite-upload local bytes to the original name.
-5. Optional local deletes: `DELETE /api/delete` (skip unless the client tracks a sync db). Extra remote-only files: download them.
+Same keys work for a bidirectional sync client (local wins; backup remote on conflict). Details in the [API docs](docs/API.md).
 
 ## Development & testing
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -71,132 +71,21 @@ Cloudflare Workers 单次 PUT 上限为 **128 MB**。超限会返回 **HTTP 413*
 
 ## 开放接口
 
-在网页端创建密钥：资源管理栏「API」，或账号菜单「开放接口」。完整密钥只展示一次，服务端仅保存 SHA-256 哈希。鉴权方式为 `Authorization: Bearer <apiKey>` 或 `X-Api-Key: <apiKey>`（不走网页会话）。通过已登录会话调用 `GET` / `POST` / `DELETE` `/api/keys` 管理密钥。API 设置页也有使用说明。
+在网页端「API」 / 「开放接口」创建密钥。鉴权：`Authorization: Bearer <apiKey>` 或 `X-Api-Key: <apiKey>`。完整请求示例见 [开放接口文档](docs/API.zh-CN.md)。
 
-内部 `_$flaredrive$/` 路径会被拒绝。单次操作覆盖超过 1000 个对象会返回 **400**，需要分批处理。
+| 方法 | 路径 | 作用 |
+| --- | --- | --- |
+| GET / POST / DELETE | `/api/keys` | 创建、列出、作废密钥（需网页登录会话） |
+| POST / PUT / DELETE | `/api/upload` | 上传文件（multipart / 原始 body / 覆盖 / >100MB 分片） |
+| GET | `/api/list` | 列出当前目录（size、uploaded、etag） |
+| GET | `/api/download` | 下载单个文件 |
+| POST | `/api/mkdir` | 创建文件夹（自动补齐父目录） |
+| POST | `/api/rename` | 重命名 / 移动文件或文件夹 |
+| POST | `/api/backup` | 冲突时把远端改名为 `name.conflict-<UTC>` |
+| DELETE | `/api/delete` | 硬删除，或 `soft=1` 进回收站 |
+| POST | `/api/shares` | 分享文件或文件夹（文件夹为 zip） |
 
-### 上传
-
-默认 `POST /api/upload` 遇到重名会自动改名（`name (2).ext`）。加上 `?overwrite=1`（或 `true`）则按相同路径 + 文件名覆盖写入。
-
-```bash
-# multipart
-curl -X POST "https://<your-domain.com>/api/upload?path=folder/" \
-  -H "Authorization: Bearer <apiKey>" \
-  -F "file=@photo.jpg"
-
-# also accepts X-Api-Key, or a raw body with X-File-Name
-curl -X POST "https://<your-domain.com>/api/upload?path=docs/" \
-  -H "X-Api-Key: <apiKey>" \
-  -H "X-File-Name: notes.txt" \
-  --data-binary @notes.txt
-
-# overwrite upload
-curl -X POST "https://<your-domain.com>/api/upload?path=folder/&overwrite=1" \
-  -H "Authorization: Bearer <apiKey>" \
-  -F "file=@photo.jpg"
-```
-
-单次请求上传上限约 100 MB（超出返回 **HTTP 413**）。更大的文件请使用三步分片 API：
-
-```bash
-# 1) create
-curl -X POST "https://<your-domain.com>/api/upload?uploads&path=folder/big.bin" \
-  -H "Authorization: Bearer <apiKey>"
-# → 201 { key, uploadId }
-
-# 2) upload each part (≤100MB per request, partNumber 1..10000)
-curl -X PUT "https://<your-domain.com>/api/upload?path=folder/big.bin&uploadId=<id>&partNumber=1" \
-  -H "Authorization: Bearer <apiKey>" \
-  --data-binary @part1.bin
-# → 200 { partNumber, etag }
-
-# 3) complete with the collected parts (order matters)
-curl -X POST "https://<your-domain.com>/api/upload?path=folder/big.bin&uploadId=<id>" \
-  -H "Authorization: Bearer <apiKey>" \
-  -H "Content-Type: application/json" \
-  -d '{"parts":[{"partNumber":1,"etag":"..."},{"partNumber":2,"etag":"..."}]}'
-
-# abort an unfinished upload
-curl -X DELETE "https://<your-domain.com>/api/upload?path=folder/big.bin&uploadId=<id>" \
-  -H "Authorization: Bearer <apiKey>"
-```
-
-### 列出、下载、创建目录
-
-同一把密钥可以列出文件夹并逐个下载文件（`/api/download` 不会把文件夹打成 zip；目录 zip 请走目录分享）。
-
-```bash
-# Depth-1 list (empty path = root). Does not recurse.
-curl "https://<your-domain.com>/api/list?path=folder/" \
-  -H "Authorization: Bearer <apiKey>"
-
-# download each item where isDir is false
-curl -L "https://<your-domain.com>/api/download?path=folder/notes.txt" \
-  -H "Authorization: Bearer <apiKey>" \
-  -o notes.txt
-
-# also accepts X-Api-Key
-curl -L "https://<your-domain.com>/api/download?path=folder/notes.txt" \
-  -H "X-Api-Key: <apiKey>" \
-  -o notes.txt
-```
-
-`GET /api/list` 只返回当前文件夹的 `{ items: [{ key, name, size, isDir, uploaded, etag }] }`。文件始终包含数值 `size`、ISO `uploaded`（以及别名 `updated`）和 R2 `etag`。前缀分隔出来的文件夹为 `isDir: true`、`size: 0`、`uploaded: null`（未知；不会伪造 mtime）。嵌套目录：再用该项的 `key` 调用一次 `/api/list`。若 `path` 指向文件，列表接口返回 **400** 并提示改用 `/api/download`。目录不存在：**404**。密钥无效或过期：**401**。大目录可加 `limit=1..1000`（以及上一页返回的 `cursor`）做分页 —— 还有下一页时响应会带 `nextCursor`。
-
-`GET /api/download` 的 `path` 是对象 key。**HTTP 200** 会流式返回文件（`Content-Type` 来自 R2，否则为 `application/octet-stream`，`Content-Disposition: attachment`）。`path` 缺失/为空，或指向目录/前缀文件夹，返回 **400**；对象不存在 **404**；密钥无效或过期 **401**。内部 `_$flaredrive$/` 路径会被拒绝。
-
-脚本创建文件夹（父目录会自动创建）：
-
-```bash
-# JSON body or ?path= both work. 201 created / 200 already exists / 409 same-name file
-curl -X POST "https://<your-domain.com>/api/mkdir" \
-  -H "Authorization: Bearer <apiKey>" \
-  -H "Content-Type: application/json" \
-  -d '{"path":"folder/sub"}'
-```
-
-### 备份、重命名、删除
-
-```bash
-# conflict backup: rename remote to name.conflict-YYYYMMDDTHHMMSS.ext (UTC)
-curl -X POST "https://<your-domain.com>/api/backup?path=folder/notes.txt" \
-  -H "Authorization: Bearer <apiKey>"
-
-# rename (409 if `to` exists unless overwrite=1; directories move recursively, no overwrite)
-curl -X POST "https://<your-domain.com>/api/rename" \
-  -H "Authorization: Bearer <apiKey>" \
-  -H "Content-Type: application/json" \
-  -d '{"from":"folder/old.txt","to":"folder/new.txt"}'
-
-# delete a file only
-curl -X DELETE "https://<your-domain.com>/api/delete?path=folder/notes.txt" \
-  -H "Authorization: Bearer <apiKey>"
-
-# soft delete (goes to the recycle bin, restorable; works for directories too)
-curl -X DELETE "https://<your-domain.com>/api/delete?path=folder/notes.txt&soft=1" \
-  -H "Authorization: Bearer <apiKey>"
-
-# delete a whole directory recursively (≤1000 objects per call)
-curl -X DELETE "https://<your-domain.com>/api/delete?path=folder/sub" \
-  -H "Authorization: Bearer <apiKey>"
-```
-
-`/api/rename` 和 `/api/delete` 也支持目录 —— 重命名会移动整棵子树，删除会递归移除（默认硬删除，除非带 `soft=1`）。对目录调用 `/api/backup` 会把整棵子树重命名为 `name.conflict-<UTCstamp>`。单次操作覆盖超过 1000 个对象会返回 **400**，需要分批处理。
-
-### 分享
-
-`POST /api/shares` 也接受文件夹 key —— 打开分享链接会把整棵子树以 zip 流式下载（提取码和过期时间照常生效）。
-
-### 双向同步示例
-
-以本地为准；冲突时先备份远端。鉴权与上传相同（Bearer / `X-Api-Key`），不走网页会话。WebDAV 协议不变。
-
-1. 用 `GET /api/list` 列出，比较本地 mtime/size/etag 与远端 `uploaded` / `size` / `etag`。
-2. 仅本地新增/变更 → `POST /api/upload?overwrite=1`。
-3. 仅远端新增/变更 → `GET /api/download`。
-4. 两边都变 → `POST /api/backup?path=remoteKey`，再把本地内容覆盖上传到原文件名。
-5. 可选的本地删除：`DELETE /api/delete`（除非客户端维护同步库，否则跳过）。远端多出来的文件：下载下来。
+同一把密钥可做双向同步（本地优先，冲突时先备份远端）。详见 [开放接口文档](docs/API.zh-CN.md)。
 
 ## 开发与测试
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,0 +1,132 @@
+# Davflare Open API
+
+[English](API.md) | [中文](API.zh-CN.md)
+
+← [README](../README.md)
+
+Create keys in the web UI: ExplorerBar 「API」 or account menu 「开放接口」. Full keys are shown once; only SHA-256 hashes are stored. Auth is `Authorization: Bearer <apiKey>` or `X-Api-Key: <apiKey>` (no web session). Manage keys via session-authenticated `GET` / `POST` / `DELETE` `/api/keys`. Usage docs are also on the API settings page.
+
+Internal `_$flaredrive$/` keys are rejected. Operations covering more than 1000 objects return **400** and must be batched.
+
+### Upload
+
+Default `POST /api/upload` uniqueNames collisions (`name (2).ext`). Add `?overwrite=1` (or `true`) to PUT/replace the same path + filename.
+
+```bash
+# multipart
+curl -X POST "https://<your-domain.com>/api/upload?path=folder/" \
+  -H "Authorization: Bearer <apiKey>" \
+  -F "file=@photo.jpg"
+
+# also accepts X-Api-Key, or a raw body with X-File-Name
+curl -X POST "https://<your-domain.com>/api/upload?path=docs/" \
+  -H "X-Api-Key: <apiKey>" \
+  -H "X-File-Name: notes.txt" \
+  --data-binary @notes.txt
+
+# overwrite upload
+curl -X POST "https://<your-domain.com>/api/upload?path=folder/&overwrite=1" \
+  -H "Authorization: Bearer <apiKey>" \
+  -F "file=@photo.jpg"
+```
+
+Single-request uploads are limited to about 100 MB (**HTTP 413** otherwise). Larger files use the 3-step multipart API:
+
+```bash
+# 1) create
+curl -X POST "https://<your-domain.com>/api/upload?uploads&path=folder/big.bin" \
+  -H "Authorization: Bearer <apiKey>"
+# → 201 { key, uploadId }
+
+# 2) upload each part (≤100MB per request, partNumber 1..10000)
+curl -X PUT "https://<your-domain.com>/api/upload?path=folder/big.bin&uploadId=<id>&partNumber=1" \
+  -H "Authorization: Bearer <apiKey>" \
+  --data-binary @part1.bin
+# → 200 { partNumber, etag }
+
+# 3) complete with the collected parts (order matters)
+curl -X POST "https://<your-domain.com>/api/upload?path=folder/big.bin&uploadId=<id>" \
+  -H "Authorization: Bearer <apiKey>" \
+  -H "Content-Type: application/json" \
+  -d '{"parts":[{"partNumber":1,"etag":"..."},{"partNumber":2,"etag":"..."}]}'
+
+# abort an unfinished upload
+curl -X DELETE "https://<your-domain.com>/api/upload?path=folder/big.bin&uploadId=<id>" \
+  -H "Authorization: Bearer <apiKey>"
+```
+
+### List, download, mkdir
+
+The same keys can list a folder and download each file (folders are not a zip via `/api/download`; use a directory share for zip).
+
+```bash
+# Depth-1 list (empty path = root). Does not recurse.
+curl "https://<your-domain.com>/api/list?path=folder/" \
+  -H "Authorization: Bearer <apiKey>"
+
+# download each item where isDir is false
+curl -L "https://<your-domain.com>/api/download?path=folder/notes.txt" \
+  -H "Authorization: Bearer <apiKey>" \
+  -o notes.txt
+
+# also accepts X-Api-Key
+curl -L "https://<your-domain.com>/api/download?path=folder/notes.txt" \
+  -H "X-Api-Key: <apiKey>" \
+  -o notes.txt
+```
+
+`GET /api/list` returns `{ items: [{ key, name, size, isDir, uploaded, etag }] }` for the current folder only. Files always include numeric `size`, ISO `uploaded` (and alias `updated`), and R2 `etag`. Delimited-prefix folders have `isDir: true`, `size: 0`, and `uploaded: null` (unknown; no fake mtime). Nested folders: call `/api/list` again with that item's `key`. If `path` is a file, the list API returns **400** and tells you to use `/api/download`. Missing folder: **404**. Bad/expired key: **401**. Large folders: add `limit=1..1000` (plus `cursor` from the previous response) for paged reads — the response then carries `nextCursor` while more pages remain.
+
+`GET /api/download` `path` is the object key. **HTTP 200** streams the file (`Content-Type` from R2 or `application/octet-stream`, `Content-Disposition: attachment`). Missing/empty path or a directory/prefix folder returns **400**; unknown object **404**; bad/expired key **401**. Internal `_$flaredrive$/` keys are rejected.
+
+Create folders from scripts (parents are auto-created):
+
+```bash
+# JSON body or ?path= both work. 201 created / 200 already exists / 409 same-name file
+curl -X POST "https://<your-domain.com>/api/mkdir" \
+  -H "Authorization: Bearer <apiKey>" \
+  -H "Content-Type: application/json" \
+  -d '{"path":"folder/sub"}'
+```
+
+### Backup, rename, delete
+
+```bash
+# conflict backup: rename remote to name.conflict-YYYYMMDDTHHMMSS.ext (UTC)
+curl -X POST "https://<your-domain.com>/api/backup?path=folder/notes.txt" \
+  -H "Authorization: Bearer <apiKey>"
+
+# rename (409 if `to` exists unless overwrite=1; directories move recursively, no overwrite)
+curl -X POST "https://<your-domain.com>/api/rename" \
+  -H "Authorization: Bearer <apiKey>" \
+  -H "Content-Type: application/json" \
+  -d '{"from":"folder/old.txt","to":"folder/new.txt"}'
+
+# delete a file only
+curl -X DELETE "https://<your-domain.com>/api/delete?path=folder/notes.txt" \
+  -H "Authorization: Bearer <apiKey>"
+
+# soft delete (goes to the recycle bin, restorable; works for directories too)
+curl -X DELETE "https://<your-domain.com>/api/delete?path=folder/notes.txt&soft=1" \
+  -H "Authorization: Bearer <apiKey>"
+
+# delete a whole directory recursively (≤1000 objects per call)
+curl -X DELETE "https://<your-domain.com>/api/delete?path=folder/sub" \
+  -H "Authorization: Bearer <apiKey>"
+```
+
+`/api/rename` and `/api/delete` accept directories — rename moves the whole tree, delete removes it recursively (hard delete unless `soft=1`). `/api/backup` on a directory renames the whole tree to `name.conflict-<UTCstamp>`. Operations covering more than 1000 objects return **400** and must be batched.
+
+### Shares
+
+`POST /api/shares` accepts a folder key too — visiting the share link streams the whole tree as a zip download (extract code and expiry apply as usual).
+
+### Bidirectional sync recipe
+
+Local wins; backup remote on conflict. Same Bearer / `X-Api-Key` auth as upload; no web session. WebDAV protocol is unchanged.
+
+1. List with `GET /api/list` and compare local mtime/size/etag vs remote `uploaded` / `size` / `etag`.
+2. Local-only new/changed → `POST /api/upload?overwrite=1`.
+3. Remote-only new/changed → `GET /api/download`.
+4. Both changed → `POST /api/backup?path=remoteKey` then overwrite-upload local bytes to the original name.
+5. Optional local deletes: `DELETE /api/delete` (skip unless the client tracks a sync db). Extra remote-only files: download them.

--- a/docs/API.zh-CN.md
+++ b/docs/API.zh-CN.md
@@ -1,0 +1,132 @@
+# Davflare 开放接口
+
+[English](API.md) | [中文](API.zh-CN.md)
+
+← [README](../README.zh-CN.md)
+
+在网页端创建密钥：资源管理栏「API」，或账号菜单「开放接口」。完整密钥只展示一次，服务端仅保存 SHA-256 哈希。鉴权方式为 `Authorization: Bearer <apiKey>` 或 `X-Api-Key: <apiKey>`（不走网页会话）。通过已登录会话调用 `GET` / `POST` / `DELETE` `/api/keys` 管理密钥。API 设置页也有使用说明。
+
+内部 `_$flaredrive$/` 路径会被拒绝。单次操作覆盖超过 1000 个对象会返回 **400**，需要分批处理。
+
+### 上传
+
+默认 `POST /api/upload` 遇到重名会自动改名（`name (2).ext`）。加上 `?overwrite=1`（或 `true`）则按相同路径 + 文件名覆盖写入。
+
+```bash
+# multipart
+curl -X POST "https://<your-domain.com>/api/upload?path=folder/" \
+  -H "Authorization: Bearer <apiKey>" \
+  -F "file=@photo.jpg"
+
+# also accepts X-Api-Key, or a raw body with X-File-Name
+curl -X POST "https://<your-domain.com>/api/upload?path=docs/" \
+  -H "X-Api-Key: <apiKey>" \
+  -H "X-File-Name: notes.txt" \
+  --data-binary @notes.txt
+
+# overwrite upload
+curl -X POST "https://<your-domain.com>/api/upload?path=folder/&overwrite=1" \
+  -H "Authorization: Bearer <apiKey>" \
+  -F "file=@photo.jpg"
+```
+
+单次请求上传上限约 100 MB（超出返回 **HTTP 413**）。更大的文件请使用三步分片 API：
+
+```bash
+# 1) create
+curl -X POST "https://<your-domain.com>/api/upload?uploads&path=folder/big.bin" \
+  -H "Authorization: Bearer <apiKey>"
+# → 201 { key, uploadId }
+
+# 2) upload each part (≤100MB per request, partNumber 1..10000)
+curl -X PUT "https://<your-domain.com>/api/upload?path=folder/big.bin&uploadId=<id>&partNumber=1" \
+  -H "Authorization: Bearer <apiKey>" \
+  --data-binary @part1.bin
+# → 200 { partNumber, etag }
+
+# 3) complete with the collected parts (order matters)
+curl -X POST "https://<your-domain.com>/api/upload?path=folder/big.bin&uploadId=<id>" \
+  -H "Authorization: Bearer <apiKey>" \
+  -H "Content-Type: application/json" \
+  -d '{"parts":[{"partNumber":1,"etag":"..."},{"partNumber":2,"etag":"..."}]}'
+
+# abort an unfinished upload
+curl -X DELETE "https://<your-domain.com>/api/upload?path=folder/big.bin&uploadId=<id>" \
+  -H "Authorization: Bearer <apiKey>"
+```
+
+### 列出、下载、创建目录
+
+同一把密钥可以列出文件夹并逐个下载文件（`/api/download` 不会把文件夹打成 zip；目录 zip 请走目录分享）。
+
+```bash
+# Depth-1 list (empty path = root). Does not recurse.
+curl "https://<your-domain.com>/api/list?path=folder/" \
+  -H "Authorization: Bearer <apiKey>"
+
+# download each item where isDir is false
+curl -L "https://<your-domain.com>/api/download?path=folder/notes.txt" \
+  -H "Authorization: Bearer <apiKey>" \
+  -o notes.txt
+
+# also accepts X-Api-Key
+curl -L "https://<your-domain.com>/api/download?path=folder/notes.txt" \
+  -H "X-Api-Key: <apiKey>" \
+  -o notes.txt
+```
+
+`GET /api/list` 只返回当前文件夹的 `{ items: [{ key, name, size, isDir, uploaded, etag }] }`。文件始终包含数值 `size`、ISO `uploaded`（以及别名 `updated`）和 R2 `etag`。前缀分隔出来的文件夹为 `isDir: true`、`size: 0`、`uploaded: null`（未知；不会伪造 mtime）。嵌套目录：再用该项的 `key` 调用一次 `/api/list`。若 `path` 指向文件，列表接口返回 **400** 并提示改用 `/api/download`。目录不存在：**404**。密钥无效或过期：**401**。大目录可加 `limit=1..1000`（以及上一页返回的 `cursor`）做分页 —— 还有下一页时响应会带 `nextCursor`。
+
+`GET /api/download` 的 `path` 是对象 key。**HTTP 200** 会流式返回文件（`Content-Type` 来自 R2，否则为 `application/octet-stream`，`Content-Disposition: attachment`）。`path` 缺失/为空，或指向目录/前缀文件夹，返回 **400**；对象不存在 **404**；密钥无效或过期 **401**。内部 `_$flaredrive$/` 路径会被拒绝。
+
+脚本创建文件夹（父目录会自动创建）：
+
+```bash
+# JSON body or ?path= both work. 201 created / 200 already exists / 409 same-name file
+curl -X POST "https://<your-domain.com>/api/mkdir" \
+  -H "Authorization: Bearer <apiKey>" \
+  -H "Content-Type: application/json" \
+  -d '{"path":"folder/sub"}'
+```
+
+### 备份、重命名、删除
+
+```bash
+# conflict backup: rename remote to name.conflict-YYYYMMDDTHHMMSS.ext (UTC)
+curl -X POST "https://<your-domain.com>/api/backup?path=folder/notes.txt" \
+  -H "Authorization: Bearer <apiKey>"
+
+# rename (409 if `to` exists unless overwrite=1; directories move recursively, no overwrite)
+curl -X POST "https://<your-domain.com>/api/rename" \
+  -H "Authorization: Bearer <apiKey>" \
+  -H "Content-Type: application/json" \
+  -d '{"from":"folder/old.txt","to":"folder/new.txt"}'
+
+# delete a file only
+curl -X DELETE "https://<your-domain.com>/api/delete?path=folder/notes.txt" \
+  -H "Authorization: Bearer <apiKey>"
+
+# soft delete (goes to the recycle bin, restorable; works for directories too)
+curl -X DELETE "https://<your-domain.com>/api/delete?path=folder/notes.txt&soft=1" \
+  -H "Authorization: Bearer <apiKey>"
+
+# delete a whole directory recursively (≤1000 objects per call)
+curl -X DELETE "https://<your-domain.com>/api/delete?path=folder/sub" \
+  -H "Authorization: Bearer <apiKey>"
+```
+
+`/api/rename` 和 `/api/delete` 也支持目录 —— 重命名会移动整棵子树，删除会递归移除（默认硬删除，除非带 `soft=1`）。对目录调用 `/api/backup` 会把整棵子树重命名为 `name.conflict-<UTCstamp>`。单次操作覆盖超过 1000 个对象会返回 **400**，需要分批处理。
+
+### 分享
+
+`POST /api/shares` 也接受文件夹 key —— 打开分享链接会把整棵子树以 zip 流式下载（提取码和过期时间照常生效）。
+
+### 双向同步示例
+
+以本地为准；冲突时先备份远端。鉴权与上传相同（Bearer / `X-Api-Key`），不走网页会话。WebDAV 协议不变。
+
+1. 用 `GET /api/list` 列出，比较本地 mtime/size/etag 与远端 `uploaded` / `size` / `etag`。
+2. 仅本地新增/变更 → `POST /api/upload?overwrite=1`。
+3. 仅远端新增/变更 → `GET /api/download`。
+4. 两边都变 → `POST /api/backup?path=remoteKey`，再把本地内容覆盖上传到原文件名。
+5. 可选的本地删除：`DELETE /api/delete`（除非客户端维护同步库，否则跳过）。远端多出来的文件：下载下来。


### PR DESCRIPTION
## Summary
- README / 中文 README 的开放接口只保留接口清单和用途
- 完整 curl 示例挪到 `docs/API.md` 和 `docs/API.zh-CN.md`
- 只改文档

## Test plan
- [ ] README 表格链接能点到 API 文档
- [ ] API 文档里的 curl 示例还在