### PR TITLE
feat: 静态站按 Host 分流（SITES_HOST + sites/{slug}/）

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Share (expiry + extract code):
 - WebDAV Class 1/2 at `/webdav`
 - API keys for scripted upload, download, and bidirectional sync
 - Remote MCP at `/mcp` (list, upload, download, mkdir, delete)
+- Static sites on a separate host (`SITES_HOST` + `sites/{slug}/`); [docs/sites.md](docs/sites.md)
 - Agent layouts on R2: `agents/{global|agent|agent/project}/{skills|rules|mcp}/` (manual pull/push; see [docs/agents.md](docs/agents.md))
 - Chinese / English UI (globe icon in the header; defaults to browser language, persisted locally)
 
@@ -51,8 +52,9 @@ After the first deploy:
 1. Bind your R2 bucket to the `BUCKET` variable
 2. Set `WEBDAV_USERNAME` and `WEBDAV_PASSWORD`
 3. Optional: `WEBDAV_PUBLIC_READ=1` for public read; `TRASH_RETENTION_DAYS` (default `30`, `-1` disables purge)
-4. Retry deploy so the binding and env vars apply
-5. Optional: add a custom domain
+4. Optional static sites: bind `sites.<your-domain>` to this same Pages project and set `SITES_HOST=sites.<your-domain>`
+5. Retry deploy so the binding and env vars apply
+6. Optional: add a custom domain for the drive UI
 
 ### Manual Cloudflare Pages
 
@@ -116,6 +118,10 @@ Cursor (`mcp.json`):
   }
 }
 ```
+
+## Static sites
+
+Public HTML from `sites/{slug}/` on a **separate hostname** (`SITES_HOST`). Same Worker, Host routing — not `/sites` on the drive origin. Details: [docs/sites.md](docs/sites.md).
 
 ## Agent layouts
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -33,6 +33,7 @@
 - WebDAV Class 1/2，路径 `/webdav`
 - API Key，可用于脚本上传、下载与双向同步
 - 远程 MCP，路径 `/mcp`（list / upload / download / mkdir / delete）
+- 静态站点走单独域名（`SITES_HOST` + `sites/{slug}/`）；[docs/sites.zh-CN.md](docs/sites.zh-CN.md)
 - Agent 目录约定：`agents/{global|agent|agent/project}/{skills|rules|mcp}/`（手动拉取/推送，见 [docs/agents.zh-CN.md](docs/agents.zh-CN.md)）
 - 中 / 英界面（标题栏地球图标；默认跟随浏览器语言，并保存在本地）
 
@@ -114,6 +115,10 @@ Cursor（`mcp.json`）：
   }
 }
 ```
+
+## 静态站点
+
+`sites/{slug}/` 下的 HTML 只在**单独域名**（`SITES_HOST`）上提供。同一个 Worker，按 Host 分流，不是网盘源上的 `/sites`。详见 [docs/sites.zh-CN.md](docs/sites.zh-CN.md)。
 
 ## Agent 目录
 

--- a/docs/sites.md
+++ b/docs/sites.md
@@ -1,0 +1,28 @@
+# Static sites (v1)
+
+Serve folders from R2 as public websites on a **separate hostname**. Same Worker as the drive; routing is by `Host`. Never serve site HTML on the drive origin — uploaded pages could read `localStorage` login state.
+
+## Enable
+
+1. Bind a custom domain to the same Cloudflare Pages project: `sites.<your-domain>`.
+2. Set the Pages env var `SITES_HOST=sites.<your-domain>` (exact hostname, no `https://`).
+3. Redeploy. If `SITES_HOST` is empty, static hosting stays off.
+
+The drive host (`*.pages.dev` or your app domain) is unchanged. `/api`, `/mcp`, and `/webdav` are not exposed on the sites host.
+
+## Publish
+
+Upload a folder to `sites/{slug}/` (web UI, Open API, or MCP `mkdir` + `upload`). `{slug}` is `[a-z0-9][a-z0-9-]{0,62}`.
+
+```
+sites/blog/index.html
+sites/blog/style.css
+```
+
+Then open `https://sites.<your-domain>/blog/` (or `/blog/style.css`). Missing files 404. Directory URLs resolve to `index.html`. No git deploy, no Pages project per site.
+
+## Security
+
+- Different origin from the file manager: site JS cannot read drive credentials.
+- All slugs share the sites origin (`sites.domain/a/` and `/b/`). Fine for one owner; do not host untrusted third-party HTML on the same sites host.
+- Do not put API keys in the uploaded HTML.

