### PR TITLE
fix: 插件 Release zip 写到仓库根目录

### DIFF
--- a/scripts/package-extension.sh
+++ b/scripts/package-extension.sh
@@ -8,8 +8,9 @@
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
-OUT="${1:-$ROOT}"
-mkdir -p "$OUT"
+OUT_ARG="${1:-$ROOT}"
+mkdir -p "$OUT_ARG"
+OUT="$(cd "$OUT_ARG" && pwd)"
 
 DEFAULT_ZIP="$OUT/davflare-extension.zip"
 NEWTAB_ZIP="$OUT/davflare-extension-newtab.zip"


### PR DESCRIPTION
## Summary
- `scripts/package-extension.sh .` resolved zip paths relative to `extension/`, so the default zip was missing at repo root and the newtab zip swallowed it.
- Resolve output dir to an absolute path before zipping.
