### PR TITLE
docs: README/MCP/站点对齐现网（15 工具、Sites、CLI）

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,10 @@ Share (expiry + extract code):
 - Recycle bin with `TRASH_RETENTION_DAYS` (default 30; `-1` disables; lazy purge up to 200 items when trash is opened)
 - WebDAV Class 1/2 at `/webdav`
 - API keys for scripted upload, download, and bidirectional sync
-- Remote MCP at `/mcp` (list, upload, download, mkdir, delete)
+- Remote MCP at `/mcp` (15 tools: files, search, move/copy, shares, sites). Uploads auto-chunk up to 25 MB; downloads page with `part`
+- Sites manager in the UI (`#/sites`): zip deploy, SPA toggle, per-site delete
 - Static sites on a separate host (`SITES_HOST` + `sites/{slug}/`); [docs/sites.md](docs/sites.md)
+- `davflare-cli` for login / ls / mkdir / rm / mv / cp / sync ([cli/README.md](cli/README.md))
 - Agent layouts on R2: `agents/{global|agent|agent/project}/{skills|rules|mcp}/` (manual pull/push; see [docs/agents.md](docs/agents.md))
 - Chinese / English UI (globe icon in the header; defaults to browser language, persisted locally)
 
@@ -90,19 +92,27 @@ Create keys in the web UI (「API」 / 「开放接口」). Auth: `Authorization
 | GET / POST / DELETE | `/api/keys` | Create, list, and revoke keys (session auth) |
 | POST / PUT / DELETE | `/api/upload` | Upload a file (multipart, raw body, overwrite, or chunked >100MB) |
 | GET | `/api/list` | Depth-1 folder listing (size, uploaded, etag) |
-| GET | `/api/download` | Download one file |
+| GET | `/api/download` | Download one file (Range / 206 resume) |
 | POST | `/api/mkdir` | Create a folder (parents auto-created) |
 | POST | `/api/rename` | Rename or move a file or folder |
+| POST | `/api/copy` | Copy a file |
+| GET | `/api/stat` | Object metadata |
+| GET | `/api/search` | Filename substring search |
 | POST | `/api/backup` | Rename remote to `name.conflict-<UTC>` before overwrite |
 | DELETE | `/api/delete` | Hard delete, or `soft=1` to trash |
 | POST | `/api/shares` | Share a file or folder (folder → zip) |
-| POST | `/mcp` | Remote MCP (JSON-RPC 2.0; same API keys; ~1 MiB cap) |
+| GET / POST / DELETE | `/api/sites` | List, SPA-config, or delete static sites |
+| POST | `/mcp` | Remote MCP (JSON-RPC 2.0; same API keys; 15 tools) |
 
 Same keys work for a bidirectional sync client (local wins; backup remote on conflict). Details in the [API docs](docs/API.md).
 
 ## MCP
 
-Same-origin Model Context Protocol (Streamable HTTP) at `/mcp`. Auth is the same API key as the Open API (`Authorization: Bearer <apiKey>` or `X-Api-Key`). v1 tools: `list`, `upload`, `download`, `mkdir`, `delete`. MCP uploads/downloads are capped at about 1 MiB; use the web UI for larger files.
+Same-origin Model Context Protocol (Streamable HTTP) at `/mcp`. Auth is the same API key as the Open API (`Authorization: Bearer <apiKey>` or `X-Api-Key`).
+
+Tools (15): `list`, `upload`, `download`, `mkdir`, `delete`, `search`, `move`, `copy`, `stat`, `share_create`, `share_list`, `share_revoke`, `sites_list`, `sites_config`, `sites_delete`.
+
+Uploads up to 1 MiB go inline; larger content is auto-chunked (cap **25 MB**). Bigger files: web UI or `davflare-cli`. Downloads over 1 MiB page with `part` / `partSize`. Default `delete` is trash; `hard=true` permanently deletes. Publish a static site by uploading into `sites/{slug}/`, then `sites_config` if you need SPA fallback. Details: [docs/API.md](docs/API.md).
 
 Cursor (`mcp.json`):
 
@@ -121,7 +131,13 @@ Cursor (`mcp.json`):
 
 ## Static sites
 
-Public HTML from `sites/{slug}/` on a **separate hostname** (`SITES_HOST`). Same Worker, Host routing — not `/sites` on the drive origin. Details: [docs/sites.md](docs/sites.md).
+Public HTML from `sites/{slug}/` on a **separate hostname** (`SITES_HOST`). Same Worker, Host routing — not `/sites` on the drive origin.
+
+In the drive UI, **Sites** (`#/sites`) lists each slug with stats, one-click zip deploy, SPA toggle, and delete. MCP `sites_list` / `sites_config` / `sites_delete` wrap the same `/api/sites` endpoints. Details: [docs/sites.md](docs/sites.md).
+
+## CLI
+
+[`davflare-cli`](cli/README.md) is the Open API command-line client: `login`, `ls`, `mkdir`, `rm`, `mv`, `cp`, `sync`. Uploads over 100 MB are chunked; downloads resume with HTTP Range. See `cli/README.md` for install, login, and sync semantics.
 
 ## Agent layouts
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -32,8 +32,10 @@
 - 回收站，由 `TRASH_RETENTION_DAYS` 控制（默认 30 天；`-1` 关闭；打开回收站时惰性清理最多 200 项）
 - WebDAV Class 1/2，路径 `/webdav`
 - API Key，可用于脚本上传、下载与双向同步