--- a/docs/sites.zh-CN.md
+++ b/docs/sites.zh-CN.md
@@ -1,0 +1,28 @@
+# 静态站点（v1）
+
+把 R2 里的目录当成公开网站，挂在**单独的域名**上。和网盘同一个 Worker，按 `Host` 分流。绝不要在网盘源上直接吐 HTML——上传的页面能读到 `localStorage` 登录态。
+
+## 开启
+
+1. 给同一个 Cloudflare Pages 项目绑自定义域：`sites.<你的域>`。
+2. 设置环境变量 `SITES_HOST=sites.<你的域>`（只要主机名，不要 `https://`）。
+3. 重新部署。`SITES_HOST` 为空则功能关闭。
+
+网盘域名（`*.pages.dev` 或应用域）不变。站点域上不开放 `/api`、`/mcp`、`/webdav`。
+
+## 发布
+
+把目录上传到 `sites/{slug}/`（网页端、开放接口，或 MCP 的 `mkdir` + `upload`）。`{slug}` 为 `[a-z0-9][a-z0-9-]{0,62}`。
+
+```
+sites/blog/index.html
+sites/blog/style.css
+```
+
+然后打开 `https://sites.<你的域>/blog/`（或 `/blog/style.css`）。没有文件就是 404。目录 URL 找 `index.html`。不做 git 部署，不为每个站再建一个 Pages 项目。
+
+## 安全
+
+- 和网盘不同源：站点脚本读不到网盘登录态。
+- 所有 slug 共用站点域（`sites.domain/a/` 和 `/b/`）。自己用没问题；不要在同一站点域托管别人不可信的 HTML。
+- 不要把 API 密钥写进上传的 HTML。

--- a/functions/_middleware.ts
+++ b/functions/_middleware.ts
@@ -1,0 +1,38 @@
+import { indexFallbackKey, isSitesHost, parseSitesPath, sitesNotFound, sitesResponse } from "./_sites";
+
+interface SitesEnv {
+  BUCKET: R2Bucket;
+  SITES_HOST?: string;
+}
+
+export const onRequest: PagesFunction<SitesEnv> = async (context) => {
+  const host = context.request.headers.get("Host") || new URL(context.request.url).host;
+  if (!isSitesHost(host, context.env.SITES_HOST)) {
+    return context.next();
+  }
+
+  const method = context.request.method.toUpperCase();
+  if (method !== "GET" && method !== "HEAD") {
+    return new Response("Method Not Allowed", {
+      status: 405,
+      headers: { Allow: "GET, HEAD", "Content-Type": "text/plain; charset=utf-8" },
+    });
+  }
+
+  const parsed = parseSitesPath(new URL(context.request.url).pathname);
+  if (!parsed.ok) return sitesNotFound();
+
+  let key = parsed.key;
+  let object = await context.env.BUCKET.get(key);
+  if (!object && parsed.tryIndex) {
+    key = indexFallbackKey(parsed.key);
+    object = await context.env.BUCKET.get(key);
+  }
+  if (!object) return sitesNotFound();
+
+  return sitesResponse(
+    { body: object.body, httpEtag: object.httpEtag },
+    key,
+    method === "HEAD"
+  );
+};

--- a/functions/_sites.ts
+++ b/functions/_sites.ts
@@ -1,0 +1,101 @@
+export const SITES_PREFIX = "sites/";
+
+const SLUG_RE = /^[a-z0-9][a-z0-9-]{0,62}$/;
+
+const MIME: Record<string, string> = {
+  html: "text/html; charset=utf-8",
+  htm: "text/html; charset=utf-8",
+  css: "text/css; charset=utf-8",
+  js: "text/javascript; charset=utf-8",
+  mjs: "text/javascript; charset=utf-8",
+  json: "application/json; charset=utf-8",
+  svg: "image/svg+xml",
+  png: "image/png",
+  jpg: "image/jpeg",
+  jpeg: "image/jpeg",
+  gif: "image/gif",
+  webp: "image/webp",
+  ico: "image/x-icon",
+  txt: "text/plain; charset=utf-8",
+  md: "text/markdown; charset=utf-8",
+  xml: "application/xml; charset=utf-8",
+  woff: "font/woff",
+  woff2: "font/woff2",
+  ttf: "font/ttf",
+  pdf: "application/pdf",
+  wasm: "application/wasm",
+  map: "application/json",
+};
+
+export function normalizeSitesHost(raw: string | undefined | null): string {
+  return (raw || "").trim().toLowerCase().replace(/\.$/, "");
+}
+
+export function isSitesHost(requestHost: string, sitesHost: string | undefined | null): boolean {
+  const want = normalizeSitesHost(sitesHost);
+  if (!want) return false;
+  const got = normalizeSitesHost(requestHost.split(":")[0]);
+  return got === want;
+}
+
+export function mimeForKey(key: string): string {
+  const base = key.split("/").pop() || "";
+  const dot = base.lastIndexOf(".");
+  if (dot < 0) return "application/octet-stream";
+  const ext = base.slice(dot + 1).toLowerCase();
+  return MIME[ext] || "application/octet-stream";
+}
+
+export function parseSitesPath(
+  pathname: string
+): { ok: true; slug: string; key: string; tryIndex: boolean } | { ok: false; reason: string } {
+  const raw = pathname.replace(/\\/g, "/");
+  if (raw.includes("..") || raw.includes("_$flaredrive$")) {
+    return { ok: false, reason: "bad path" };
+  }
+  const parts = raw.split("/").filter(Boolean);
+  if (parts.length === 0) return { ok: false, reason: "missing slug" };
+  const slug = parts[0].toLowerCase();
+  if (!SLUG_RE.test(slug)) return { ok: false, reason: "bad slug" };
+  const rest = parts.slice(1);
+  const trailingSlash = raw.endsWith("/");
+  if (rest.length === 0) {
+    return { ok: true, slug, key: `${SITES_PREFIX}${slug}/index.html`, tryIndex: false };
+  }
+  const file = rest.join("/");
+  if (trailingSlash) {
+    return { ok: true, slug, key: `${SITES_PREFIX}${slug}/${file.replace(/\/$/, "")}/index.html`, tryIndex: false };
+  }
+  const hasDot = rest[rest.length - 1].includes(".");
+  return {
+    ok: true,
+    slug,
+    key: `${SITES_PREFIX}${slug}/${file}`,
+    tryIndex: !hasDot,
+  };
+}
+
+export function indexFallbackKey(key: string): string {
+  return key.endsWith("/") ? `${key}index.html` : `${key}/index.html`;
+}
+
+export function sitesNotFound(): Response {
+  return new Response("Not Found", {
+    status: 404,
+    headers: {
+      "Content-Type": "text/plain; charset=utf-8",
+      "X-Content-Type-Options": "nosniff",
+      "Cache-Control": "no-store",
+    },
+  });
+}
+
+export function sitesResponse(object: { body: ReadableStream | null; httpEtag?: string }, key: string, head: boolean) {
+  const headers = new Headers();
+  headers.set("Content-Type", mimeForKey(key));
+  headers.set("X-Content-Type-Options", "nosniff");
+  headers.set("Cache-Control", "public, max-age=60");
+  headers.set("X-Robots-Tag", "noindex");
+  if (object.httpEtag) headers.set("ETag", object.httpEtag);
+  return new Response(head ? null : object.body, { status: 200, headers });
+}

