### PR TITLE
chore: 界面与 wrangler 项目名改为 Davflare

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "flare-drive",
+  "name": "davflare",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "flare-drive",
+      "name": "davflare",
       "version": "0.1.0",
       "dependencies": {
         "@emotion/react": "^11.11.4",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "flare-drive",
+  "name": "davflare",
   "version": "0.1.0",
   "private": true,
   "dependencies": {

--- a/public/index.html
+++ b/public/index.html
@@ -8,7 +8,7 @@
     <meta name="description" content="Cloudflare R2 file manager" />
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
-    <title>FlareDrive</title>
+    <title>Davflare</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,6 +1,6 @@
 {
-  "short_name": "Flare Drive",
-  "name": "Flare Drive",
+  "short_name": "Davflare",
+  "name": "Davflare",
   "icons": [
     {
       "src": "favicon.ico",

--- a/src/app/strings.ts
+++ b/src/app/strings.ts
@@ -2,7 +2,7 @@ import React from "react";
 
 export type Lang = "zh" | "en";
 
-export const APP_NAME = "FlareDrive";
+export const APP_NAME = "Davflare";
 
 type Entry = { zh: string; en: string };
 
@@ -227,7 +227,7 @@ const entries: Record<string, Entry> = {  searchPlaceholder: { zh: "搜索文件
   language: { zh: "语言", en: "Language" },
   langZh: { zh: "中文", en: "中文" },
   langEn: { zh: "English", en: "English" },
-  loginTitle: { zh: "登录 FlareDrive", en: "Sign in to FlareDrive" },
+  loginTitle: { zh: "登录 Davflare", en: "Sign in to Davflare" },
   loginHint: {
     zh: "请输入 WebDAV 用户名和密码以访问你的文件。",
     en: "Enter your WebDAV username and password to access your files.",

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,4 +1,4 @@
-name = "flaredrive"
+name = "davflare"
 pages_build_output_dir = "build"
 compatibility_date = "2024-06-20"
 


### PR DESCRIPTION
页标题、PWA 名称、登录文案、wrangler 项目名改为 Davflare。R2 桶和内部前缀未改。