-- 远程 MCP，路径 `/mcp`（list / upload / download / mkdir / delete）
+- 远程 MCP，路径 `/mcp`（15 个工具：文件、搜索、移动/复制、分享、站点）。上传超过 1 MiB 自动分块，上限 25 MB；下载用 `part` 分页
+- 网页端站点管理（`#/sites`）：zip 一键部署、SPA 开关、按站删除
 - 静态站点走单独域名（`SITES_HOST` + `sites/{slug}/`）；[docs/sites.zh-CN.md](docs/sites.zh-CN.md)
+- `davflare-cli`：login / ls / mkdir / rm / mv / cp / sync（[cli/README.md](cli/README.md)）
 - Agent 目录约定：`agents/{global|agent|agent/project}/{skills|rules|mcp}/`（手动拉取/推送，见 [docs/agents.zh-CN.md](docs/agents.zh-CN.md)）
 - 中 / 英界面（标题栏地球图标；默认跟随浏览器语言，并保存在本地）
 
@@ -50,8 +52,9 @@
 1. 将 R2 bucket 绑定到 `BUCKET` 变量
 2. 设置 `WEBDAV_USERNAME` 和 `WEBDAV_PASSWORD`
 3. 可选：`WEBDAV_PUBLIC_READ=1` 开启公开读取；`TRASH_RETENTION_DAYS`（默认 `30`，`-1` 关闭清理）
-4. 重新部署，使绑定和环境变量生效
-5. 可选：绑定自定义域名
+4. 可选静态站点：把 `sites.<你的域>` 绑到同一个 Pages 项目，并设置 `SITES_HOST=sites.<你的域>`
+5. 重新部署，使绑定和环境变量生效
+6. 可选：给网盘界面绑自定义域名
 
 ### 手动部署 Cloudflare Pages
 
@@ -87,19 +90,27 @@ Cloudflare Workers 单次 PUT 上限为 **128 MB**。超限会返回 **HTTP 413*
 | GET / POST / DELETE | `/api/keys` | 创建、列出、作废密钥（需网页登录会话） |
 | POST / PUT / DELETE | `/api/upload` | 上传文件（multipart / 原始 body / 覆盖 / >100MB 分片） |
 | GET | `/api/list` | 列出当前目录（size、uploaded、etag） |
-| GET | `/api/download` | 下载单个文件 |
+| GET | `/api/download` | 下载单个文件（Range / 206 断点续传） |
 | POST | `/api/mkdir` | 创建文件夹（自动补齐父目录） |
 | POST | `/api/rename` | 重命名 / 移动文件或文件夹 |
+| POST | `/api/copy` | 复制文件 |
+| GET | `/api/stat` | 对象元数据 |
+| GET | `/api/search` | 按文件名子串搜索 |
 | POST | `/api/backup` | 冲突时把远端改名为 `name.conflict-<UTC>` |
 | DELETE | `/api/delete` | 硬删除，或 `soft=1` 进回收站 |
 | POST | `/api/shares` | 分享文件或文件夹（文件夹为 zip） |
