### PR TITLE
chore: wrangler.toml 里 SITES_HOST 改回空

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -5,7 +5,7 @@ compatibility_date = "2024-06-20"
 [vars]
 WEBDAV_PUBLIC_READ = "0"
 # Exact hostname for static sites, e.g. sites.example.com. Empty = off.
-SITES_HOST = "sites.freedrg.com"
+SITES_HOST = ""
 
 [[r2_buckets]]
 binding = "BUCKET"


### PR DESCRIPTION
## Summary
- Revert baked-in sites.freedrg.com. Open-source default is empty; production sets Pages env only.
