### PR TITLE
docs: P0 follow-along examples and blunt SITES_HOST / MCP copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,33 @@ Share (expiry + extract code):
 - Agent layouts on R2: `agents/{global|agent|agent/project}/{skills|rules|mcp}/` (manual pull/push; see [docs/agents.md](docs/agents.md))
 - Chinese / English UI (globe icon in the header; defaults to browser language, persisted locally)
 
+## Follow along
+
+Three short paths. Use **your** bound host — there is no public live demo other people can open.
+
+### Publish a static site from Cursor
+
+1. In `#/settings`, leave **API Key** and **MCP** on. Create a key (account menu → API keys) and paste it into Cursor `mcp.json` as in [MCP](#mcp).
+2. Ask Cursor (copy-paste):
+
+   ```
+   Upload this folder to sites/hello/ on Davflare (mkdir parents, overwrite same names). Then call sites_config for slug hello if this is an SPA.
+   ```
+
+3. Open `https://<SITES_HOST>/hello/` on the hostname you bound to **this** Pages project. Until `SITES_HOST` is set and redeployed, that URL will not open.
+
+### Host an image and copy its URL
+
+1. Open `#/images` in the drive UI.
+2. Drag an image onto the page (or click Upload).
+3. Click **Copy URL** or **Copy Markdown** (`![](https://<SITES_HOST>/i/{id})`). Public URLs only work after you bind a custom domain and set Pages env `SITES_HOST` (hostname only).
+
+### Toggle the five Settings switches
+
+1. Open `#/settings` from the account menu.
+2. The five switches are WebDAV, MCP, API Key, Sites, and Image host (all default on). Stored files are not deleted when a switch is off.
+3. MCP depends on API Key: if Key is off, `/mcp` is 404 even if MCP is on. Sites and image-host public URLs also need `SITES_HOST`.
+
 ## Deploy
 
 One-click:

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -41,6 +41,33 @@
 - Agent 目录约定：`agents/{global|agent|agent/project}/{skills|rules|mcp}/`（手动拉取/推送，见 [docs/agents.zh-CN.md](docs/agents.zh-CN.md)）
 - 中 / 英界面（标题栏地球图标；默认跟随浏览器语言，并保存在本地）
 
+## 跟着做
+
+三条短路径。请用**你自己绑定的域名**——没有别人能打开的公开演示站。
+
+### 用 Cursor 对话发布静态站
+
+1. 在 `#/settings` 保持 **API Key** 和 **MCP** 打开。创建一把密钥（账号菜单 → 开放接口），按 [MCP](#mcp) 写进 Cursor 的 `mcp.json`。
+2. 对 Cursor 说（可直接粘贴）：
+
+   ```
+   把这个文件夹上传到 Davflare 的 sites/hello/（自动建父目录，同名覆盖）。如果是 SPA，再对 slug hello 调用 sites_config。
+   ```
+
+3. 在你绑到**本** Pages 项目的主机上打开 `https://<SITES_HOST>/hello/`。未设置 `SITES_HOST` 并重新部署之前，这个地址打不开。
+
+### 图床拖放并复制链接
+
+1. 打开网盘里的 `#/images`。
+2. 把图片拖到页面上（或点上传）。
+3. 点 **复制链接** 或 **复制 Markdown**（`![](https://<SITES_HOST>/i/{id})`）。公开地址只有在绑定自定义域并设置 Pages 环境变量 `SITES_HOST`（只要主机名）之后才可用。
+
+### 设置里的五个开关
+
+1. 从账号菜单打开 `#/settings`。
+2. 五个开关是 WebDAV、MCP、API Key、静态站点、图床（默认全部开启）。关闭开关不会删除已有文件。
+3. MCP 依赖 API Key：Key 关闭时，即使 MCP 打开，`/mcp` 也是 404。站点和图床的公开地址还需要 `SITES_HOST`。
+
 ## 部署
 
 一键部署：

--- a/src/app/__tests__/p0CopyViews.test.tsx
+++ b/src/app/__tests__/p0CopyViews.test.tsx
@@ -59,7 +59,7 @@ describe("P0 copy: Settings / Sites / Images", () => {
 
   test("Sites view is blunt when SITES_HOST is missing", async () => {
     mockListSites.mockResolvedValue({ sitesHost: null, sites: [] });
-    render(<SitesView onNotify={jest.fn()} />);
+    render(<SitesView onNotify={jest.fn()} onManageFiles={jest.fn()} />);
     await waitFor(() => {
       expect(screen.getByText(strings.sitesHostMissing)).toBeInTheDocument();
     });

--- a/src/app/__tests__/p0CopyViews.test.tsx
+++ b/src/app/__tests__/p0CopyViews.test.tsx
@@ -1,0 +1,83 @@
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+
+import ImagesView from "../../ImagesView";
+import SettingsView from "../../SettingsView";
+import SitesView from "../../SitesView";
+import { DEFAULT_FEATURE_FLAGS, useFeatures } from "../features";
+import { listImages } from "../images";
+import { listSites } from "../sites";
+import { setLang, strings } from "../strings";
+
+jest.mock("../features", () => {
+  const actual = jest.requireActual("../features");
+  return { ...actual, useFeatures: jest.fn() };
+});
+
+jest.mock("../sites", () => {
+  const actual = jest.requireActual("../sites");
+  return { ...actual, listSites: jest.fn() };
+});
+
+jest.mock("../images", () => {
+  const actual = jest.requireActual("../images");
+  return { ...actual, listImages: jest.fn() };
+});
+
+jest.mock("../transferQueue", () => ({
+  useUploadEnqueue: () => jest.fn(),
+}));
+
+const mockUseFeatures = useFeatures as unknown as jest.Mock;
+const mockListSites = listSites as unknown as jest.Mock;
+const mockListImages = listImages as unknown as jest.Mock;
+
+beforeEach(() => {
+  setLang("en");
+  mockUseFeatures.mockReset();
+  mockListSites.mockReset();
+  mockListImages.mockReset();
+  mockUseFeatures.mockReturnValue({
+    flags: DEFAULT_FEATURE_FLAGS,
+    sitesHost: null,
+    updateFlags: jest.fn(),
+  });
+});
+
+describe("P0 copy: Settings / Sites / Images", () => {
+  test("Settings states MCP is 404 when API Key is off", () => {
+    render(<SettingsView onNotify={jest.fn()} />);
+    expect(screen.getByText(strings.mcpRequiresApiKey)).toBeInTheDocument();
+    expect(strings.mcpRequiresApiKey).toMatch(/404/);
+    expect(strings.mcpRequiresApiKey).toMatch(/API Key/i);
+    expect(screen.getByText(strings.flagWebdav)).toBeInTheDocument();
+    expect(screen.getByText(strings.flagMcp)).toBeInTheDocument();
+    expect(screen.getByText(strings.flagApiKey)).toBeInTheDocument();
+    expect(screen.getByText(strings.flagSites)).toBeInTheDocument();
+    expect(screen.getByText(strings.flagImageHost)).toBeInTheDocument();
+  });
+
+  test("Sites view is blunt when SITES_HOST is missing", async () => {
+    mockListSites.mockResolvedValue({ sitesHost: null, sites: [] });
+    render(<SitesView onNotify={jest.fn()} />);
+    await waitFor(() => {
+      expect(screen.getByText(strings.sitesHostMissing)).toBeInTheDocument();
+    });
+    expect(screen.getByText(strings.sitesHostMissingHint)).toBeInTheDocument();
+    expect(strings.sitesHostMissingHint).toMatch(/SITES_HOST/);
+    expect(strings.sitesHostMissingHint).toMatch(/redeploy/i);
+    expect(strings.sitesHostMissingHint).toMatch(/hostname only/i);
+  });
+
+  test("Images view is blunt when SITES_HOST is missing", async () => {
+    mockListImages.mockResolvedValue({ sitesHost: null, images: [] });
+    render(<ImagesView onNotify={jest.fn()} />);
+    await waitFor(() => {
+      expect(screen.getByText(strings.imagesHostMissing)).toBeInTheDocument();
+    });
+    expect(screen.getByText(strings.imagesHostMissingHint)).toBeInTheDocument();
+    expect(strings.imagesHostMissingHint).toMatch(/SITES_HOST/);
+    expect(strings.imagesHostMissingHint).toMatch(/redeploy/i);
+    expect(strings.imagesHostMissing).toMatch(/will not open/);
+  });
+});

--- a/src/app/__tests__/strings.test.ts
+++ b/src/app/__tests__/strings.test.ts
@@ -56,6 +56,32 @@ describe("strings / translate", () => {
     expect(translate("validForever")).toBe("Never expires");
   });
 
+  test("MCP copy states API Key 404 dependency", () => {
+    for (const lang of ["zh", "en"] as const) {
+      const mcp = dictionary.mcpRequiresApiKey[lang];
+      const mcpHint = dictionary.flagMcpHint[lang];
+      const keyHint = dictionary.flagApiKeyHint[lang];
+      expect(mcp).toMatch(/API Key/i);
+      expect(mcp).toMatch(/404/);
+      expect(mcpHint).toMatch(/404/);
+      expect(keyHint).toMatch(/404/);
+    }
+  });
+
+  test("SITES_HOST missing hints say bind, env, redeploy", () => {
+    for (const lang of ["zh", "en"] as const) {
+      for (const key of ["sitesHostMissingHint", "imagesHostMissingHint"] as const) {
+        const hint = dictionary[key][lang];
+        expect(hint).toMatch(/SITES_HOST/);
+        expect(hint).toMatch(/https:\/\//);
+        expect(hint).toMatch(lang === "zh" ? /绑定/ : /[Bb]ind/);
+        expect(hint).toMatch(lang === "zh" ? /重新部署/ : /redeploy/);
+      }
+      expect(dictionary.sitesHostMissing[lang]).toMatch(lang === "zh" ? /打不开/ : /will not open/);
+      expect(dictionary.imagesHostMissing[lang]).toMatch(lang === "zh" ? /打不开/ : /will not open/);
+    }
+  });
+
   test("setLang 通知订阅者", () => {
     const seen: string[] = [];
     const unsubscribe = subscribeLang(() => seen.push(getLang()));

--- a/src/app/strings.ts
+++ b/src/app/strings.ts
@@ -31,10 +31,10 @@ const entries: Record<string, Entry> = {  searchPlaceholder: { zh: "搜索文件
   trash: { zh: "回收站", en: "Trash" },
   sitesSection: { zh: "站点", en: "Sites" },
   sitesTitle: { zh: "静态站点", en: "Static sites" },
-  sitesHostMissing: { zh: "未配置 SITES_HOST,站点访问已禁用", en: "SITES_HOST not set — site visits are disabled" },
+  sitesHostMissing: { zh: "未配置 SITES_HOST，公开地址打不开", en: "SITES_HOST is not set — public URLs will not open" },
   sitesHostMissingHint: {
-    zh: "在 Cloudflare Pages 项目的环境变量中设置 SITES_HOST(如 sites.example.com)并绑定该自定义域,站点才会在此域名下对外服务。详见 docs/sites.md。",
-    en: "Set SITES_HOST as a Cloudflare Pages environment variable (e.g. sites.example.com) and bind that custom domain to serve sites publicly. See docs/sites.md.",
+    zh: "给这个 Pages 项目绑定自定义域，并设置 Pages 环境变量 SITES_HOST（只要主机名，不要 https://），然后重新部署。在此之前公开地址打不开。",
+    en: "Bind a custom domain to this Pages project AND set the Pages env SITES_HOST (hostname only, no https://), then redeploy. Until then public URLs will not open.",
   },
   emptySites: { zh: "还没有站点", en: "No sites yet" },
   emptySitesHint: {
@@ -88,13 +88,13 @@ const entries: Record<string, Entry> = {  searchPlaceholder: { zh: "搜索文件
   },
   flagMcp: { zh: "MCP", en: "MCP" },
   flagMcpHint: {
-    zh: "关闭后 POST /mcp 返回 404。MCP 依赖 API Key：若 API Key 关闭，即使本开关打开也无法使用。",
-    en: "Off: POST /mcp returns 404. MCP requires API Key — if API Key is off, MCP is unusable even when this switch is on.",
+    zh: "关闭后 POST /mcp 返回 404。MCP 依赖 API Key：若 API Key 关闭，即使本开关打开，/mcp 也是 404。",
+    en: "Off: POST /mcp returns 404. MCP depends on the API Key switch — if Key is off, /mcp is 404 even if MCP is on.",
   },
   flagApiKey: { zh: "API Key", en: "API Key" },
   flagApiKeyHint: {
-    zh: "关闭后隐藏密钥管理，Bearer / X-Api-Key 开放接口返回 401。网页会话接口不受影响。MCP 也将不可用。",
-    en: "Off: hide key management; Bearer / X-Api-Key Open API calls return 401. Session APIs keep working. MCP also becomes unusable.",
+    zh: "关闭后隐藏密钥管理，Bearer / X-Api-Key 开放接口返回 401。网页会话接口不受影响。MCP 也会 404：即使 MCP 开关仍打开，/mcp 也不可用。",
+    en: "Off: hide key management; Bearer / X-Api-Key Open API calls return 401. Session APIs keep working. MCP is also 404: if Key is off, /mcp is 404 even if MCP is on.",
   },
   flagSites: { zh: "静态站点", en: "Static sites" },
   flagSitesHint: {
@@ -116,10 +116,10 @@ const entries: Record<string, Entry> = {  searchPlaceholder: { zh: "搜索文件
     zh: "拖放图片上传。公开地址只在站点域名：https://<SITES_HOST>/i/{id}",
     en: "Drop images to upload. Public URLs live only on the sites host: https://<SITES_HOST>/i/{id}",
   },
-  imagesHostMissing: { zh: "未配置 SITES_HOST，图床公开地址不可用", en: "SITES_HOST not set — public image URLs are disabled" },
+  imagesHostMissing: { zh: "未配置 SITES_HOST，公开地址打不开", en: "SITES_HOST is not set — public URLs will not open" },
   imagesHostMissingHint: {
-    zh: "在 Cloudflare Pages 项目的环境变量中设置 SITES_HOST（如 sites.example.com）并绑定该自定义域，图床才会在此域名下以 /i/{id} 对外服务。详见 docs/sites.md。",
-    en: "Set SITES_HOST as a Cloudflare Pages environment variable (e.g. sites.example.com) and bind that custom domain. Images are then served at /i/{id} on that host. See docs/sites.md.",
+    zh: "给这个 Pages 项目绑定自定义域，并设置 Pages 环境变量 SITES_HOST（只要主机名，不要 https://），然后重新部署。在此之前图床公开地址打不开。",
+    en: "Bind a custom domain to this Pages project AND set the Pages env SITES_HOST (hostname only, no https://), then redeploy. Until then public image URLs will not open.",
   },
   emptyImages: { zh: "还没有图片", en: "No images yet" },
   emptyImagesHint: { zh: "把图片拖到这里，或点击上传", en: "Drop an image here, or click upload" },
@@ -137,8 +137,8 @@ const entries: Record<string, Entry> = {  searchPlaceholder: { zh: "搜索文件
   imageUrlCopied: { zh: "链接已复制", en: "URL copied" },
   imageMarkdownCopied: { zh: "Markdown 已复制", en: "Markdown copied" },
   mcpRequiresApiKey: {
-    zh: "MCP 依赖 API Key。关闭 API Key 后 MCP 不可用，即使 MCP 开关仍打开。",
-    en: "MCP depends on API Key. If API Key is off, MCP is unusable even when the MCP switch is on.",
+    zh: "MCP 依赖 API Key 开关：若 API Key 关闭，即使 MCP 开关打开，/mcp 也是 404。",
+    en: "MCP depends on the API Key switch: if Key is off, /mcp is 404 even if MCP is on.",
   },
   siteFilesCount: { zh: "{count} 个文件", en: "{count} file(s)" },
   siteStatsTruncated: { zh: "统计达到扫描上限,数值为下限", en: "Scan cap reached; figures are lower bounds" },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
P0 docs and UI copy only. Can merge independently of P1 (MCP `pull` / `push` / `publish_site` is #35).

## What changed

- **README EN + ZH**: three short, copy-pasteable follow-along paths
  1. Cursor talk → upload to `sites/{slug}/` (uses your bound host; no public demo URL)
  2. Image host drag → copy URL / Markdown
  3. Settings five switches
- **Settings**: MCP depends on the API Key switch — if Key is off, `/mcp` is **404** even if MCP is on
- **Sites + Images**: if `SITES_HOST` is missing, the hint is blunt: bind a custom domain to this Pages project **and** set Pages env `SITES_HOST` (hostname only), then redeploy; until then public URLs will not open

## What did not change

- WebDAV protocol
- MCP tool list (still **15** tools)
- Upload auto-chunk **25 MB** / download `part` / `partSize`
- No public demo site, no `SITES_HOST` probe, no multi-tenant / OAuth / git deploy

Existing README MCP text (15 tools, 25 MB cap, `#/sites`, davflare-cli, `#/settings`, `#/images` at `https://<SITES_HOST>/i/{id}`, MCP requires API Key, PATCH `/api/config` Basic-only) is unchanged except for the added Follow along section.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-140a13b1-0361-4a07-ad85-e9a1bd42f107?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-140a13b1-0361-4a07-ad85-e9a1bd42f107&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

