### PR TITLE
docs: Agent 目录约定 v1（skills/rules/mcp）

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Share (expiry + extract code):
 - WebDAV Class 1/2 at `/webdav`
 - API keys for scripted upload, download, and bidirectional sync
 - Remote MCP at `/mcp` (list, upload, download, mkdir, delete)
+- Agent layouts on R2: `agents/{global|agent|agent/project}/{skills|rules|mcp}/` (manual pull/push; see [docs/agents.md](docs/agents.md))
 - Chinese / English UI (globe icon in the header; defaults to browser language, persisted locally)
 
 ## Deploy
@@ -115,6 +116,10 @@ Cursor (`mcp.json`):
   }
 }
 ```
+
+## Agent layouts
+
+Skills, rules, and MCP snippets live on R2 under `agents/`. v1 is a directory convention plus manual pull/push with the existing MCP tools (or the web UI). Merge order: project > agent > global. Never store raw API keys in `mcp.json` — use `${env:DAVFLARE_API_KEY}`. Cursor local paths and the walk-the-tree recipe: [docs/agents.md](docs/agents.md).
 
 ## Development & testing
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -33,6 +33,7 @@
 - WebDAV Class 1/2，路径 `/webdav`
 - API Key，可用于脚本上传、下载与双向同步
 - 远程 MCP，路径 `/mcp`（list / upload / download / mkdir / delete）
+- Agent 目录约定：`agents/{global|agent|agent/project}/{skills|rules|mcp}/`（手动拉取/推送，见 [docs/agents.zh-CN.md](docs/agents.zh-CN.md)）
 - 中 / 英界面（标题栏地球图标；默认跟随浏览器语言，并保存在本地）
 
 ## 部署
@@ -113,6 +114,10 @@ Cursor（`mcp.json`）：
   }
 }
 ```
+
+## Agent 目录
+
+skills / rules / MCP 片段放在 R2 的 `agents/` 下。v1 只是目录约定 + 用现有 MCP 工具（或网页端）手动拉取/推送。合并顺序：project 覆盖 agent 覆盖 global。`mcp.json` 里不要存明文密钥，用 `${env:DAVFLARE_API_KEY}`。Cursor 落地路径和走目录步骤见 [docs/agents.zh-CN.md](docs/agents.zh-CN.md)。
 
 ## 开发与测试
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -154,6 +154,10 @@ Cursor (`mcp.json`):
 }
 ```
 
+### Agent layouts
+
+Skills / rules / MCP snippets: `agents/{global|{agent}|{agent}/{project}}/{skills|rules|mcp}/`. v1 is manual (existing list/upload/download/mkdir/delete or the web UI). Merge: project > agent > global. Do not store raw keys in `mcp.json`. Full convention: [agents.md](./agents.md).
+
 ### Bidirectional sync recipe
 
 Local wins; backup remote on conflict. Same Bearer / `X-Api-Key` auth as upload; no web session. WebDAV protocol is unchanged.

--- a/docs/API.zh-CN.md
+++ b/docs/API.zh-CN.md
@@ -154,6 +154,10 @@ Cursor（`mcp.json`）：
 }
 ```
 
+### Agent 目录
+
+skills / rules / MCP 片段：`agents/{global|{agent}|{agent}/{project}}/{skills|rules|mcp}/`。v1 手动（现有 list/upload/download/mkdir/delete 或网页端）。合并：project 覆盖 agent 覆盖 global。`mcp.json` 不要明文密钥。完整约定：[agents.zh-CN.md](./agents.zh-CN.md)。
+
 ### 双向同步示例
 
 以本地为准；冲突时先备份远端。鉴权与上传相同（Bearer / `X-Api-Key`），不走网页会话。WebDAV 协议不变。

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -1,0 +1,81 @@
+# Davflare agent layouts (v1)
+
+Store Cursor (and later Codex / Claude / OpenCode) **skills**, **rules**, and **MCP** snippets on R2 using a fixed directory tree. v1 is a **convention + manual pull/push** with the existing five MCP tools (or the web UI). No file watcher. No new MCP methods. Secrets are not stored as files.
+
+Merge order when the same name exists at more than one layer: **project > agent > global**.
+
+## Remote tree
+
+```
+agents/
+  global/
+    skills/
+    rules/
+    mcp/
+  {agent}/                 # cursor | claude | codex | opencode
+    skills/
+    rules/
+    mcp/
+    {project}/             # repo or workspace name, e.g. Davflare
+      skills/
+      rules/
+      mcp/
+```
+
+Slugs are lowercase (`cursor`, not `Cursor`). Project names match the repo/workspace name.
+
+| Type | What lives in that folder |
+| --- | --- |
+| `skills/` | One directory per skill, each with a `SKILL.md` (and optional helpers) |
+| `rules/` | Cursor `.mdc` rule files (or `AGENTS.md`) |
+| `mcp/` | `mcp.json` only — **placeholders, never raw keys** |
+
+Example keys:
+
+- `agents/global/skills/commit/SKILL.md`
+- `agents/cursor/rules/typescript.mdc`
+- `agents/cursor/mcp/mcp.json`
+- `agents/cursor/Davflare/skills/pages-deploy/SKILL.md`
+- `agents/cursor/Davflare/mcp/mcp.json`
+
+## Cursor local paths (v1)
+
+| Layer | skills | rules | mcp |
+| --- | --- | --- | --- |
+| global / agent | `~/.cursor/skills/<name>/SKILL.md` | copy `.mdc` into `~/.cursor/rules/` (or apply as User Rules) | `~/.cursor/mcp.json` |
+| project | `<repo>/.cursor/skills/<name>/SKILL.md` | `<repo>/.cursor/rules/*.mdc` | `<repo>/.cursor/mcp.json` |
+
+Cursor MCP also accepts `${env:NAME}` in `headers` / `url`. Use that. Do not upload a file that contains `Bearer fd_…` or a pasted token.
+
+Safe remote `mcp.json` (store this, not a live key):
+
+```json
+{
+  "mcpServers": {
+    "davflare": {
+      "url": "https://<your-domain.com>/mcp",
+      "headers": {
+        "Authorization": "Bearer ${env:DAVFLARE_API_KEY}"
+      }
+    }
+  }
+}
+```
+
+## Manual pull / push (v1)
+
+`GET /api/list` and the MCP `list` tool are **depth 1**. Walk each folder yourself.
+
+Pull (remote → Cursor), project first:
+
+1. `list` `agents/cursor/<project>/skills/` (then `rules/`, `mcp/`) → `download` each file into the project `.cursor/…` paths above.
+2. Same for `agents/cursor/{skills,rules,mcp}/` → user-level Cursor paths. Skip a file if the project layer already provided that name.
+3. Same for `agents/global/…`.
+
+Push (Cursor → remote): `mkdir` the remote folder, then `upload` (or the web UI). Strip secrets from `mcp.json` before upload. MCP v1 upload cap is 1 MiB; bigger files go through the web UI.
+
+v2 will add `pull` / `push` tools that walk this tree. v3 will add other agents and conflict policy. Until then, do not auto-sync and do not watch the local disk.
+
+## Web UI
+
+The file browser can create and edit the same `agents/…` tree. That is the supported way to manage these files without an MCP client.