-| POST | `/mcp` | 远程 MCP（JSON-RPC 2.0；同一把 API 密钥；约 1 MiB 上限） |
+| GET / POST / DELETE | `/api/sites` | 列出、配置 SPA、删除静态站 |
+| POST | `/mcp` | 远程 MCP（JSON-RPC 2.0；同一把 API 密钥；15 个工具） |
 
 同一把密钥可做双向同步（本地优先，冲突时先备份远端）。详见 [开放接口文档](docs/API.zh-CN.md)。
 
 ## MCP
 
-同源 Model Context Protocol（Streamable HTTP），路径 `POST /mcp`。鉴权与开放接口相同（`Authorization: Bearer <apiKey>` 或 `X-Api-Key`）。v1 工具：`list`、`upload`、`download`、`mkdir`、`delete`。经 MCP 上传/下载约 1 MiB 上限，更大的文件请用网页端。
+同源 Model Context Protocol（Streamable HTTP），路径 `POST /mcp`。鉴权与开放接口相同（`Authorization: Bearer <apiKey>` 或 `X-Api-Key`）。
+
+工具（15 个）：`list`、`upload`、`download`、`mkdir`、`delete`、`search`、`move`、`copy`、`stat`、`share_create`、`share_list`、`share_revoke`、`sites_list`、`sites_config`、`sites_delete`。
+
+不超过 1 MiB 的上传走内联；更大内容自动分块（上限 **25 MB**）。再大请用网页端或 `davflare-cli`。下载超过 1 MiB 用 `part` / `partSize` 分页。`delete` 默认进回收站，`hard=true` 永久删除。把文件上传到 `sites/{slug}/` 即发布静态站，需要 SPA 回退再调 `sites_config`。详见 [docs/API.zh-CN.md](docs/API.zh-CN.md)。
 
 Cursor（`mcp.json`）：
 
@@ -118,7 +129,13 @@ Cursor（`mcp.json`）：
 
 ## 静态站点
 
-`sites/{slug}/` 下的 HTML 只在**单独域名**（`SITES_HOST`）上提供。同一个 Worker，按 Host 分流，不是网盘源上的 `/sites`。详见 [docs/sites.zh-CN.md](docs/sites.zh-CN.md)。
+`sites/{slug}/` 下的 HTML 只在**单独域名**（`SITES_HOST`）上提供。同一个 Worker，按 Host 分流，不是网盘源上的 `/sites`。
+
+网页端「站点」（`#/sites`）可看每个 slug 的统计、zip 一键部署、SPA 开关和删除。MCP 的 `sites_list` / `sites_config` / `sites_delete` 包装同一套 `/api/sites`。详见 [docs/sites.zh-CN.md](docs/sites.zh-CN.md)。
+
+## 命令行
+
+[`davflare-cli`](cli/README.md) 是开放接口的命令行客户端：`login`、`ls`、`mkdir`、`rm`、`mv`、`cp`、`sync`。超过 100 MB 自动分块上传，下载支持 HTTP Range 断点续传。安装与同步语义见 `cli/README.md`。
 
 ## Agent 目录
 

--- a/docs/API.zh-CN.md
+++ b/docs/API.zh-CN.md
@@ -119,11 +119,19 @@ curl -X DELETE "https://<your-domain.com>/api/delete?path=folder/sub" \
 
 ### 分享
 
-`POST /api/shares` 也接受文件夹 key —— 打开分享链接会把整棵子树以 zip 流式下载（提取码和过期时间照常生效）。
+`POST /api/shares` 也接受文件夹 key —— 打开分享链接会把整棵子树以 zip 流式下载（提取码和过期时间照常生效）。分享管理（GET/POST/DELETE /api/shares）同时接受网页会话（Basic）和 API key。
+
+### 复制、stat、搜索
+
+`POST /api/copy` 复制文件（to 已存在则 409，除非 overwrite=1；不支持目录）。`GET /api/stat?path=` 返回 kind / size / etag / uploaded / contentType。`GET /api/search?q=` 按文件名子串搜索（cursor 分页）。`GET /api/download` 会发 Accept-Ranges: bytes，并响应单个 Range 为 206。
+
+### 静态站点 API
+
+GET / POST / DELETE /api/sites 列站、切 SPA、删站。会话或 API key 均可。详见 [sites.zh-CN.md](./sites.zh-CN.md)。
 
 ### MCP
 
