### PR TITLE
docs: remove redundant fork intro from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,6 @@ Cloudflare R2 file manager on Pages + Workers — free 10 GB storage and 100,000
 
 基于 Cloudflare R2 的网盘：免费 10GB 存储、每天 10 万次 Worker 调用。[R2 定价](https://developers.cloudflare.com/r2/platform/pricing/)
 
-Started as a fork of [longern/FlareDrive](https://github.com/longern/FlareDrive) and has been fully rewritten. The GitHub repository is [fanchenggang/Davflare](https://github.com/fanchenggang/Davflare).
-
 ## Screenshots
 
 File browser (light theme):

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -6,8 +6,6 @@
 
 基于 Cloudflare Pages + Workers 的 R2 网盘 —— 免费 10 GB 存储、每天 10 万次 Worker 调用。[R2 定价](https://developers.cloudflare.com/r2/platform/pricing/)
 
-本项目最初 fork 自 [longern/FlareDrive](https://github.com/longern/FlareDrive)，现已全面重写。GitHub 仓库：[fanchenggang/Davflare](https://github.com/fanchenggang/Davflare)。
-
 ## 截图
 
 文件浏览器（浅色主题）：


### PR DESCRIPTION
Acknowledgments already credit FlareDrive. Drop the duplicate intro sentence from both READMEs.