### PR TITLE
feat: MCP pull, push, and publish_site (18 tools)

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,33 @@ Share (expiry + extract code):
 - Agent layouts on R2: `agents/{global|agent|agent/project}/{skills|rules|mcp}/` (manual pull/push; see [docs/agents.md](docs/agents.md))
 - Chinese / English UI (globe icon in the header; defaults to browser language, persisted locally)
 
+## Follow along
+
+Three short paths. Use **your** bound host — there is no public live demo other people can open.
+
+### Publish a static site from Cursor
+
+1. In `#/settings`, leave **API Key** and **MCP** on. Create a key (account menu → API keys) and paste it into Cursor `mcp.json` as in [MCP](#mcp).
+2. Ask Cursor (copy-paste):
+
+   ```
+   Upload this folder to sites/hello/ on Davflare (mkdir parents, overwrite same names). Then call sites_config for slug hello if this is an SPA.
+   ```
+
+3. Open `https://<SITES_HOST>/hello/` on the hostname you bound to **this** Pages project. Until `SITES_HOST` is set and redeployed, that URL will not open.
+
+### Host an image and copy its URL
+
+1. Open `#/images` in the drive UI.
+2. Drag an image onto the page (or click Upload).
+3. Click **Copy URL** or **Copy Markdown** (`![](https://<SITES_HOST>/i/{id})`). Public URLs only work after you bind a custom domain and set Pages env `SITES_HOST` (hostname only).
+
+### Toggle the five Settings switches
+
+1. Open `#/settings` from the account menu.
+2. The five switches are WebDAV, MCP, API Key, Sites, and Image host (all default on). Stored files are not deleted when a switch is off.
+3. MCP depends on API Key: if Key is off, `/mcp` is 404 even if MCP is on. Sites and image-host public URLs also need `SITES_HOST`.
+
 ## Deploy
 
 One-click:

--- a/README.md
+++ b/README.md
@@ -34,13 +34,13 @@ Share (expiry + extract code):
 - Recycle bin with `TRASH_RETENTION_DAYS` (default 30; `-1` disables; lazy purge up to 200 items when trash is opened)
 - WebDAV Class 1/2 at `/webdav` (can be switched off without affecting the web file manager)
 - API keys for scripted upload, download, and bidirectional sync
-- Remote MCP at `/mcp` (15 tools: files, search, move/copy, shares, sites). Uploads auto-chunk up to 25 MB; downloads page with `part`. **MCP requires an API Key** — if the API Key switch is off, `/mcp` is 404 even when the MCP switch is on
+- Remote MCP at `/mcp` (18 tools: files, search, move/copy, shares, sites, plus `pull` / `push` / `publish_site`). Uploads auto-chunk up to 25 MB; downloads page with `part`. **MCP requires an API Key** — if the API Key switch is off, `/mcp` is 404 even when the MCP switch is on
 - Sites manager in the UI (`#/sites`): zip deploy, SPA toggle, per-site delete
 - Static sites on a separate host (`SITES_HOST` + `sites/{slug}/`); [docs/sites.md](docs/sites.md)
 - Image host on the same sites hostname at `/i/{id}` (stored under `_$flaredrive$/img/`, not `sites/` or share links)
 - Owner Settings (`#/settings`) with five persistent feature switches (default all on)
 - `davflare-cli` for login / ls / mkdir / rm / mv / cp / sync ([cli/README.md](cli/README.md))
-- Agent layouts on R2: `agents/{global|agent|agent/project}/{skills|rules|mcp}/` (manual pull/push; see [docs/agents.md](docs/agents.md))
+- Agent layouts on R2: `agents/{global|agent|agent/project}/{skills|rules|mcp}/` (`pull` / `push` tools; see [docs/agents.md](docs/agents.md))
 - Chinese / English UI (globe icon in the header; defaults to browser language, persisted locally)
 
 ## Follow along
@@ -133,7 +133,7 @@ Create keys in the web UI (「API」 / 「开放接口」). Auth: `Authorization
 | DELETE | `/api/delete` | Hard delete, or `soft=1` to trash |
 | POST | `/api/shares` | Share a file or folder (folder → zip) |
 | GET / POST / DELETE | `/api/sites` | List, SPA-config, or delete static sites |
-| POST | `/mcp` | Remote MCP (JSON-RPC 2.0; same API keys; 15 tools) |
+| POST | `/mcp` | Remote MCP (JSON-RPC 2.0; same API keys; 18 tools) |
 
 Same keys work for a bidirectional sync client (local wins; backup remote on conflict). Details in the [API docs](docs/API.md).
 
@@ -157,9 +157,9 @@ Owner-only Settings (`#/settings`, account menu) persist five flags in R2 at `_$
 
 Same-origin Model Context Protocol (Streamable HTTP) at `/mcp`. Auth is the same API key as the Open API (`Authorization: Bearer <apiKey>` or `X-Api-Key`). **MCP depends on API Key: if the API Key switch is off, MCP is unusable even if the MCP switch is on.**
 
-Tools (15): `list`, `upload`, `download`, `mkdir`, `delete`, `search`, `move`, `copy`, `stat`, `share_create`, `share_list`, `share_revoke`, `sites_list`, `sites_config`, `sites_delete`.
+Tools (18): `list`, `upload`, `download`, `mkdir`, `delete`, `search`, `move`, `copy`, `stat`, `share_create`, `share_list`, `share_revoke`, `sites_list`, `sites_config`, `sites_delete`, `pull`, `push`, `publish_site`.
 
-Uploads up to 1 MiB go inline; larger content is auto-chunked (cap **25 MB**). Bigger files: web UI or `davflare-cli`. Downloads over 1 MiB page with `part` / `partSize`. Default `delete` is trash; `hard=true` permanently deletes. Publish a static site by uploading into `sites/{slug}/`, then `sites_config` if you need SPA fallback. Details: [docs/API.md](docs/API.md).
+Uploads up to 1 MiB go inline; larger content is auto-chunked (cap **25 MB**). Bigger files: web UI or `davflare-cli`. Downloads over 1 MiB page with `part` / `partSize`. Default `delete` is trash; `hard=true` permanently deletes. Publish a static site by uploading into `sites/{slug}/` (or `publish_site` from a drive folder), then `sites_config` if you need SPA fallback. `pull` / `push` walk `agents/…` (merge: project > agent > global). Details: [docs/API.md](docs/API.md).
 
 Cursor (`mcp.json`):
 
@@ -194,7 +194,7 @@ On the sites host, `/i/{id}` is matched **before** slug static sites. The image-
 
 ## Agent layouts
 
-Skills, rules, and MCP snippets live on R2 under `agents/`. v1 is a directory convention plus manual pull/push with the existing MCP tools (or the web UI). Merge order: project > agent > global. Never store raw API keys in `mcp.json` — use `${env:DAVFLARE_API_KEY}`. Cursor local paths and the walk-the-tree recipe: [docs/agents.md](docs/agents.md).
+Skills, rules, and MCP snippets live on R2 under `agents/`. v2 `pull` / `push` walk that tree (or use the web UI). Merge order: project > agent > global. Never store raw API keys in `mcp.json` — use `${env:DAVFLARE_API_KEY}`. Cursor local paths: [docs/agents.md](docs/agents.md).
 
 ## Development & testing
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -41,6 +41,33 @@
 - Agent 目录约定：`agents/{global|agent|agent/project}/{skills|rules|mcp}/`（手动拉取/推送，见 [docs/agents.zh-CN.md](docs/agents.zh-CN.md)）
 - 中 / 英界面（标题栏地球图标；默认跟随浏览器语言，并保存在本地）
 
+## 跟着做
+
+三条短路径。请用**你自己绑定的域名**——没有别人能打开的公开演示站。
+
+### 用 Cursor 对话发布静态站
+
+1. 在 `#/settings` 保持 **API Key** 和 **MCP** 打开。创建一把密钥（账号菜单 → 开放接口），按 [MCP](#mcp) 写进 Cursor 的 `mcp.json`。
+2. 对 Cursor 说（可直接粘贴）：
+
+   ```
+   把这个文件夹上传到 Davflare 的 sites/hello/（自动建父目录，同名覆盖）。如果是 SPA，再对 slug hello 调用 sites_config。
+   ```
+
+3. 在你绑到**本** Pages 项目的主机上打开 `https://<SITES_HOST>/hello/`。未设置 `SITES_HOST` 并重新部署之前，这个地址打不开。
+
+### 图床拖放并复制链接
+
+1. 打开网盘里的 `#/images`。
+2. 把图片拖到页面上（或点上传）。
+3. 点 **复制链接** 或 **复制 Markdown**（`![](https://<SITES_HOST>/i/{id})`）。公开地址只有在绑定自定义域并设置 Pages 环境变量 `SITES_HOST`（只要主机名）之后才可用。
+
+### 设置里的五个开关
+
+1. 从账号菜单打开 `#/settings`。
+2. 五个开关是 WebDAV、MCP、API Key、静态站点、图床（默认全部开启）。关闭开关不会删除已有文件。
+3. MCP 依赖 API Key：Key 关闭时，即使 MCP 打开，`/mcp` 也是 404。站点和图床的公开地址还需要 `SITES_HOST`。
+
 ## 部署
 
 一键部署：

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -32,13 +32,13 @@
 - 回收站，由 `TRASH_RETENTION_DAYS` 控制（默认 30 天；`-1` 关闭；打开回收站时惰性清理最多 200 项）
 - WebDAV Class 1/2，路径 `/webdav`（可关闭，不影响网页端文件管理）
 - API Key，可用于脚本上传、下载与双向同步
-- 远程 MCP，路径 `/mcp`（15 个工具：文件、搜索、移动/复制、分享、站点）。上传超过 1 MiB 自动分块，上限 25 MB；下载用 `part` 分页。**MCP 依赖 API Key**：若 API Key 开关关闭，即使 MCP 开关打开，`/mcp` 也是 404
+- 远程 MCP，路径 `/mcp`（18 个工具：文件、搜索、移动/复制、分享、站点，以及 `pull` / `push` / `publish_site`）。上传超过 1 MiB 自动分块，上限 25 MB；下载用 `part` 分页。**MCP 依赖 API Key**：若 API Key 开关关闭，即使 MCP 开关打开，`/mcp` 也是 404
 - 网页端站点管理（`#/sites`）：zip 一键部署、SPA 开关、按站删除
 - 静态站点走单独域名（`SITES_HOST` + `sites/{slug}/`）；[docs/sites.zh-CN.md](docs/sites.zh-CN.md)
 - 图床走同一站点域名的 `/i/{id}`（对象存在 `_$flaredrive$/img/`，不与 `sites/` 或分享链接混用）
 - 拥有者设置页（`#/settings`）五个功能开关（默认全部开启，持久化到 R2）
 - `davflare-cli`：login / ls / mkdir / rm / mv / cp / sync（[cli/README.md](cli/README.md)）
-- Agent 目录约定：`agents/{global|agent|agent/project}/{skills|rules|mcp}/`（手动拉取/推送，见 [docs/agents.zh-CN.md](docs/agents.zh-CN.md)）
+- Agent 目录约定：`agents/{global|agent|agent/project}/{skills|rules|mcp}/`（`pull` / `push` 工具，见 [docs/agents.zh-CN.md](docs/agents.zh-CN.md)）
 - 中 / 英界面（标题栏地球图标；默认跟随浏览器语言，并保存在本地）
 
 ## 跟着做
@@ -131,7 +131,7 @@ Cloudflare Workers 单次 PUT 上限为 **128 MB**。超限会返回 **HTTP 413*
 | DELETE | `/api/delete` | 硬删除，或 `soft=1` 进回收站 |
 | POST | `/api/shares` | 分享文件或文件夹（文件夹为 zip） |
 | GET / POST / DELETE | `/api/sites` | 列出、配置 SPA、删除静态站 |
-| POST | `/mcp` | 远程 MCP（JSON-RPC 2.0；同一把 API 密钥；15 个工具） |
+| POST | `/mcp` | 远程 MCP（JSON-RPC 2.0；同一把 API 密钥；18 个工具） |
 
 同一把密钥可做双向同步（本地优先，冲突时先备份远端）。详见 [开放接口文档](docs/API.zh-CN.md)。
 
@@ -155,9 +155,9 @@ Cloudflare Workers 单次 PUT 上限为 **128 MB**。超限会返回 **HTTP 413*
 
 同源 Model Context Protocol（Streamable HTTP），路径 `POST /mcp`。鉴权与开放接口相同（`Authorization: Bearer <apiKey>` 或 `X-Api-Key`）。**MCP 依赖 API Key：API Key 开关关闭后，即使 MCP 开关仍打开也无法使用。**
 
-工具（15 个）：`list`、`upload`、`download`、`mkdir`、`delete`、`search`、`move`、`copy`、`stat`、`share_create`、`share_list`、`share_revoke`、`sites_list`、`sites_config`、`sites_delete`。
+工具（18 个）：`list`、`upload`、`download`、`mkdir`、`delete`、`search`、`move`、`copy`、`stat`、`share_create`、`share_list`、`share_revoke`、`sites_list`、`sites_config`、`sites_delete`、`pull`、`push`、`publish_site`。
 
-不超过 1 MiB 的上传走内联；更大内容自动分块（上限 **25 MB**）。再大请用网页端或 `davflare-cli`。下载超过 1 MiB 用 `part` / `partSize` 分页。`delete` 默认进回收站，`hard=true` 永久删除。把文件上传到 `sites/{slug}/` 即发布静态站，需要 SPA 回退再调 `sites_config`。详见 [docs/API.zh-CN.md](docs/API.zh-CN.md)。
+不超过 1 MiB 的上传走内联；更大内容自动分块（上限 **25 MB**）。再大请用网页端或 `davflare-cli`。下载超过 1 MiB 用 `part` / `partSize` 分页。`delete` 默认进回收站，`hard=true` 永久删除。把文件上传到 `sites/{slug}/`（或用 `publish_site` 从网盘目录同步）即发布静态站，需要 SPA 回退再调 `sites_config`。`pull` / `push` 走 `agents/…`（合并：project 覆盖 agent 覆盖 global）。详见 [docs/API.zh-CN.md](docs/API.zh-CN.md)。
 
 Cursor（`mcp.json`）：
 
@@ -192,7 +192,7 @@ Cursor（`mcp.json`）：
 
 ## Agent 目录
 
-skills / rules / MCP 片段放在 R2 的 `agents/` 下。v1 只是目录约定 + 用现有 MCP 工具（或网页端）手动拉取/推送。合并顺序：project 覆盖 agent 覆盖 global。`mcp.json` 里不要存明文密钥，用 `${env:DAVFLARE_API_KEY}`。Cursor 落地路径和走目录步骤见 [docs/agents.zh-CN.md](docs/agents.zh-CN.md)。
+skills / rules / MCP 片段放在 R2 的 `agents/` 下。v2 的 `pull` / `push` 会走这棵树（也可用网页端）。合并顺序：project 覆盖 agent 覆盖 global。`mcp.json` 里不要存明文密钥，用 `${env:DAVFLARE_API_KEY}`。Cursor 落地路径见 [docs/agents.zh-CN.md](docs/agents.zh-CN.md)。
 
 ## 开发与测试
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -180,7 +180,7 @@ Public URL: `https://<SITES_HOST>/i/{id}`. SVG responses use `Content-Dispositio
 
 ### MCP
 
-Same-origin Streamable HTTP MCP at `POST /mcp` (JSON-RPC 2.0). Auth is the same `Authorization: Bearer <apiKey>` or `X-Api-Key` as the rest of this API (no web session, no OAuth). **MCP depends on the API Key switch** — if API Key is off (or MCP is off), `/mcp` returns **404**. Missing or invalid keys return **HTTP 401**. Tools: `list`, `upload`, `download`, `mkdir`, `delete`, `search`, `move`, `copy`, `stat`, `share_create`, `share_list`, `share_revoke`, `sites_list`, `sites_config`, `sites_delete` (they wrap the Open API handlers above). Uploads over 1 MiB are automatically sent in multipart chunks (cap **25 MB**; larger returns a tool error — use the web UI or scripts). Downloads over 1 MiB page with `part` / `partSize` (base64 slices). Default `delete` is soft-delete to trash; pass `hard=true` to permanently delete. `sites_*` manage the static sites under `sites/` (see [sites.md](./sites.md)); `upload`/`delete` also work directly on `sites/<slug>/` keys.
+Same-origin Streamable HTTP MCP at `POST /mcp` (JSON-RPC 2.0). Auth is the same `Authorization: Bearer <apiKey>` or `X-Api-Key` as the rest of this API (no web session, no OAuth). **MCP depends on the API Key switch** — if API Key is off (or MCP is off), `/mcp` returns **404**. Missing or invalid keys return **HTTP 401**. Tools: `list`, `upload`, `download`, `mkdir`, `delete`, `search`, `move`, `copy`, `stat`, `share_create`, `share_list`, `share_revoke`, `sites_list`, `sites_config`, `sites_delete`, `pull`, `push`, `publish_site` (they wrap the Open API handlers above). Uploads over 1 MiB are automatically sent in multipart chunks (cap **25 MB**; larger returns a tool error — use the web UI or scripts). Downloads over 1 MiB page with `part` / `partSize` (base64 slices). Default `delete` is soft-delete to trash; pass `hard=true` to permanently delete. `sites_*` manage the static sites under `sites/` (see [sites.md](./sites.md)); `upload`/`delete` also work directly on `sites/<slug>/` keys. `pull` walks `agents/{global|agent|agent/project}/{skills|rules|mcp}/` and returns layered files (merge: project > agent > global); large files page like `download`. `push` writes that tree (`mcp.json` must use `${env:...}`, not raw keys). `publish_site` copies a drive folder onto `sites/{slug}/` (overwrite same names; SPA config is kept; 404 if the Sites switch is off).
 
 ```bash
 # initialize
@@ -213,7 +213,7 @@ Cursor (`mcp.json`):
 
 ### Agent layouts
 
-Skills / rules / MCP snippets: `agents/{global|{agent}|{agent}/{project}}/{skills|rules|mcp}/`. v1 is manual (existing list/upload/download/mkdir/delete or the web UI). Merge: project > agent > global. Do not store raw keys in `mcp.json`. Full convention: [agents.md](./agents.md).
+Skills / rules / MCP snippets: `agents/{global|{agent}|{agent}/{project}}/{skills|rules|mcp}/`. v2 `pull` / `push` walk this tree (or use the web UI). Merge: project > agent > global. Do not store raw keys in `mcp.json`. Full convention: [agents.md](./agents.md).
 
 ### Bidirectional sync recipe
 

--- a/docs/API.zh-CN.md
+++ b/docs/API.zh-CN.md
@@ -168,7 +168,7 @@ curl -X DELETE "https://<your-domain.com>/api/images?id=<id>" \
 
 ### MCP
 
-同源 Streamable HTTP MCP：`POST /mcp`（JSON-RPC 2.0）。鉴权与其它开放接口相同（`Authorization: Bearer <apiKey>` 或 `X-Api-Key`；不走网页会话，无 OAuth）。**MCP 依赖 API Key 开关** —— API Key 关闭（或 MCP 关闭）时 `/mcp` 返回 **404**。密钥缺失或无效返回 **HTTP 401**。工具：`list`、`upload`、`download`、`mkdir`、`delete`、`search`、`move`、`copy`、`stat`、`share_create`、`share_list`、`share_revoke`、`sites_list`、`sites_config`、`sites_delete`（包装上方 Open API）。超过 1 MiB 的上传自动改走分块（上限 **25 MB**；再大返回工具错误，请用网页端或 davflare-cli）。下载超过 1 MiB 用 `part` / `partSize` 分页。`delete` 默认进回收站；`hard=true` 为永久删除。`sites_*` 管理 `sites/` 下的静态站；`upload` / `delete` 也可以直接操作 `sites/<slug>/`。
+同源 Streamable HTTP MCP：`POST /mcp`（JSON-RPC 2.0）。鉴权与其它开放接口相同（`Authorization: Bearer <apiKey>` 或 `X-Api-Key`；不走网页会话，无 OAuth）。**MCP 依赖 API Key 开关** —— API Key 关闭（或 MCP 关闭）时 `/mcp` 返回 **404**。密钥缺失或无效返回 **HTTP 401**。工具：`list`、`upload`、`download`、`mkdir`、`delete`、`search`、`move`、`copy`、`stat`、`share_create`、`share_list`、`share_revoke`、`sites_list`、`sites_config`、`sites_delete`、`pull`、`push`、`publish_site`（包装上方 Open API）。超过 1 MiB 的上传自动改走分块（上限 **25 MB**；再大返回工具错误，请用网页端或 davflare-cli）。下载超过 1 MiB 用 `part` / `partSize` 分页。`delete` 默认进回收站；`hard=true` 为永久删除。`sites_*` 管理 `sites/` 下的静态站；`upload` / `delete` 也可以直接操作 `sites/<slug>/`。`pull` 走 `agents/{global|agent|agent/project}/{skills|rules|mcp}/` 并返回分层文件（合并：project 覆盖 agent 覆盖 global）；大文件与 `download` 一样分页。`push` 写入该树（`mcp.json` 只能用 `${env:...}`，不要明文密钥）。`publish_site` 把网盘目录同步到 `sites/{slug}/`（同名覆盖，不删 SPA 配置；站点开关关闭时 404）。
 
 ```bash
 # initialize
@@ -201,7 +201,7 @@ Cursor（`mcp.json`）：
 
 ### Agent 目录
 
-skills / rules / MCP 片段：`agents/{global|{agent}|{agent}/{project}}/{skills|rules|mcp}/`。v1 手动（现有 list/upload/download/mkdir/delete 或网页端）。合并：project 覆盖 agent 覆盖 global。`mcp.json` 不要明文密钥。完整约定：[agents.zh-CN.md](./agents.zh-CN.md)。
+skills / rules / MCP 片段：`agents/{global|{agent}|{agent}/{project}}/{skills|rules|mcp}/`。v2 的 `pull` / `push` 会走这棵树（也可用网页端）。合并：project 覆盖 agent 覆盖 global。`mcp.json` 不要明文密钥。完整约定：[agents.zh-CN.md](./agents.zh-CN.md)。
 
 ### 双向同步示例
 

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -1,6 +1,6 @@
-# Davflare agent layouts (v1)
+# Davflare agent layouts (v2)
 
-Store Cursor (and later Codex / Claude / OpenCode) **skills**, **rules**, and **MCP** snippets on R2 using a fixed directory tree. v1 is a **convention + manual pull/push** with the existing MCP tools (or the web UI). No file watcher. Secrets are not stored as files.
+Store Cursor (and later Codex / Claude / OpenCode) **skills**, **rules**, and **MCP** snippets on R2 using a fixed directory tree. v2 adds MCP `pull` / `push` that walk this tree (the web UI still works). No file watcher. Secrets are not stored as files.
 
 Merge order when the same name exists at more than one layer: **project > agent > global**.
 
@@ -38,7 +38,7 @@ Example keys:
 - `agents/cursor/Davflare/skills/pages-deploy/SKILL.md`
 - `agents/cursor/Davflare/mcp/mcp.json`
 
-## Cursor local paths (v1)
+## Cursor local paths
 
 | Layer | skills | rules | mcp |
 | --- | --- | --- | --- |
@@ -62,19 +62,17 @@ Safe remote `mcp.json` (store this, not a live key):
 }
 ```
 
-## Manual pull / push (v1)
+## pull / push (v2)
 
-`GET /api/list` and the MCP `list` tool are **depth 1**. Walk each folder yourself.
+`GET /api/list` and the MCP `list` tool are still **depth 1**. Use `pull` / `push` instead of walking by hand.
 
-Pull (remote → Cursor), project first:
+`pull` args: `agent` (optional, e.g. `cursor`), `project` (optional; requires `agent`), `type` optional filter (`skills` | `rules` | `mcp`). It walks `agents/{global|agent|agent/project}/{skills|rules|mcp}/` and returns the tree plus file contents. Each file is tagged with `layer`, `rel`, and the remote `key`. Merge order for the client: **project > agent > global**. Files larger than 1 MiB page with `part` / `partSize` like `download`.
 
-1. `list` `agents/cursor/<project>/skills/` (then `rules/`, `mcp/`) → `download` each file into the project `.cursor/…` paths above.
-2. Same for `agents/cursor/{skills,rules,mcp}/` → user-level Cursor paths. Skip a file if the project layer already provided that name.
-3. Same for `agents/global/…`.
+`push` args: the same `agent` / `project` plus `files: [{ path, content, encoding? }]`. Paths are relative to that layer root (omit both → `agents/global/`). Parents are created as needed. `mcp.json` must use `${env:...}` placeholders — raw API keys (`fd_…`, `Bearer` tokens that are not `${env:…}`) are rejected. No local disk watcher; the agent calls the tool with file contents.
 
-Push (Cursor → remote): `mkdir` the remote folder, then `upload` (or the web UI). Strip secrets from `mcp.json` before upload. MCP uploads over 1 MiB auto-chunk (cap 25 MB); bigger files go through the web UI or davflare-cli.
+The depth-1 `list` + `download` / `upload` recipe still works if you need it. MCP uploads over 1 MiB auto-chunk (cap 25 MB); bigger files go through the web UI or davflare-cli.
 
-v2 will add `pull` / `push` tools that walk this tree. v3 will add other agents and conflict policy. Until then, do not auto-sync and do not watch the local disk.
+v3 may add other agents and conflict policy. Do not auto-sync and do not watch the local disk.
 
 ## Web UI
 

--- a/docs/agents.zh-CN.md
+++ b/docs/agents.zh-CN.md
@@ -1,6 +1,6 @@
-# Davflare Agent 目录约定（v1）
+# Davflare Agent 目录约定（v2）
 
-把 Cursor（以及后续 Codex / Claude / OpenCode）的 **skills**、**rules**、**MCP 片段**按固定目录放进 R2。v1 只是**约定 + 手动拉取/推送**：用现有 MCP 工具或网页端即可。不做文件监听。密钥不当文件存。
+把 Cursor（以及后续 Codex / Claude / OpenCode）的 **skills**、**rules**、**MCP 片段**按固定目录放进 R2。v2 增加 MCP `pull` / `push` 自动走这棵树（网页端仍可用）。不做文件监听。密钥不当文件存。
 
 同名文件的合并顺序：**project 覆盖 agent 覆盖 global**。
 
@@ -38,7 +38,7 @@ agent 用小写（`cursor`，不要 `Cursor`）。project 与仓库/工作区名
 - `agents/cursor/Davflare/skills/pages-deploy/SKILL.md`
 - `agents/cursor/Davflare/mcp/mcp.json`
 
-## Cursor 落地路径（v1）
+## Cursor 落地路径
 
 | 层 | skills | rules | mcp |
 | --- | --- | --- | --- |
@@ -62,19 +62,17 @@ Cursor 的 `mcp.json` 支持在 `headers` / `url` 里写 `${env:NAME}`。用这�
 }
 ```
 
-## 手动拉取 / 推送（v1）
+## pull / push（v2）
 
-`GET /api/list` 和 MCP `list` 都是 **Depth 1**，要自己一层层走。
+`GET /api/list` 和 MCP `list` 仍是 **Depth 1**。请用 `pull` / `push`，不必手走目录。
 
-拉取（远端 → Cursor），先 project：
+`pull` 参数：`agent`（可选，如 `cursor`）、`project`（可选；需要 `agent`）、`type` 可选过滤（`skills` | `rules` | `mcp`）。会走 `agents/{global|agent|agent/project}/{skills|rules|mcp}/`，返回目录树和文件内容。每个文件带 `layer`、`rel` 和远端 `key`。客户端合并顺序：**project 覆盖 agent 覆盖 global**。超过 1 MiB 的文件与 `download` 一样用 `part` / `partSize` 分页。
 
-1. `list` `agents/cursor/<project>/skills/`（再 `rules/`、`mcp/`）→ `download` 到上表的项目 `.cursor/…`。
-2. 再处理 `agents/cursor/{skills,rules,mcp}/` → 用户级路径。project 层已经有的同名文件跳过。
-3. 最后 `agents/global/…`。
+`push` 参数：同样的 `agent` / `project`，加上 `files: [{ path, content, encoding? }]`。路径相对该层根目录（两者都省略则写 `agents/global/`）。需要时自动建父目录。`mcp.json` 必须用 `${env:...}` 占位符——明文密钥（`fd_…`、不是 `${env:…}` 的 `Bearer`）会被拒绝。没有本地磁盘监听；由 agent 带着文件内容调用工具。
 
-推送（Cursor → 远端）：先 `mkdir` 远端目录，再 `upload`（或网页端）。上传 `mcp.json` 前去掉密钥。MCP 上传超过 1 MiB 会自动分块（上限 25 MB）；再大走网页端或 davflare-cli。
+需要时仍可用 Depth-1 的 `list` + `download` / `upload`。MCP 上传超过 1 MiB 会自动分块（上限 25 MB）；再大走网页端或 davflare-cli。
 
-v2 会加 `pull` / `push` 两个工具自动走这棵树。v3 再接其它 agent 和冲突策略。在此之前不要自动同步、不要监听本地磁盘。
+v3 可能再接其它 agent 和冲突策略。不要自动同步、不要监听本地磁盘。
 
 ## 网页端
 

--- a/docs/sites.md
+++ b/docs/sites.md
@@ -16,7 +16,7 @@ On this host, `/i/{id}` (image host) is matched **first**, then slug static site
 
 ## Publish
 
-Upload a folder to `sites/{slug}/` (web UI Sites zip deploy, Open API, MCP `mkdir` + `upload`, or davflare-cli cp/sync). `{slug}` is `[a-z0-9][a-z0-9-]{0,62}`.
+Upload a folder to `sites/{slug}/` (web UI Sites zip deploy, Open API, MCP `mkdir` + `upload`, MCP `publish_site` from a drive folder, or davflare-cli cp/sync). `{slug}` is `[a-z0-9][a-z0-9-]{0,62}`.
 
 ```
 sites/blog/index.html
@@ -28,7 +28,7 @@ Then open `https://sites.<your-domain>/blog/` (or `/blog/style.css`). Missing fi
 ## Management API & UI
 
 - Web UI: open the **Sites** section (`#/sites`) — list sites with stats, one-click zip deploy (client-side unzip + upload queue), SPA toggle, per-site delete. "Manage files" jumps into the regular file manager at `sites/<slug>/`.
-- MCP: `sites_list`, `sites_config`, `sites_delete` (same `/api/sites` handlers).
+- MCP: `sites_list`, `sites_config`, `sites_delete` (same `/api/sites` handlers). `publish_site` copies a drive folder onto `sites/{slug}/` (overwrite same names; SPA config is kept).
 - `GET /api/sites` — list sites (`?stats=1` adds cached object count / total size). Session (Basic) or API key.
 - `POST /api/sites` — `{"slug":"blog","spa":true}` toggles SPA fallback. The site must already exist.
 - `DELETE /api/sites?slug=blog` — remove all site files (config kept, so a redeploy keeps the SPA flag); add `&purge=1` to also delete the config.

--- a/docs/sites.zh-CN.md
+++ b/docs/sites.zh-CN.md
@@ -16,7 +16,7 @@
 
 ## 发布
 
-把目录上传到 `sites/{slug}/`（网页端站点 zip 部署、开放接口、MCP 的 `mkdir` + `upload`，或 davflare-cli cp/sync）。`{slug}` 为 `[a-z0-9][a-z0-9-]{0,62}`。
+把目录上传到 `sites/{slug}/`（网页端站点 zip 部署、开放接口、MCP 的 `mkdir` + `upload`、MCP `publish_site` 从网盘目录同步，或 davflare-cli cp/sync）。`{slug}` 为 `[a-z0-9][a-z0-9-]{0,62}`。
 
 ```
 sites/blog/index.html
@@ -28,7 +28,7 @@ sites/blog/style.css
 ## 管理 API 与界面
 
 - 网页端：打开「站点」区块（`#/sites`）——站点列表与统计、zip 一键部署（浏览器解压后走上传队列）、SPA 开关、按站删除；「管理文件」直接跳到 `sites/<slug>/` 的常规文件管理器。
-- MCP：`sites_list`、`sites_config`、`sites_delete`（同一套 `/api/sites`）。
+- MCP：`sites_list`、`sites_config`、`sites_delete`（同一套 `/api/sites`）。`publish_site` 把网盘目录同步到 `sites/{slug}/`（同名覆盖，不删 SPA 配置）。
 - `GET /api/sites` — 列站点（`?stats=1` 附带缓存的文件数/总大小）。会话（Basic）或 API key 均可。
 - `POST /api/sites` — `{"slug":"blog","spa":true}` 切换 SPA 回退；站点需已存在。
 - `DELETE /api/sites?slug=blog` — 删除站点全部文件（保留配置，重新部署同 slug 时 SPA 开关仍在）；加 `&purge=1` 连配置一起删。

--- a/functions/_mcp.ts
+++ b/functions/_mcp.ts
@@ -106,6 +106,8 @@ export type ToolCallApis = {
   sitesList: (query: { withStats?: boolean }) => Promise<Response>;
   sitesConfig: (query: { slug: string; spa: boolean }) => Promise<Response>;
   sitesDelete: (query: { slug: string; purge?: boolean }) => Promise<Response>;
+  /** Product Sites switch; publish_site is 404 when false. */
+  sitesEnabled: () => Promise<boolean>;
 };
 
 export const MCP_TOOLS = [
@@ -367,6 +369,85 @@ export const MCP_TOOLS = [
         },
       },
       required: ["slug"],
+    },
+  },
+  {
+    name: "pull",
+    description:
+      "Walk agents/{global|agent|agent/project}/{skills|rules|mcp}/ and return the tree plus file contents. Merge order for the client: project > agent > global (files are tagged with layer and remote key). Large files page with part/partSize like download.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        agent: {
+          type: "string",
+          description: "Optional agent slug, e.g. cursor. Omit to read the global layer only.",
+        },
+        project: {
+          type: "string",
+          description: "Optional project/workspace name under that agent. Requires agent.",
+        },
+        type: {
+          type: "string",
+          enum: ["skills", "rules", "mcp"],
+          description: "Optional folder filter (skills, rules, or mcp)",
+        },
+      },
+    },
+  },
+  {
+    name: "push",
+    description:
+      "Upload files into agents/{global|agent|agent/project}/ (mkdir as needed). mcp.json must use ${env:...} placeholders — raw API keys are rejected. No local disk watcher; pass file contents.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        agent: {
+          type: "string",
+          description: "Optional agent slug, e.g. cursor. Omit to write the global layer.",
+        },
+        project: {
+          type: "string",
+          description: "Optional project/workspace name. Requires agent.",
+        },
+        files: {
+          type: "array",
+          description: "Files relative to that layer root, e.g. skills/commit/SKILL.md or mcp/mcp.json",
+          items: {
+            type: "object",
+            properties: {
+              path: { type: "string", description: "Relative path under the layer root" },
+              content: { type: "string", description: "File content (utf8 text or base64)" },
+              encoding: {
+                type: "string",
+                enum: ["utf8", "base64"],
+                default: "utf8",
+                description: "How to decode content; default utf8",
+              },
+            },
+            required: ["path", "content"],
+          },
+        },
+      },
+      required: ["files"],
+    },
+  },
+  {
+    name: "publish_site",
+    description:
+      "Copy a drive folder onto sites/{slug}/ (overwrite same names; does not wipe SPA config). Slug is [a-z0-9][a-z0-9-]{0,62}. Errors if the Sites feature switch is off.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        slug: {
+          type: "string",
+          description: "Site slug [a-z0-9][a-z0-9-]{0,62}",
+        },
+        source: {
+          type: "string",
+          description: "Source folder key in the drive",
+        },
+      },
+      required: ["slug", "source"],
     },
   },
 ] as const;