-同源 Streamable HTTP MCP：`POST /mcp`（JSON-RPC 2.0）。鉴权与其它开放接口相同（`Authorization: Bearer <apiKey>` 或 `X-Api-Key`；不走网页会话，无 OAuth）。密钥缺失或无效返回 **HTTP 401**。v1 工具：`list`、`upload`、`download`、`mkdir`、`delete`（包装上方 Open API）。经 MCP 上传/下载约 1 MiB 上限，更大则工具错误（会提到 **413** / 网页端）。`delete` 默认进回收站；`hard=true` 为永久删除。
+同源 Streamable HTTP MCP：`POST /mcp`（JSON-RPC 2.0）。鉴权与其它开放接口相同（`Authorization: Bearer <apiKey>` 或 `X-Api-Key`；不走网页会话，无 OAuth）。密钥缺失或无效返回 **HTTP 401**。工具：`list`、`upload`、`download`、`mkdir`、`delete`、`search`、`move`、`copy`、`stat`、`share_create`、`share_list`、`share_revoke`、`sites_list`、`sites_config`、`sites_delete`（包装上方 Open API）。超过 1 MiB 的上传自动改走分块（上限 **25 MB**；再大返回工具错误，请用网页端或 davflare-cli）。下载超过 1 MiB 用 `part` / `partSize` 分页。`delete` 默认进回收站；`hard=true` 为永久删除。`sites_*` 管理 `sites/` 下的静态站；`upload` / `delete` 也可以直接操作 `sites/<slug>/`。
 
 ```bash
 # initialize

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -1,6 +1,6 @@
 # Davflare agent layouts (v1)
 
-Store Cursor (and later Codex / Claude / OpenCode) **skills**, **rules**, and **MCP** snippets on R2 using a fixed directory tree. v1 is a **convention + manual pull/push** with the existing five MCP tools (or the web UI). No file watcher. No new MCP methods. Secrets are not stored as files.
+Store Cursor (and later Codex / Claude / OpenCode) **skills**, **rules**, and **MCP** snippets on R2 using a fixed directory tree. v1 is a **convention + manual pull/push** with the existing MCP tools (or the web UI). No file watcher. Secrets are not stored as files.
 
 Merge order when the same name exists at more than one layer: **project > agent > global**.
 
@@ -72,7 +72,7 @@ Pull (remote → Cursor), project first:
 2. Same for `agents/cursor/{skills,rules,mcp}/` → user-level Cursor paths. Skip a file if the project layer already provided that name.
 3. Same for `agents/global/…`.
 
-Push (Cursor → remote): `mkdir` the remote folder, then `upload` (or the web UI). Strip secrets from `mcp.json` before upload. MCP v1 upload cap is 1 MiB; bigger files go through the web UI.
+Push (Cursor → remote): `mkdir` the remote folder, then `upload` (or the web UI). Strip secrets from `mcp.json` before upload. MCP uploads over 1 MiB auto-chunk (cap 25 MB); bigger files go through the web UI or davflare-cli.
 
 v2 will add `pull` / `push` tools that walk this tree. v3 will add other agents and conflict policy. Until then, do not auto-sync and do not watch the local disk.
 

--- a/docs/agents.zh-CN.md
+++ b/docs/agents.zh-CN.md
@@ -1,6 +1,6 @@
 # Davflare Agent 目录约定（v1）
 
-把 Cursor（以及后续 Codex / Claude / OpenCode）的 **skills**、**rules**、**MCP 片段**按固定目录放进 R2。v1 只是**约定 + 手动拉取/推送**：用现有五个 MCP 工具或网页端即可。不做文件监听。不新开协议。密钥不当文件存。
+把 Cursor（以及后续 Codex / Claude / OpenCode）的 **skills**、**rules**、**MCP 片段**按固定目录放进 R2。v1 只是**约定 + 手动拉取/推送**：用现有 MCP 工具或网页端即可。不做文件监听。密钥不当文件存。
 
 同名文件的合并顺序：**project 覆盖 agent 覆盖 global**。
 
@@ -72,7 +72,7 @@ Cursor 的 `mcp.json` 支持在 `headers` / `url` 里写 `${env:NAME}`。用这�
 2. 再处理 `agents/cursor/{skills,rules,mcp}/` → 用户级路径。project 层已经有的同名文件跳过。
 3. 最后 `agents/global/…`。
 
-推送（Cursor → 远端）：先 `mkdir` 远端目录，再 `upload`（或网页端）。上传 `mcp.json` 前去掉密钥。MCP v1 单文件约 1 MiB，更大走网页。
+推送（Cursor → 远端）：先 `mkdir` 远端目录，再 `upload`（或网页端）。上传 `mcp.json` 前去掉密钥。MCP 上传超过 1 MiB 会自动分块（上限 25 MB）；再大走网页端或 davflare-cli。
 
 v2 会加 `pull` / `push` 两个工具自动走这棵树。v3 再接其它 agent 和冲突策略。在此之前不要自动同步、不要监听本地磁盘。
 

--- a/docs/sites.md
+++ b/docs/sites.md
@@ -14,7 +14,7 @@ The drive host (`*.pages.dev` or your app domain) is unchanged. `/api`, `/mcp`, 
 
 ## Publish
 
-Upload a folder to `sites/{slug}/` (web UI, Open API, or MCP `mkdir` + `upload`). `{slug}` is `[a-z0-9][a-z0-9-]{0,62}`.
+Upload a folder to `sites/{slug}/` (web UI Sites zip deploy, Open API, MCP `mkdir` + `upload`, or davflare-cli cp/sync). `{slug}` is `[a-z0-9][a-z0-9-]{0,62}`.
 
 ```
 sites/blog/index.html