--- a/docs/agents.zh-CN.md
+++ b/docs/agents.zh-CN.md
@@ -1,0 +1,81 @@
+# Davflare Agent 目录约定（v1）
+
+把 Cursor（以及后续 Codex / Claude / OpenCode）的 **skills**、**rules**、**MCP 片段**按固定目录放进 R2。v1 只是**约定 + 手动拉取/推送**：用现有五个 MCP 工具或网页端即可。不做文件监听。不新开协议。密钥不当文件存。
+
+同名文件的合并顺序：**project 覆盖 agent 覆盖 global**。
+
+## 远端目录
+
+```
+agents/
+  global/
+    skills/
+    rules/
+    mcp/
+  {agent}/                 # cursor | claude | codex | opencode
+    skills/
+    rules/
+    mcp/
+    {project}/             # 仓库或工作区名，例如 Davflare
+      skills/
+      rules/
+      mcp/
+```
+
+agent 用小写（`cursor`，不要 `Cursor`）。project 与仓库/工作区名一致。
+
+| 类型 | 目录里放什么 |
+| --- | --- |
+| `skills/` | 每个技能一个子目录，内含 `SKILL.md`（可带辅助文件） |
+| `rules/` | Cursor 的 `.mdc` 规则（或 `AGENTS.md`） |
+| `mcp/` | 只放 `mcp.json` — **占位符，不要明文密钥** |
+
+示例 key：
+
+- `agents/global/skills/commit/SKILL.md`
+- `agents/cursor/rules/typescript.mdc`
+- `agents/cursor/mcp/mcp.json`
+- `agents/cursor/Davflare/skills/pages-deploy/SKILL.md`
+- `agents/cursor/Davflare/mcp/mcp.json`
+
+## Cursor 落地路径（v1）
+
+| 层 | skills | rules | mcp |
+| --- | --- | --- | --- |
+| global / agent | `~/.cursor/skills/<name>/SKILL.md` | `.mdc` 拷到 `~/.cursor/rules/`（或当作 User Rules） | `~/.cursor/mcp.json` |
+| project | `<仓库>/.cursor/skills/<name>/SKILL.md` | `<仓库>/.cursor/rules/*.mdc` | `<仓库>/.cursor/mcp.json` |
+
+Cursor 的 `mcp.json` 支持在 `headers` / `url` 里写 `${env:NAME}`。用这个。不要上传带 `Bearer fd_…` 或粘贴出来的 token 的文件。
+
+远端应保存的安全示例（不要存活密钥）：
+
+```json
+{
+  "mcpServers": {
+    "davflare": {
+      "url": "https://<your-domain.com>/mcp",
+      "headers": {
+        "Authorization": "Bearer ${env:DAVFLARE_API_KEY}"
+      }
+    }
+  }
+}
+```
+
+## 手动拉取 / 推送（v1）
+
+`GET /api/list` 和 MCP `list` 都是 **Depth 1**，要自己一层层走。
+
+拉取（远端 → Cursor），先 project：
+
+1. `list` `agents/cursor/<project>/skills/`（再 `rules/`、`mcp/`）→ `download` 到上表的项目 `.cursor/…`。
+2. 再处理 `agents/cursor/{skills,rules,mcp}/` → 用户级路径。project 层已经有的同名文件跳过。
+3. 最后 `agents/global/…`。
+
+推送（Cursor → 远端）：先 `mkdir` 远端目录，再 `upload`（或网页端）。上传 `mcp.json` 前去掉密钥。MCP v1 单文件约 1 MiB，更大走网页。
+
+v2 会加 `pull` / `push` 两个工具自动走这棵树。v3 再接其它 agent 和冲突策略。在此之前不要自动同步、不要监听本地磁盘。
+
+## 网页端
+
+文件浏览器可以直接建、改这套 `agents/…` 目录。这是不经过 MCP 客户端时的正式管理方式。


### PR DESCRIPTION
## Summary
- v1 agent layouts: agents/{global|agent|agent/project}/{skills|rules|mcp}/
- Cursor local paths + secret-safe mcp.json (env placeholder)
- Manual pull/push only; no new MCP tools

## Test plan
- Read docs/agents.md and the README Agent layouts section
- Confirm no protocol/code change