@@ -649,6 +730,283 @@ function asOptionalBoolean(value: unknown): boolean | undefined {
   return typeof value === "boolean" ? value : undefined;
 }
 
+export const AGENT_LAYOUT_TYPES = ["skills", "rules", "mcp"] as const;
+export type AgentLayoutType = (typeof AGENT_LAYOUT_TYPES)[number];
+export const AGENT_MERGE_ORDER = ["project", "agent", "global"] as const;
+export type AgentLayer = (typeof AGENT_MERGE_ORDER)[number];
+export const AGENT_WALK_ORDER: AgentLayer[] = ["global", "agent", "project"];
+
+const SITE_SLUG_RE = /^[a-z0-9][a-z0-9-]{0,62}$/;
+const AGENT_SLUG_RE = /^[a-z0-9][a-z0-9-]{0,62}$/;
+
+export function isSiteSlug(slug: string): boolean {
+  return SITE_SLUG_RE.test(slug);
+}
+
+export function isAgentLayoutType(value: string): value is AgentLayoutType {
+  return (AGENT_LAYOUT_TYPES as readonly string[]).includes(value);
+}
+
+/** Davflare keys (`fd_` + hex) or Bearer / Authorization values that are not `${env:...}`. */
+export function mcpJsonHasRawSecrets(text: string): boolean {
+  if (/\bfd_[0-9a-fA-F]{16,}\b/.test(text)) return true;
+  const bearer = /Bearer\s+(\S+)/gi;
+  let match: RegExpExecArray | null;
+  while ((match = bearer.exec(text))) {
+    const token = match[1].replace(/[,"']+$/g, "");
+    if (!/^\$\{env:[^}]+\}/i.test(token)) return true;
+  }
+  if (/"X-Api-Key"\s*:\s*"(?!\$\{env:)[^"]+"/i.test(text)) return true;
+  if (/"Authorization"\s*:\s*"(?!Bearer \$\{env:)[^"]+"/i.test(text)) return true;
+  return false;
+}
+
+function normalizeAgentSlug(raw: string): string | { error: string } {
+  const slug = raw.trim().toLowerCase();
+  if (!slug) return { error: "agent is empty" };
+  if (slug === "global") {
+    return { error: "omit agent to use the global layer; 'global' is not an agent slug" };
+  }
+  if (!AGENT_SLUG_RE.test(slug)) {
+    return { error: "agent must be a lowercase slug like cursor" };
+  }
+  return slug;
+}
+
+function normalizeProjectName(raw: string): string | { error: string } {
+  const name = raw.trim();
+  if (!name) return { error: "project is empty" };
+  if (
+    name.includes("/") ||
+    name.includes("\\") ||
+    name === "." ||
+    name === ".." ||
+    name.includes("..")
+  ) {
+    return { error: "project must be a single path segment" };
+  }
+  if ((AGENT_LAYOUT_TYPES as readonly string[]).includes(name)) {
+    return { error: "project cannot be skills, rules, or mcp" };
+  }
+  return name;
+}
+
+export function agentLayerPrefixes(opts: {
+  agent?: string;
+  project?: string;
+  type?: string;
+}):
+  | { ok: true; typeFilter: AgentLayoutType | null; layers: Array<{ layer: AgentLayer; prefix: string }> }
+  | { ok: false; error: string } {
+  const typeRaw = typeof opts.type === "string" ? opts.type.trim().toLowerCase() : "";
+  if (typeRaw && !isAgentLayoutType(typeRaw)) {
+    return { ok: false, error: "type must be skills, rules, or mcp" };
+  }
+  const typeFilter = typeRaw ? (typeRaw as AgentLayoutType) : null;
+
+  let agent: string | undefined;
+  if (opts.agent !== undefined && opts.agent !== "") {
+    const parsed = normalizeAgentSlug(opts.agent);
+    if (typeof parsed !== "string") return { ok: false, error: parsed.error };
+    agent = parsed;
+  }
+  let project: string | undefined;
+  if (opts.project !== undefined && opts.project !== "") {
+    if (!agent) return { ok: false, error: "project requires agent" };
+    const parsed = normalizeProjectName(opts.project);
+    if (typeof parsed !== "string") return { ok: false, error: parsed.error };
+    project = parsed;
+  }
+
+  const layers: Array<{ layer: AgentLayer; prefix: string }> = [
+    { layer: "global", prefix: "agents/global/" },
+  ];
+  if (agent) layers.push({ layer: "agent", prefix: `agents/${agent}/` });
+  if (agent && project) {
+    layers.push({ layer: "project", prefix: `agents/${agent}/${project}/` });
+  }
+  return { ok: true, typeFilter, layers };
+}
+
+export function agentPushPrefix(opts: { agent?: string; project?: string }):
+  | { ok: true; prefix: string; layer: AgentLayer }
+  | { ok: false; error: string } {
+  const parsed = agentLayerPrefixes(opts);
+  if (!parsed.ok) return parsed;
+  const last = parsed.layers[parsed.layers.length - 1];
+  return { ok: true, prefix: last.prefix, layer: last.layer };
+}
+
+export function sanitizeAgentRelPath(raw: string): string | { error: string } {
+  const trimmed = raw.trim().replace(/^\/+/, "");
+  if (!trimmed) return { error: "path is required" };
+  const parts = trimmed.split("/").filter((part) => part && part !== ".");
+  if (parts.length === 0) return { error: "path is required" };
+  if (parts.some((part) => part === ".." || part === "\\" || part.includes("\\"))) {
+    return { error: "path cannot contain '..'" };
+  }
+  return parts.join("/");
+}
+
+type ListedItem = { key: string; name: string; isDir: boolean; size: number };
+
+async function listFolderPages(
+  apis: ToolCallApis,
+  path: string
+): Promise<ListedItem[] | { error: string } | "missing"> {
+  const items: ListedItem[] = [];
+  let cursor: string | undefined;
+  do {
+    const response = await apis.list({ path, limit: 1000, cursor });
+    if (response.status === 404) return "missing";
+    if (response.status === 400) {
+      const text = await response.text();
+      return { error: text || "path is not a folder" };
+    }
+    if (!response.ok) {
+      const text = await response.text();
+      return { error: text || `HTTP ${response.status}` };
+    }
+    const body = await readJsonBody(response);
+    if (!body || !Array.isArray(body.items)) {
+      return { error: "list returned unexpected JSON" };
+    }
+    for (const item of body.items) {
+      if (!isPlainObject(item) || typeof item.key !== "string" || !item.key) continue;
+      items.push({
+        key: item.key.replace(/\/+$/, ""),
+        name: typeof item.name === "string" ? item.name : item.key,
+        isDir: item.isDir === true,
+        size: typeof item.size === "number" ? item.size : 0,
+      });
+    }
+    cursor = typeof body.nextCursor === "string" ? body.nextCursor : undefined;
+  } while (cursor);
+  return items;
+}
+
+async function walkFolderFiles(
+  apis: ToolCallApis,
+  root: string
+): Promise<{ files: ListedItem[] } | { error: string } | "missing"> {
+  const folder = root.replace(/\/+$/, "");
+  const first = await listFolderPages(apis, folder);
+  if (first === "missing") return "missing";
+  if ("error" in first) return first;
+  const files: ListedItem[] = [];
+  const queue: string[] = [];
+  const seen = new Set<string>([folder]);
+  for (const item of first) {
+    if (item.isDir) queue.push(item.key);
+    else files.push(item);
+  }
+  while (queue.length) {
+    const next = queue.shift()!;
+    if (seen.has(next)) continue;
+    seen.add(next);
+    const listed = await listFolderPages(apis, next);
+    if (listed === "missing") continue;
+    if ("error" in listed) return listed;
+    for (const item of listed) {
+      if (item.isDir) {
+        if (!seen.has(item.key)) queue.push(item.key);
+      } else {
+        files.push(item);
+      }
+    }
+  }
+  return { files };
+}
+
+async function readPulledFile(
+  apis: ToolCallApis,
+  key: string
+): Promise<Record<string, unknown> | { error: string }> {
+  const statResponse = await apis.stat({ path: key });
+  if (statResponse.ok) {
+    const stat = await readJsonBody(statResponse);
+    const size = stat && typeof stat.size === "number" ? stat.size : NaN;
+    if (Number.isFinite(size) && size > MCP_MAX_BYTES) {
+      const paged = await downloadPartTool(apis, key, 1, MCP_DOWNLOAD_PART_SIZE);
+      if (paged.isError) {
+        return { error: paged.content[0]?.text || "paged download failed" };
+      }
+      try {
+        const parsed = JSON.parse(paged.content[0].text) as Record<string, unknown>;
+        return {
+          ...parsed,
+          key,
+          size,
+          note: "File larger than 1 MiB. Use download with part=N to read the rest.",
+        };
+      } catch {
+        return { error: "paged download returned unexpected JSON" };
+      }
+    }
+  }
+  const response = await apis.download({ path: key });
+  if (response.status >= 400) {
+    const text = await response.text();
+    return { error: text || `HTTP ${response.status}` };
+  }
+  const declared = Number(response.headers.get("Content-Length"));
+  if (Number.isFinite(declared) && declared > MCP_MAX_BYTES) {
+    const paged = await downloadPartTool(apis, key, 1, MCP_DOWNLOAD_PART_SIZE);
+    if (paged.isError) {
+      return { error: paged.content[0]?.text || "paged download failed" };
+    }
+    try {
+      return JSON.parse(paged.content[0].text) as Record<string, unknown>;
+    } catch {
+      return { error: "paged download returned unexpected JSON" };
+    }
+  }
+  const bytes = new Uint8Array(await response.arrayBuffer());
+  if (bytes.byteLength > MCP_MAX_BYTES) {
+    return {
+      error: `File larger than 1 MiB (${bytes.byteLength} bytes). Use download with part=1.`,
+    };
+  }
+  const contentType =
+    response.headers.get("Content-Type") || "application/octet-stream";
+  if (isUtf8Text(bytes)) {
+    return {
+      key,
+      size: bytes.byteLength,
+      contentType,
+      encoding: "utf8",
+      content: new TextDecoder("utf-8").decode(bytes),
+    };
+  }
+  return {
+    key,
+    size: bytes.byteLength,
+    contentType,
+    encoding: "base64",
+    content: encodeBase64(bytes),
+  };
+}
+
+async function uploadBytes(
+  apis: ToolCallApis,
+  folder: string,
+  name: string,
+  bytes: Uint8Array
+): Promise<McpToolResult> {
+  if (bytes.byteLength > MCP_MAX_UPLOAD_BYTES) {
+    return toolError(
+      `Content larger than ${Math.floor(MCP_MAX_UPLOAD_BYTES / 1000000)} MB (MCP cap). Use the web UI or API scripts.`
+    );
+  }
+  if (bytes.byteLength > MCP_MAX_BYTES) {
+    const fullKey = folder ? `${folder.replace(/\/+$/, "")}/${name}` : name;
+    return multipartUploadTool(apis, fullKey, bytes);
+  }
+  return wrapApiResponse(
+    await apis.upload({ path: folder, name, body: bytes, overwrite: true })
+  );
+}
+
 function parseToolCall(
   params: unknown
 ): { name: string; args: Record<string, unknown> } | { error: string } {
@@ -848,6 +1206,144 @@ async function callTool(
       if (!slug) return toolError("slug is required");
       const purge = asOptionalBoolean(args.purge) === true;
       return wrapApiResponse(await apis.sitesDelete({ slug, purge }));
+    }
+    case "pull": {
+      const planned = agentLayerPrefixes({
+        agent: asString(args.agent) || undefined,
+        project: asString(args.project) || undefined,
+        type: asString(args.type) || undefined,
+      });
+      if (!planned.ok) return toolError(planned.error);
+      const types = planned.typeFilter
+        ? [planned.typeFilter]
+        : [...AGENT_LAYOUT_TYPES];
+      const files: Array<Record<string, unknown>> = [];
+      for (const layer of planned.layers) {
+        for (const type of types) {
+          const root = `${layer.prefix}${type}`;
+          const walked = await walkFolderFiles(apis, root);
+          if (walked === "missing") continue;
+          if ("error" in walked) return toolError(walked.error);
+          for (const item of walked.files) {
+            const rel = item.key.startsWith(layer.prefix)
+              ? item.key.slice(layer.prefix.length)
+              : item.key;
+            const content = await readPulledFile(apis, item.key);
+            if ("error" in content) return toolError(`${item.key}: ${content.error}`);
+            files.push({
+              ...content,
+              layer: layer.layer,
+              type,
+              rel,
+              key: item.key,
+            });
+          }
+        }
+      }
+      return toolText(
+        JSON.stringify({
+          mergeOrder: [...AGENT_MERGE_ORDER],
+          mergeHint:
+            "When the same rel exists in more than one layer, apply project > agent > global (project wins).",
+          layers: planned.layers,
+          files,
+        })
+      );
+    }
+    case "push": {
+      const dest = agentPushPrefix({
+        agent: asString(args.agent) || undefined,
+        project: asString(args.project) || undefined,
+      });
+      if (!dest.ok) return toolError(dest.error);
+      if (!Array.isArray(args.files)) return toolError("files is required");
+      const uploaded: Array<{ key: string; layer: AgentLayer }> = [];
+      for (const entry of args.files) {
+        if (!isPlainObject(entry)) return toolError("each file must be an object");
+        const rel = sanitizeAgentRelPath(asString(entry.path));
+        if (typeof rel !== "string") return toolError(rel.error);
+        if (!Object.prototype.hasOwnProperty.call(entry, "content")) {
+          return toolError(`${rel}: content is required`);
+        }
+        const decoded = decodeUploadContent(
+          asString(entry.content),
+          typeof entry.encoding === "string" ? entry.encoding : undefined
+        );
+        if (!decoded.ok) return toolError(`${rel}: ${decoded.error}`);
+        const base = rel.split("/").pop() || rel;
+        if (base.toLowerCase() === "mcp.json") {
+          const text = new TextDecoder("utf-8").decode(decoded.bytes);
+          if (mcpJsonHasRawSecrets(text)) {
+            return toolError(
+              `${rel}: mcp.json must not contain raw API keys — use \${env:...} placeholders only`
+            );
+          }
+        }
+        const slash = rel.lastIndexOf("/");
+        const folder =
+          slash >= 0 ? `${dest.prefix}${rel.slice(0, slash)}` : dest.prefix.replace(/\/+$/, "");
+        const name = slash >= 0 ? rel.slice(slash + 1) : rel;
+        if (slash >= 0) {
+          const mkdirResult = await wrapApiResponse(await apis.mkdir({ path: folder }));
+          if (mkdirResult.isError) return mkdirResult;
+        }
+        const uploadedResult = await uploadBytes(apis, folder, name, decoded.bytes);
+        if (uploadedResult.isError) return uploadedResult;
+        uploaded.push({ key: `${dest.prefix}${rel}`, layer: dest.layer });
+      }
+      return toolText(
+        JSON.stringify({
+          layer: dest.layer,
+          prefix: dest.prefix,
+          uploaded,
+        })
+      );
+    }
+    case "publish_site": {
+      if (!(await apis.sitesEnabled())) {
+        return toolError(
+          "Sites feature is off (404). Enable the Sites switch to publish."
+        );
+      }
+      const slug = asString(args.slug).trim().toLowerCase();
+      if (!slug) return toolError("slug is required");
+      if (!isSiteSlug(slug)) {
+        return toolError("slug must match [a-z0-9][a-z0-9-]{0,62}");
+      }
+      const sourceRaw = asString(args.source).trim().replace(/^\/+/, "").replace(/\/+$/, "");
+      if (!sourceRaw) return toolError("source is required");
+      if (sourceRaw.includes("..") || sourceRaw.startsWith("_$flaredrive$")) {
+        return toolError("source is not a usable folder key");
+      }
+      const walked = await walkFolderFiles(apis, sourceRaw);
+      if (walked === "missing") return toolError(`source folder not found: ${sourceRaw}`);
+      if ("error" in walked) return toolError(walked.error);
+      const copied: Array<{ from: string; to: string }> = [];
+      const sourcePrefix = `${sourceRaw}/`;
+      for (const item of walked.files) {
+        const rel = item.key.startsWith(sourcePrefix)
+          ? item.key.slice(sourcePrefix.length)
+          : item.key === sourceRaw
+            ? item.name
+            : item.key.startsWith(`${sourceRaw}/`)
+              ? item.key.slice(sourceRaw.length + 1)
+              : item.name;
+        if (!rel || rel.includes("..")) continue;
+        const to = `sites/${slug}/${rel}`;
+        const copyResult = await wrapApiResponse(
+          await apis.copy({ from: item.key, to, overwrite: true })
+        );
+        if (copyResult.isError) return copyResult;
+        copied.push({ from: item.key, to });
+      }
+      return toolText(
+        JSON.stringify({
+          slug,
+          source: sourceRaw,
+          copied: copied.length,
+          files: copied,
+        })
+      );
     }
     default:
       return toolError(`Unknown tool: ${name}`);

--- a/functions/mcp.ts
+++ b/functions/mcp.ts
@@ -267,6 +267,10 @@ function makeApis(context: McpContext): ToolCallApis {
       const request = cloneApiRequest(context.request, "DELETE", url);
       return sitesOnDelete(withRequest(context, request));
     },
+    async sitesEnabled() {
+      const flags = await loadFeatureFlags(context.env.BUCKET);
+      return flags.sites;
+    },
   };
 }
 