--- a/src/app/__tests__/sites.test.ts
+++ b/src/app/__tests__/sites.test.ts
@@ -1,0 +1,61 @@
+import {
+  indexFallbackKey,
+  isSitesHost,
+  mimeForKey,
+  parseSitesPath,
+} from "../../../functions/_sites";
+
+describe("static sites host routing", () => {
+  test("feature off when SITES_HOST empty", () => {
+    expect(isSitesHost("sites.example.com", "")).toBe(false);
+    expect(isSitesHost("sites.example.com", undefined)).toBe(false);
+  });
+
+  test("only the bound sites host matches", () => {
+    expect(isSitesHost("sites.example.com", "sites.example.com")).toBe(true);
+    expect(isSitesHost("SITES.EXAMPLE.COM:443", "sites.example.com")).toBe(true);
+    expect(isSitesHost("flaredrive-bgb.pages.dev", "sites.example.com")).toBe(false);
+    expect(isSitesHost("example.com", "sites.example.com")).toBe(false);
+  });
+
+  test("parse slug and index.html", () => {
+    expect(parseSitesPath("/blog")).toEqual({
+      ok: true,
+      slug: "blog",
+      key: "sites/blog/index.html",
+      tryIndex: false,
+    });
+    expect(parseSitesPath("/blog/")).toEqual({
+      ok: true,
+      slug: "blog",
+      key: "sites/blog/index.html",
+      tryIndex: false,
+    });
+    expect(parseSitesPath("/blog/style.css")).toEqual({
+      ok: true,
+      slug: "blog",
+      key: "sites/blog/style.css",
+      tryIndex: false,
+    });
+    expect(parseSitesPath("/blog/about")).toEqual({
+      ok: true,
+      slug: "blog",
+      key: "sites/blog/about",
+      tryIndex: true,
+    });
+    expect(indexFallbackKey("sites/blog/about")).toBe("sites/blog/about/index.html");
+  });
+
+  test("reject traversal and empty slug", () => {
+    expect(parseSitesPath("/").ok).toBe(false);
+    expect(parseSitesPath("/../etc/passwd").ok).toBe(false);
+    expect(parseSitesPath("/bad_slug").ok).toBe(false);
+    expect(parseSitesPath("/_$flaredrive$/x").ok).toBe(false);
+  });
+
+  test("mime by extension", () => {
+    expect(mimeForKey("sites/a/index.html")).toMatch(/^text\/html/);
+    expect(mimeForKey("sites/a/app.js")).toMatch(/javascript/);
+    expect(mimeForKey("sites/a/noext")).toBe("application/octet-stream");
+  });
+});

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -4,6 +4,8 @@ compatibility_date = "2024-06-20"
 
 [vars]
 WEBDAV_PUBLIC_READ = "0"
+# Exact hostname for static sites, e.g. sites.example.com. Empty = off.
+SITES_HOST = ""
 
 [[r2_buckets]]
 binding = "BUCKET"


### PR DESCRIPTION
## Summary
- Same Worker; only Host == SITES_HOST serves R2 sites/{slug}/.
- Drive origin unchanged. Empty SITES_HOST keeps the feature off.
- Docs: docs/sites.md

## Test plan
- typecheck + sites.test passed
- Bind sites.<domain>, set SITES_HOST, upload sites/demo/index.html, open /demo/