@@ -26,6 +26,7 @@ Then open `https://sites.<your-domain>/blog/` (or `/blog/style.css`). Missing fi
 ## Management API & UI
 
 - Web UI: open the **Sites** section (`#/sites`) — list sites with stats, one-click zip deploy (client-side unzip + upload queue), SPA toggle, per-site delete. "Manage files" jumps into the regular file manager at `sites/<slug>/`.
+- MCP: `sites_list`, `sites_config`, `sites_delete` (same `/api/sites` handlers).
 - `GET /api/sites` — list sites (`?stats=1` adds cached object count / total size). Session (Basic) or API key.
 - `POST /api/sites` — `{"slug":"blog","spa":true}` toggles SPA fallback. The site must already exist.
 - `DELETE /api/sites?slug=blog` — remove all site files (config kept, so a redeploy keeps the SPA flag); add `&purge=1` to also delete the config.

--- a/docs/sites.zh-CN.md
+++ b/docs/sites.zh-CN.md
@@ -14,7 +14,7 @@
 
 ## 发布
 
-把目录上传到 `sites/{slug}/`（网页端、开放接口，或 MCP 的 `mkdir` + `upload`）。`{slug}` 为 `[a-z0-9][a-z0-9-]{0,62}`。
+把目录上传到 `sites/{slug}/`（网页端站点 zip 部署、开放接口、MCP 的 `mkdir` + `upload`，或 davflare-cli cp/sync）。`{slug}` 为 `[a-z0-9][a-z0-9-]{0,62}`。
 
 ```
 sites/blog/index.html
@@ -26,6 +26,7 @@ sites/blog/style.css
 ## 管理 API 与界面
 
 - 网页端：打开「站点」区块（`#/sites`）——站点列表与统计、zip 一键部署（浏览器解压后走上传队列）、SPA 开关、按站删除；「管理文件」直接跳到 `sites/<slug>/` 的常规文件管理器。
+- MCP：`sites_list`、`sites_config`、`sites_delete`（同一套 `/api/sites`）。
 - `GET /api/sites` — 列站点（`?stats=1` 附带缓存的文件数/总大小）。会话（Basic）或 API key 均可。
 - `POST /api/sites` — `{"slug":"blog","spa":true}` 切换 SPA 回退；站点需已存在。
 - `DELETE /api/sites?slug=blog` — 删除站点全部文件（保留配置，重新部署同 slug 时 SPA 开关仍在）；加 `&purge=1` 连配置一起删。


### PR DESCRIPTION
## Summary
- README / 中文 README / MCP / 静态站文档对齐现网：15 个 MCP 工具、上传自动分块上限 25 MB、站点管理 UI、`/api/copy|stat|search|sites`、davflare-cli。
- 不新开功能。HelloGitHub 请按此稿改，不要再写五个工具 / 1 MiB 上限。