--- a/src/app/__tests__/mcp.test.ts
+++ b/src/app/__tests__/mcp.test.ts
@@ -10,11 +10,13 @@ import {
   MCP_MAX_BYTES,
   MCP_MAX_UPLOAD_BYTES,
   MCP_PROTOCOL_VERSION,
+  AGENT_MERGE_ORDER,
   MCP_TOOL_NAMES,
   MCP_TOOLS,
   MCP_UPLOAD_PART_SIZE,
   decodeUploadContent,
   dispatchMcpRequest,
+  mcpJsonHasRawSecrets,
   parseJsonRpcBody,
   type JsonRpcRequest,
   type ToolCallApis,
@@ -63,6 +65,7 @@ function mockApis(overrides: Partial<ToolCallApis> = {}): ToolCallApis {
     sitesList: async () => jsonResponse({ sitesHost: "sites.example.com", sites: [] }),
     sitesConfig: async () => jsonResponse({ slug: "demo", spa: true }),
     sitesDelete: async () => jsonResponse({ slug: "demo", deleted: 2 }),
+    sitesEnabled: async () => true,
     ...overrides,
   };
 }
@@ -80,7 +83,7 @@ function toolPayload(result: Awaited<ReturnType<typeof dispatchMcpRequest>>) {
 }
 
 describe("mcp protocol", () => {
-  test("tool catalog: base + search/move/copy/stat/share/sites", () => {
+  test("tool catalog: base + search/move/copy/stat/share/sites + pull/push/publish_site", () => {
     expect(MCP_TOOL_NAMES).toEqual([
       "list",
       "upload",
@@ -97,8 +100,11 @@ describe("mcp protocol", () => {
       "sites_list",
       "sites_config",
       "sites_delete",
+      "pull",
+      "push",
+      "publish_site",
     ]);
-    expect(MCP_TOOLS).toHaveLength(15);
+    expect(MCP_TOOLS).toHaveLength(18);
   });
 
   test("parseJsonRpcBody rejects invalid json", () => {
@@ -339,5 +345,195 @@ describe("mcp protocol", () => {
     const missing = await callTool("sites_config", { slug: "demo" }, { sitesConfig });
     expect(toolPayload(missing).isError).toBe(true);
     expect(sitesConfig).not.toHaveBeenCalled();
+  });
+
+  test("pull walks layers and documents merge order project > agent > global", async () => {
+    const trees: Record<string, Array<{ key: string; name: string; isDir: boolean }>> = {
+      "agents/global/skills": [{ key: "agents/global/skills/commit", name: "commit", isDir: true }],
+      "agents/global/skills/commit": [
+        { key: "agents/global/skills/commit/SKILL.md", name: "SKILL.md", isDir: false },
+      ],
+      "agents/cursor/rules": [
+        { key: "agents/cursor/rules/typescript.mdc", name: "typescript.mdc", isDir: false },
+      ],
+      "agents/cursor/Davflare/skills": [
+        { key: "agents/cursor/Davflare/skills/pages-deploy", name: "pages-deploy", isDir: true },
+      ],
+      "agents/cursor/Davflare/skills/pages-deploy": [
+        {
+          key: "agents/cursor/Davflare/skills/pages-deploy/SKILL.md",
+          name: "SKILL.md",
+          isDir: false,
+        },
+      ],
+    };
+    const contents: Record<string, string> = {
+      "agents/global/skills/commit/SKILL.md": "global-commit",
+      "agents/cursor/rules/typescript.mdc": "agent-rule",
+      "agents/cursor/Davflare/skills/pages-deploy/SKILL.md": "project-skill",
+    };
+    const list = jest.fn(async ({ path }: { path: string }) => {
+      const folder = path.replace(/\/+$/, "");
+      const items = trees[folder];
+      if (!items) return new Response("目录不存在", { status: 404 });
+      return jsonResponse({ items });
+    });
+    const download = jest.fn(async ({ path }: { path: string }) => {
+      const text = contents[path];
+      if (!text) return new Response("missing", { status: 404 });
+      return new Response(text, { status: 200, headers: { "Content-Type": "text/plain" } });
+    });
+    const result = await callTool(
+      "pull",
+      { agent: "cursor", project: "Davflare" },
+      { list, download }
+    );
+    const body = toolPayload(result);
+    expect(body.isError).toBeFalsy();
+    const parsed = JSON.parse(body.content[0].text);
+    expect(parsed.mergeOrder).toEqual([...AGENT_MERGE_ORDER]);
+    expect(parsed.mergeOrder).toEqual(["project", "agent", "global"]);
+    expect(parsed.mergeHint).toMatch(/project > agent > global/);
+    const byKey = Object.fromEntries(parsed.files.map((f: { key: string }) => [f.key, f]));
+    expect(byKey["agents/global/skills/commit/SKILL.md"]).toMatchObject({
+      layer: "global",
+      type: "skills",
+      rel: "skills/commit/SKILL.md",
+      content: "global-commit",
+    });
+    expect(byKey["agents/cursor/rules/typescript.mdc"]).toMatchObject({
+      layer: "agent",
+      type: "rules",
+      rel: "rules/typescript.mdc",
+      content: "agent-rule",
+    });
+    expect(byKey["agents/cursor/Davflare/skills/pages-deploy/SKILL.md"]).toMatchObject({
+      layer: "project",
+      type: "skills",
+      rel: "skills/pages-deploy/SKILL.md",
+      content: "project-skill",
+    });
+    expect(parsed.files.map((f: { layer: string }) => f.layer)).toEqual([
+      "global",
+      "agent",
+      "project",
+    ]);
+  });
+
+  test("mcpJsonHasRawSecrets detects fd_ keys and raw Bearer tokens", () => {
+    expect(mcpJsonHasRawSecrets('{"headers":{"Authorization":"Bearer ${env:DAVFLARE_API_KEY}"}}')).toBe(
+      false
+    );
+    expect(mcpJsonHasRawSecrets("Bearer ${env:DAVFLARE_API_KEY}")).toBe(false);
+    expect(
+      mcpJsonHasRawSecrets(
+        '{"headers":{"Authorization":"Bearer fd_0123456789abcdef0123456789abcdef"}}'
+      )
+    ).toBe(true);
+    expect(mcpJsonHasRawSecrets("Authorization: Bearer sk-live-secret")).toBe(true);
+    expect(mcpJsonHasRawSecrets('{"headers":{"X-Api-Key":"fd_0123456789abcdef01234567"}}')).toBe(
+      true
+    );
+  });
+
+  test("push rejects raw keys in mcp.json", async () => {
+    const upload = jest.fn(async () => jsonResponse({ key: "agents/cursor/mcp/mcp.json" }, 201));
+    const rejected = await callTool(
+      "push",
+      {
+        agent: "cursor",
+        files: [
+          {
+            path: "mcp/mcp.json",
+            content: JSON.stringify({
+              mcpServers: {
+                davflare: {
+                  url: "https://example.com/mcp",
+                  headers: { Authorization: "Bearer fd_0123456789abcdef0123456789abcdef" },
+                },
+              },
+            }),
+          },
+        ],
+      },
+      { upload }
+    );
+    expect(toolPayload(rejected).isError).toBe(true);
+    expect(toolPayload(rejected).content[0].text).toMatch(/mcp\.json/);
+    expect(toolPayload(rejected).content[0].text).toMatch(/\$\{env:/);
+    expect(upload).not.toHaveBeenCalled();
+
+    const accepted = await callTool(
+      "push",
+      {
+        agent: "cursor",
+        files: [
+          {
+            path: "mcp/mcp.json",
+            content: JSON.stringify({
+              mcpServers: {
+                davflare: {
+                  url: "https://example.com/mcp",
+                  headers: { Authorization: "Bearer ${env:DAVFLARE_API_KEY}" },
+                },
+              },
+            }),
+          },
+        ],
+      },
+      { upload }
+    );
+    expect(toolPayload(accepted).isError).toBeFalsy();
+    expect(upload).toHaveBeenCalledWith(
+      expect.objectContaining({
+        path: "agents/cursor/mcp",
+        name: "mcp.json",
+        overwrite: true,
+      })
+    );
+  });
+
+  test("publish_site copies into sites/{slug}/ and respects sites flag", async () => {
+    const trees: Record<string, Array<{ key: string; name: string; isDir: boolean }>> = {
+      "draft/hello": [
+        { key: "draft/hello/index.html", name: "index.html", isDir: false },
+        { key: "draft/hello/css", name: "css", isDir: true },
+      ],
+      "draft/hello/css": [{ key: "draft/hello/css/app.css", name: "app.css", isDir: false }],
+    };
+    const list = jest.fn(async ({ path }: { path: string }) => {
+      const items = trees[path.replace(/\/+$/, "")];
+      if (!items) return new Response("目录不存在", { status: 404 });
+      return jsonResponse({ items });
+    });
+    const copy = jest.fn(async () => jsonResponse({ copied: true }));
+    const copied = await callTool(
+      "publish_site",
+      { slug: "hello", source: "draft/hello" },
+      { list, copy, sitesEnabled: async () => true }
+    );
+    expect(toolPayload(copied).isError).toBeFalsy();
+    const payload = JSON.parse(toolPayload(copied).content[0].text);
+    expect(payload.slug).toBe("hello");
+    expect(payload.copied).toBe(2);
+    expect(copy).toHaveBeenCalledWith({
+      from: "draft/hello/index.html",
+      to: "sites/hello/index.html",
+      overwrite: true,
+    });
+    expect(copy).toHaveBeenCalledWith({
+      from: "draft/hello/css/app.css",
+      to: "sites/hello/css/app.css",
+      overwrite: true,
+    });
+
+    const blocked = await callTool(
+      "publish_site",
+      { slug: "hello", source: "draft/hello" },
+      { list, copy, sitesEnabled: async () => false }
+    );
+    expect(toolPayload(blocked).isError).toBe(true);
+    expect(toolPayload(blocked).content[0].text).toMatch(/404/);
+    expect(copy).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/app/__tests__/p0CopyViews.test.tsx
+++ b/src/app/__tests__/p0CopyViews.test.tsx
@@ -59,7 +59,7 @@ describe("P0 copy: Settings / Sites / Images", () => {
 
   test("Sites view is blunt when SITES_HOST is missing", async () => {
     mockListSites.mockResolvedValue({ sitesHost: null, sites: [] });
-    render(<SitesView onNotify={jest.fn()} />);
+    render(<SitesView onNotify={jest.fn()} onManageFiles={jest.fn()} />);
     await waitFor(() => {
       expect(screen.getByText(strings.sitesHostMissing)).toBeInTheDocument();
     });

--- a/src/app/__tests__/p0CopyViews.test.tsx
+++ b/src/app/__tests__/p0CopyViews.test.tsx
@@ -1,0 +1,83 @@
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+
+import ImagesView from "../../ImagesView";
+import SettingsView from "../../SettingsView";
+import SitesView from "../../SitesView";
+import { DEFAULT_FEATURE_FLAGS, useFeatures } from "../features";
+import { listImages } from "../images";
+import { listSites } from "../sites";
+import { setLang, strings } from "../strings";
+
+jest.mock("../features", () => {
+  const actual = jest.requireActual("../features");
+  return { ...actual, useFeatures: jest.fn() };
+});
+
+jest.mock("../sites", () => {
+  const actual = jest.requireActual("../sites");
+  return { ...actual, listSites: jest.fn() };
+});
+
+jest.mock("../images", () => {
+  const actual = jest.requireActual("../images");
+  return { ...actual, listImages: jest.fn() };
+});
+
+jest.mock("../transferQueue", () => ({
+  useUploadEnqueue: () => jest.fn(),
+}));
+
+const mockUseFeatures = useFeatures as unknown as jest.Mock;
+const mockListSites = listSites as unknown as jest.Mock;
+const mockListImages = listImages as unknown as jest.Mock;
+
+beforeEach(() => {
+  setLang("en");
+  mockUseFeatures.mockReset();
+  mockListSites.mockReset();
+  mockListImages.mockReset();
+  mockUseFeatures.mockReturnValue({
+    flags: DEFAULT_FEATURE_FLAGS,
+    sitesHost: null,
+    updateFlags: jest.fn(),
+  });
+});
+
+describe("P0 copy: Settings / Sites / Images", () => {
+  test("Settings states MCP is 404 when API Key is off", () => {
+    render(<SettingsView onNotify={jest.fn()} />);
+    expect(screen.getByText(strings.mcpRequiresApiKey)).toBeInTheDocument();
+    expect(strings.mcpRequiresApiKey).toMatch(/404/);
+    expect(strings.mcpRequiresApiKey).toMatch(/API Key/i);
+    expect(screen.getByText(strings.flagWebdav)).toBeInTheDocument();
+    expect(screen.getByText(strings.flagMcp)).toBeInTheDocument();
+    expect(screen.getByText(strings.flagApiKey)).toBeInTheDocument();
+    expect(screen.getByText(strings.flagSites)).toBeInTheDocument();
+    expect(screen.getByText(strings.flagImageHost)).toBeInTheDocument();
+  });
+
+  test("Sites view is blunt when SITES_HOST is missing", async () => {
+    mockListSites.mockResolvedValue({ sitesHost: null, sites: [] });
+    render(<SitesView onNotify={jest.fn()} />);
+    await waitFor(() => {
+      expect(screen.getByText(strings.sitesHostMissing)).toBeInTheDocument();
+    });
+    expect(screen.getByText(strings.sitesHostMissingHint)).toBeInTheDocument();
+    expect(strings.sitesHostMissingHint).toMatch(/SITES_HOST/);
+    expect(strings.sitesHostMissingHint).toMatch(/redeploy/i);
+    expect(strings.sitesHostMissingHint).toMatch(/hostname only/i);
+  });
+
+  test("Images view is blunt when SITES_HOST is missing", async () => {
+    mockListImages.mockResolvedValue({ sitesHost: null, images: [] });
+    render(<ImagesView onNotify={jest.fn()} />);
+    await waitFor(() => {
+      expect(screen.getByText(strings.imagesHostMissing)).toBeInTheDocument();
+    });
+    expect(screen.getByText(strings.imagesHostMissingHint)).toBeInTheDocument();
+    expect(strings.imagesHostMissingHint).toMatch(/SITES_HOST/);
+    expect(strings.imagesHostMissingHint).toMatch(/redeploy/i);
+    expect(strings.imagesHostMissing).toMatch(/will not open/);
+  });
+});

--- a/src/app/__tests__/strings.test.ts
+++ b/src/app/__tests__/strings.test.ts
@@ -56,6 +56,32 @@ describe("strings / translate", () => {
     expect(translate("validForever")).toBe("Never expires");
   });
 
+  test("MCP copy states API Key 404 dependency", () => {
+    for (const lang of ["zh", "en"] as const) {
+      const mcp = dictionary.mcpRequiresApiKey[lang];
+      const mcpHint = dictionary.flagMcpHint[lang];
+      const keyHint = dictionary.flagApiKeyHint[lang];
+      expect(mcp).toMatch(/API Key/i);
+      expect(mcp).toMatch(/404/);
+      expect(mcpHint).toMatch(/404/);
+      expect(keyHint).toMatch(/404/);
+    }
+  });
+
+  test("SITES_HOST missing hints say bind, env, redeploy", () => {
+    for (const lang of ["zh", "en"] as const) {
+      for (const key of ["sitesHostMissingHint", "imagesHostMissingHint"] as const) {
+        const hint = dictionary[key][lang];
+        expect(hint).toMatch(/SITES_HOST/);
+        expect(hint).toMatch(/https:\/\//);
+        expect(hint).toMatch(lang === "zh" ? /绑定/ : /[Bb]ind/);
+        expect(hint).toMatch(lang === "zh" ? /重新部署/ : /redeploy/);
+      }
+      expect(dictionary.sitesHostMissing[lang]).toMatch(lang === "zh" ? /打不开/ : /will not open/);
+      expect(dictionary.imagesHostMissing[lang]).toMatch(lang === "zh" ? /打不开/ : /will not open/);
+    }
+  });
+
   test("setLang 通知订阅者", () => {
     const seen: string[] = [];
     const unsubscribe = subscribeLang(() => seen.push(getLang()));

--- a/src/app/strings.ts
+++ b/src/app/strings.ts
@@ -31,10 +31,10 @@ const entries: Record<string, Entry> = {  searchPlaceholder: { zh: "搜索文件
   trash: { zh: "回收站", en: "Trash" },
   sitesSection: { zh: "站点", en: "Sites" },
   sitesTitle: { zh: "静态站点", en: "Static sites" },
-  sitesHostMissing: { zh: "未配置 SITES_HOST,站点访问已禁用", en: "SITES_HOST not set — site visits are disabled" },
+  sitesHostMissing: { zh: "未配置 SITES_HOST，公开地址打不开", en: "SITES_HOST is not set — public URLs will not open" },
   sitesHostMissingHint: {
-    zh: "在 Cloudflare Pages 项目的环境变量中设置 SITES_HOST(如 sites.example.com)并绑定该自定义域,站点才会在此域名下对外服务。详见 docs/sites.md。",
-    en: "Set SITES_HOST as a Cloudflare Pages environment variable (e.g. sites.example.com) and bind that custom domain to serve sites publicly. See docs/sites.md.",
+    zh: "给这个 Pages 项目绑定自定义域，并设置 Pages 环境变量 SITES_HOST（只要主机名，不要 https://），然后重新部署。在此之前公开地址打不开。",
+    en: "Bind a custom domain to this Pages project AND set the Pages env SITES_HOST (hostname only, no https://), then redeploy. Until then public URLs will not open.",
   },
   emptySites: { zh: "还没有站点", en: "No sites yet" },
   emptySitesHint: {
@@ -88,13 +88,13 @@ const entries: Record<string, Entry> = {  searchPlaceholder: { zh: "搜索文件
   },
   flagMcp: { zh: "MCP", en: "MCP" },
   flagMcpHint: {
-    zh: "关闭后 POST /mcp 返回 404。MCP 依赖 API Key：若 API Key 关闭，即使本开关打开也无法使用。",
-    en: "Off: POST /mcp returns 404. MCP requires API Key — if API Key is off, MCP is unusable even when this switch is on.",
+    zh: "关闭后 POST /mcp 返回 404。MCP 依赖 API Key：若 API Key 关闭，即使本开关打开，/mcp 也是 404。",
+    en: "Off: POST /mcp returns 404. MCP depends on the API Key switch — if Key is off, /mcp is 404 even if MCP is on.",
   },
   flagApiKey: { zh: "API Key", en: "API Key" },
   flagApiKeyHint: {
-    zh: "关闭后隐藏密钥管理，Bearer / X-Api-Key 开放接口返回 401。网页会话接口不受影响。MCP 也将不可用。",
-    en: "Off: hide key management; Bearer / X-Api-Key Open API calls return 401. Session APIs keep working. MCP also becomes unusable.",
+    zh: "关闭后隐藏密钥管理，Bearer / X-Api-Key 开放接口返回 401。网页会话接口不受影响。MCP 也会 404：即使 MCP 开关仍打开，/mcp 也不可用。",
+    en: "Off: hide key management; Bearer / X-Api-Key Open API calls return 401. Session APIs keep working. MCP is also 404: if Key is off, /mcp is 404 even if MCP is on.",
   },
   flagSites: { zh: "静态站点", en: "Static sites" },
   flagSitesHint: {
@@ -116,10 +116,10 @@ const entries: Record<string, Entry> = {  searchPlaceholder: { zh: "搜索文件
     zh: "拖放图片上传。公开地址只在站点域名：https://<SITES_HOST>/i/{id}",
     en: "Drop images to upload. Public URLs live only on the sites host: https://<SITES_HOST>/i/{id}",
   },
-  imagesHostMissing: { zh: "未配置 SITES_HOST，图床公开地址不可用", en: "SITES_HOST not set — public image URLs are disabled" },
+  imagesHostMissing: { zh: "未配置 SITES_HOST，公开地址打不开", en: "SITES_HOST is not set — public URLs will not open" },
   imagesHostMissingHint: {
-    zh: "在 Cloudflare Pages 项目的环境变量中设置 SITES_HOST（如 sites.example.com）并绑定该自定义域，图床才会在此域名下以 /i/{id} 对外服务。详见 docs/sites.md。",
-    en: "Set SITES_HOST as a Cloudflare Pages environment variable (e.g. sites.example.com) and bind that custom domain. Images are then served at /i/{id} on that host. See docs/sites.md.",
+    zh: "给这个 Pages 项目绑定自定义域，并设置 Pages 环境变量 SITES_HOST（只要主机名，不要 https://），然后重新部署。在此之前图床公开地址打不开。",
+    en: "Bind a custom domain to this Pages project AND set the Pages env SITES_HOST (hostname only, no https://), then redeploy. Until then public image URLs will not open.",
   },
   emptyImages: { zh: "还没有图片", en: "No images yet" },
   emptyImagesHint: { zh: "把图片拖到这里，或点击上传", en: "Drop an image here, or click upload" },
@@ -137,8 +137,8 @@ const entries: Record<string, Entry> = {  searchPlaceholder: { zh: "搜索文件
   imageUrlCopied: { zh: "链接已复制", en: "URL copied" },
   imageMarkdownCopied: { zh: "Markdown 已复制", en: "Markdown copied" },
   mcpRequiresApiKey: {
-    zh: "MCP 依赖 API Key。关闭 API Key 后 MCP 不可用，即使 MCP 开关仍打开。",
-    en: "MCP depends on API Key. If API Key is off, MCP is unusable even when the MCP switch is on.",
+    zh: "MCP 依赖 API Key 开关：若 API Key 关闭，即使 MCP 开关打开，/mcp 也是 404。",
+    en: "MCP depends on the API Key switch: if Key is off, /mcp is 404 even if MCP is on.",
   },
   siteFilesCount: { zh: "{count} 个文件", en: "{count} file(s)" },
   siteStatsTruncated: { zh: "统计达到扫描上限,数值为下限", en: "Scan cap reached; figures are lower bounds" },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
P1 MCP tools. Based on #34 (P0 docs/UX). Merge #34 first if you want docs-only; this PR against `main` includes those P0 commits until then.

## What changed

Keeps the existing **15** tools and adds three:

| Tool | Behavior |
| --- | --- |
| `pull` | Walks `agents/{global\|agent\|agent/project}/{skills\|rules\|mcp}/` and returns the tree + file contents. Args: `agent?`, `project?`, `type?` (`skills` \| `rules` \| `mcp`). Files are tagged with `layer`, `rel`, and remote `key`. Merge order for the client: **project > agent > global**. Large files page with `part` / `partSize` like `download`. |
| `push` | Uploads a set of files into that tree (mkdir as needed). `mcp.json` must use `${env:...}` — raw `fd_…` / Bearer tokens are **rejected**. No local disk watcher. |
| `publish_site` | Args: `slug` + `source` folder key. Copies onto `sites/{slug}/` (overwrite same names; does **not** wipe SPA config). Slug stays `[a-z0-9][a-z0-9-]{0,62}`. Sites switch off → tool error (404). Reuses existing `list` / `copy`. |

## Docs

- README / API list **18** tools (the previous 15 plus these three). Upload auto-chunk **25 MB** and download paging text are unchanged.
- `docs/agents.md` (+ zh): v2 `pull` / `push` exist now (“v2 will add” removed).
- `docs/sites.md` (+ zh): `publish_site` noted as a publish path.

## Tests

Jest covers pull tree walk + merge order, push rejecting raw keys in `mcp.json`, and `publish_site` copying into `sites/{slug}/` plus the Sites flag. `npm run test:ci` — 263 tests passed.

## Out of scope

WebDAV protocol, multi-tenant, OAuth, git/Pages deploy, public demo site, `SITES_HOST` probe (P2).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-140a13b1-0361-4a07-ad85-e9a1bd42f107?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-140a13b1-0361-4a07-ad85-e9a1bd42f107&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

