### PR TITLE
test: 补 0% UI 单测，拉高覆盖率

### DIFF
--- a/src/app/__tests__/ApiKeysPanel.test.tsx
+++ b/src/app/__tests__/ApiKeysPanel.test.tsx
@@ -1,0 +1,89 @@
+import React from "react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+import ApiKeysPanel from "../../ApiKeysPanel";
+import { createApiKey, listApiKeys, revokeApiKey } from "../apikeys";
+import { DEFAULT_FEATURE_FLAGS, useFeatures } from "../features";
+import { setLang, strings, translate } from "../strings";
+
+jest.mock("../features", () => {
+  const actual = jest.requireActual("../features");
+  return { ...actual, useFeatures: jest.fn() };
+});
+
+jest.mock("../apikeys", () => {
+  const actual = jest.requireActual("../apikeys");
+  return {
+    ...actual,
+    listApiKeys: jest.fn(),
+    createApiKey: jest.fn(),
+    revokeApiKey: jest.fn(),
+  };
+});
+
+const mockUseFeatures = useFeatures as unknown as jest.Mock;
+const mockList = listApiKeys as unknown as jest.Mock;
+const mockCreate = createApiKey as unknown as jest.Mock;
+const mockRevoke = revokeApiKey as unknown as jest.Mock;
+
+beforeEach(() => {
+  setLang("zh");
+  mockUseFeatures.mockReset();
+  mockList.mockReset();
+  mockCreate.mockReset();
+  mockRevoke.mockReset();
+  mockUseFeatures.mockReturnValue({
+    flags: DEFAULT_FEATURE_FLAGS,
+    sitesHost: null,
+    updateFlags: jest.fn(),
+  });
+  mockList.mockResolvedValue([]);
+  Object.defineProperty(navigator, "clipboard", {
+    value: { writeText: jest.fn().mockResolvedValue(undefined) },
+    configurable: true,
+  });
+});
+
+describe("ApiKeysPanel", () => {
+  test("loads empty list", async () => {
+    render(<ApiKeysPanel open onClose={jest.fn()} onNotify={jest.fn()} />);
+    await waitFor(() => expect(screen.getByText(strings.apiNoKeys)).toBeInTheDocument());
+    expect(mockList).toHaveBeenCalled();
+  });
+
+  test("empty name does not create", async () => {
+    const onNotify = jest.fn();
+    render(<ApiKeysPanel open onClose={jest.fn()} onNotify={onNotify} />);
+    await screen.findByText(strings.apiNoKeys);
+    fireEvent.click(screen.getByRole("button", { name: strings.createApiKey }));
+    expect(onNotify).toHaveBeenCalledWith(translate("fillKeyName"), "error");
+    expect(mockCreate).not.toHaveBeenCalled();
+  });
+
+  test("creates a key", async () => {
+    mockCreate.mockResolvedValue({
+      id: "1",
+      name: "k",
+      prefix: "fd_",
+      createdAt: "",
+      expiresAt: null,
+      key: "fd_secret",
+    });
+    const onNotify = jest.fn();
+    render(<ApiKeysPanel open onClose={jest.fn()} onNotify={onNotify} />);
+    await screen.findByText(strings.apiNoKeys);
+    fireEvent.change(screen.getByLabelText(strings.apiKeyName), { target: { value: "k" } });
+    fireEvent.click(screen.getByRole("button", { name: strings.createApiKey }));
+    await waitFor(() =>
+      expect(onNotify).toHaveBeenCalledWith(translate("keyCreatedToast"), "success")
+    );
+    expect(mockCreate).toHaveBeenCalled();
+  });
+
+  test("list error notifies", async () => {
+    mockList.mockRejectedValue(new Error("keys-fail"));
+    const onNotify = jest.fn();
+    render(<ApiKeysPanel open onClose={jest.fn()} onNotify={onNotify} />);
+    await waitFor(() => expect(onNotify).toHaveBeenCalledWith("keys-fail", "error"));
+  });
+});

--- a/src/app/__tests__/App.test.tsx
+++ b/src/app/__tests__/App.test.tsx
@@ -1,0 +1,69 @@
+import React from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+
+import App, { enqueueSnack, SnackbarMessage } from "../../App";
+import { setLang, strings } from "../strings";
+
+jest.mock("../transferQueue", () => {
+  const React = require("react");
+  return {
+    TransferQueueProvider: ({ children }: { children: React.ReactNode }) => children,
+    useTransferQueue: () => [],
+    useTransferQueueActions: () => ({}),
+    useTransferQueueGlobalPaused: () => false,
+    useUploadEnqueue: () => jest.fn(),
+  };
+});
+
+
+jest.mock("../../Main", () => ({
+  __esModule: true,
+  default: () => <div>main-stub</div>,
+}));
+
+jest.mock("../../LoginDialog", () => ({
+  __esModule: true,
+  default: () => <div>login-stub</div>,
+}));
+
+jest.mock("../../TransferManager", () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+jest.mock("../../ApiKeysPanel", () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+beforeEach(() => {
+  setLang("zh");
+  localStorage.clear();
+});
+
+describe("enqueueSnack", () => {
+  const error: SnackbarMessage = { key: 1, message: "e", severity: "error" };
+  const ok: SnackbarMessage = { key: 2, message: "ok", severity: "success" };
+
+  test("errors append; success jumps to front and drops non-errors", () => {
+    expect(enqueueSnack([], error)).toEqual([error]);
+    expect(enqueueSnack([error], ok)).toEqual([ok, error]);
+    expect(enqueueSnack([ok], error)).toEqual([ok, error]);
+  });
+});
+
+describe("App", () => {
+  test("renders header and main stub", () => {
+    render(<App />);
+    expect(screen.getByText("main-stub")).toBeInTheDocument();
+    expect(screen.getByText("login-stub")).toBeInTheDocument();
+    expect(screen.getByLabelText(strings.searchShortcutHint)).toBeInTheDocument();
+  });
+
+  test("slash focuses search when not typing", () => {
+    render(<App />);
+    const input = screen.getByLabelText(strings.searchShortcutHint) as HTMLInputElement;
+    fireEvent.keyDown(window, { key: "/", target: document.body });
+    expect(document.activeElement).toBe(input);
+  });
+});

--- a/src/app/__tests__/ExplorerBar.test.tsx
+++ b/src/app/__tests__/ExplorerBar.test.tsx
@@ -1,0 +1,82 @@
+import React from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+
+import ExplorerBar from "../../ExplorerBar";
+import { DEFAULT_FEATURE_FLAGS, useFeatures } from "../features";
+import { setLang, strings } from "../strings";
+
+jest.mock("../features", () => {
+  const actual = jest.requireActual("../features");
+  return { ...actual, useFeatures: jest.fn() };
+});
+
+const mockUseFeatures = useFeatures as unknown as jest.Mock;
+
+function renderBar(overrides: Partial<React.ComponentProps<typeof ExplorerBar>> = {}) {
+  const props = {
+    section: "folder" as const,
+    onSectionChange: jest.fn(),
+    onUploadFile: jest.fn(),
+    onUploadFolder: jest.fn(),
+    onCreateFolder: jest.fn(),
+    onOpenTextPad: jest.fn(),
+    onPaste: jest.fn(),
+    canPaste: false,
+    clipboardCount: 0,
+    clipboardMode: null as "copy" | "cut" | null,
+    view: "grid" as const,
+    onViewChange: jest.fn(),
+    sort: { field: "name" as const, order: "asc" as const },
+    onSortChange: jest.fn(),
+    onOpenWebDav: jest.fn(),
+    onOpenApi: jest.fn(),
+    typeFilter: "all" as const,
+    onTypeFilterChange: jest.fn(),
+    showHidden: false,
+    onShowHiddenChange: jest.fn(),
+    density: "standard" as const,
+    onDensityChange: jest.fn(),
+    recents: [] as { key: string; name: string; isDir: boolean }[],
+    onOpenRecent: jest.fn(),
+    ...overrides,
+  };
+  const result = render(<ExplorerBar {...props} />);
+  return { ...result, props };
+}
+
+beforeEach(() => {
+  setLang("zh");
+  mockUseFeatures.mockReset();
+  mockUseFeatures.mockReturnValue({
+    flags: DEFAULT_FEATURE_FLAGS,
+    sitesHost: null,
+    updateFlags: jest.fn(),
+  });
+});
+
+describe("ExplorerBar", () => {
+  test("renders folder tools and switches section", () => {
+    const { props } = renderBar();
+    expect(screen.getByLabelText(strings.uploadFile)).toBeInTheDocument();
+    fireEvent.click(screen.getByLabelText(strings.shares));
+    expect(props.onSectionChange).toHaveBeenCalledWith("shares");
+  });
+
+  test("upload file click", () => {
+    const { props } = renderBar();
+    fireEvent.click(screen.getByLabelText(strings.uploadFile));
+    expect(props.onUploadFile).toHaveBeenCalled();
+  });
+
+  test("create folder click", () => {
+    const { props } = renderBar();
+    fireEvent.click(screen.getByText(strings.createFolder));
+    expect(props.onCreateFolder).toHaveBeenCalled();
+  });
+
+  test("type filter chip", () => {
+    const { props } = renderBar();
+    fireEvent.click(screen.getByText(strings.typeImage));
+    expect(props.onTypeFilterChange).toHaveBeenCalledWith("image");
+  });
+});

--- a/src/app/__tests__/Main.test.tsx
+++ b/src/app/__tests__/Main.test.tsx
@@ -1,0 +1,140 @@
+import React from "react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+import Main from "../../Main";
+import { ClipboardProvider } from "../clipboard";
+import { DEFAULT_FEATURE_FLAGS, useFeatures } from "../features";
+import { useAuth } from "../auth";
+import { fetchPath } from "../transfer";
+import { setLang, strings } from "../strings";
+
+jest.mock("../auth", () => ({
+  useAuth: jest.fn(),
+  authFetch: jest.fn(),
+}));
+
+jest.mock("../features", () => {
+  const actual = jest.requireActual("../features");
+  return { ...actual, useFeatures: jest.fn() };
+});
+
+jest.mock("../transferQueue", () => ({
+  useTransferQueue: () => [],
+  useUploadEnqueue: () => jest.fn(),
+}));
+
+jest.mock("../transfer", () => ({
+  collectFilesFromDataTransfer: jest.fn(),
+  copyPaste: jest.fn(),
+  createFolder: jest.fn(),
+  downloadArchive: jest.fn(),
+  downloadFile: jest.fn(),
+  fetchFolderCounts: jest.fn().mockResolvedValue({}),
+  fetchPath: jest.fn(),
+  openFile: jest.fn(),
+  searchFiles: jest.fn(),
+  selectDirectoryFiles: jest.fn(),
+}));
+
+jest.mock("../trash", () => ({
+  moveToTrash: jest.fn(),
+  restoreTrash: jest.fn(),
+}));
+
+jest.mock("../../PreviewDialog", () => ({ __esModule: true, default: () => null }));
+jest.mock("../../ShareDialog", () => ({ __esModule: true, default: () => null }));
+jest.mock("../../SitesView", () => ({ __esModule: true, default: () => <div>sites-stub</div> }));
+jest.mock("../../ImagesView", () => ({ __esModule: true, default: () => <div>images-stub</div> }));
+jest.mock("../../TrashView", () => ({ __esModule: true, default: () => <div>trash-stub</div> }));
+jest.mock("../../SharesView", () => ({ __esModule: true, default: () => <div>shares-stub</div> }));
+jest.mock("../../SettingsView", () => ({ __esModule: true, default: () => <div>settings-stub</div> }));
+jest.mock("../../WebDavPanel", () => ({ __esModule: true, default: () => null }));
+jest.mock("../../TextPadDrawer", () => ({ __esModule: true, default: () => null }));
+jest.mock("../../MoveDialog", () => ({ __esModule: true, default: () => null }));
+jest.mock("../../AuthThumbnail", () => ({ __esModule: true, default: () => <span /> }));
+jest.mock("../../MimeIcon", () => ({ __esModule: true, default: () => <span /> }));
+
+const mockUseAuth = useAuth as unknown as jest.Mock;
+const mockUseFeatures = useFeatures as unknown as jest.Mock;
+const mockFetchPath = fetchPath as unknown as jest.Mock;
+
+const file = {
+  key: "a.txt",
+  name: "a.txt",
+  isDir: false,
+  size: 1,
+  uploaded: "2026-01-01T00:00:00.000Z",
+  contentType: "text/plain",
+};
+
+function renderMain(route: any = { kind: "folder", path: "" }, extra: Partial<React.ComponentProps<typeof Main>> = {}) {
+  const props = {
+    search: "",
+    onSearchChange: jest.fn(),
+    onNotify: jest.fn(),
+    view: "list" as const,
+    onViewChange: jest.fn(),
+    sort: { field: "name" as const, order: "asc" as const },
+    onSortChange: jest.fn(),
+    route,
+    navigate: jest.fn(),
+    onOpenApi: jest.fn(),
+    ...extra,
+  };
+  const result = render(
+    <ClipboardProvider>
+      <Main {...props} />
+    </ClipboardProvider>
+  );
+  return { ...result, props };
+}
+
+beforeAll(() => {
+  (global as any).IntersectionObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  };
+});
+
+beforeEach(() => {
+  setLang("zh");
+  mockUseAuth.mockReturnValue({ username: "alice", login: jest.fn(), logout: jest.fn() });
+  mockUseFeatures.mockReturnValue({
+    flags: DEFAULT_FEATURE_FLAGS,
+    sitesHost: null,
+    updateFlags: jest.fn(),
+    refresh: jest.fn(),
+    config: { username: "alice", publicRead: false, sitesHost: null, flags: DEFAULT_FEATURE_FLAGS },
+  });
+  mockFetchPath.mockReset();
+  mockFetchPath.mockResolvedValue([file]);
+});
+
+describe("Main", () => {
+  test("loads folder listing", async () => {
+    renderMain();
+    await waitFor(() => expect(screen.getByText("a.txt")).toBeInTheDocument());
+    expect(mockFetchPath).toHaveBeenCalledWith("");
+  });
+
+  test("listing error notifies", async () => {
+    mockFetchPath.mockRejectedValue(new Error("list-fail"));
+    const onNotify = jest.fn();
+    renderMain({ kind: "folder", path: "" }, { onNotify });
+    await waitFor(() => expect(onNotify).toHaveBeenCalled());
+    expect(onNotify.mock.calls[0][0]).toBe("list-fail");
+  });
+
+  test("shares route renders stub", async () => {
+    renderMain({ kind: "shares" });
+    await waitFor(() => expect(screen.getByText("shares-stub")).toBeInTheDocument());
+  });
+
+  test("section switch navigates to trash", async () => {
+    const { props } = renderMain();
+    await waitFor(() => expect(screen.getByText("a.txt")).toBeInTheDocument());
+    fireEvent.click(screen.getByLabelText(strings.trash));
+    expect(props.navigate).toHaveBeenCalledWith({ kind: "trash" });
+  });
+});

--- a/src/app/__tests__/PreviewDialog.test.tsx
+++ b/src/app/__tests__/PreviewDialog.test.tsx
@@ -1,0 +1,112 @@
+import React from "react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+import PreviewDialog from "../../PreviewDialog";
+import { authFetch } from "../auth";
+import { downloadFile } from "../transfer";
+import { setLang, strings } from "../strings";
+import { FileItem } from "../types";
+
+jest.mock("../auth", () => ({
+  authFetch: jest.fn(),
+}));
+
+jest.mock("../transfer", () => ({
+  downloadFile: jest.fn(),
+}));
+
+const mockAuthFetch = authFetch as unknown as jest.Mock;
+const mockDownload = downloadFile as unknown as jest.Mock;
+
+const textFile: FileItem = {
+  key: "notes.txt",
+  name: "notes.txt",
+  isDir: false,
+  size: 5,
+  uploaded: "",
+  contentType: "text/plain",
+};
+
+beforeEach(() => {
+  setLang("zh");
+  mockAuthFetch.mockReset();
+  mockDownload.mockReset();
+  if (!URL.createObjectURL) {
+    (URL as any).createObjectURL = jest.fn(() => "blob:preview");
+  }
+  if (!URL.revokeObjectURL) {
+    (URL as any).revokeObjectURL = jest.fn();
+  }
+});
+
+describe("PreviewDialog", () => {
+  test("renders text preview and share action", async () => {
+    const bytes = new TextEncoder().encode("hello");
+    mockAuthFetch.mockResolvedValue({
+      ok: true,
+      headers: { get: (n: string) => (n.toLowerCase() === "content-length" ? "5" : null) },
+      body: {
+        getReader: () => {
+          let done = false;
+          return {
+            read: async () => {
+              if (done) return { done: true, value: undefined };
+              done = true;
+              return { done: false, value: bytes };
+            },
+            cancel: async () => {},
+          };
+        },
+      },
+    });
+    const onShare = jest.fn();
+    render(
+      <PreviewDialog
+        file={textFile}
+        onClose={jest.fn()}
+        onNotify={jest.fn()}
+        onShare={onShare}
+        onRename={jest.fn()}
+        onDelete={jest.fn()}
+      />
+    );
+    await waitFor(() => expect(screen.getByText("hello")).toBeInTheDocument());
+    fireEvent.click(screen.getByText(strings.share));
+    expect(onShare).toHaveBeenCalled();
+  });
+
+  test("fetch error notifies", async () => {
+    mockAuthFetch.mockResolvedValue({
+      ok: false,
+      status: 500,
+      headers: { get: () => null },
+      body: null,
+    });
+    const onNotify = jest.fn();
+    render(
+      <PreviewDialog
+        file={textFile}
+        onClose={jest.fn()}
+        onNotify={onNotify}
+        onShare={jest.fn()}
+        onRename={jest.fn()}
+        onDelete={jest.fn()}
+      />
+    );
+    await waitFor(() => expect(onNotify).toHaveBeenCalled());
+  });
+
+  test("closed when file is null", () => {
+    render(
+      <PreviewDialog
+        file={null}
+        onClose={jest.fn()}
+        onNotify={jest.fn()}
+        onShare={jest.fn()}
+        onRename={jest.fn()}
+        onDelete={jest.fn()}
+      />
+    );
+    expect(screen.queryByText(strings.share)).not.toBeInTheDocument();
+  });
+});

--- a/src/app/__tests__/ShareDialog.test.tsx
+++ b/src/app/__tests__/ShareDialog.test.tsx
@@ -1,0 +1,82 @@
+import React from "react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+import ShareDialog from "../../ShareDialog";
+import { createShare, listShares, revokeShare } from "../share";
+import { setLang, strings, translate } from "../strings";
+import { FileItem, ShareInfo } from "../types";
+
+jest.mock("../share", () => {
+  const actual = jest.requireActual("../share");
+  return {
+    ...actual,
+    createShare: jest.fn(),
+    listShares: jest.fn(),
+    revokeShare: jest.fn(),
+  };
+});
+
+const mockCreateShare = createShare as unknown as jest.Mock;
+const mockListShares = listShares as unknown as jest.Mock;
+const mockRevokeShare = revokeShare as unknown as jest.Mock;
+
+const file: FileItem = {
+  key: "a.txt",
+  name: "a.txt",
+  isDir: false,
+  size: 1,
+  uploaded: "",
+  contentType: "text/plain",
+};
+
+const share: ShareInfo = {
+  token: "tok1",
+  key: "a.txt",
+  name: "a.txt",
+  expiresAt: null,
+  createdAt: "2026-01-01",
+  url: "https://x.example/s/tok1",
+};
+
+beforeEach(() => {
+  setLang("zh");
+  mockCreateShare.mockReset();
+  mockListShares.mockReset();
+  mockRevokeShare.mockReset();
+  mockListShares.mockResolvedValue([share]);
+  Object.defineProperty(navigator, "clipboard", {
+    value: { writeText: jest.fn().mockResolvedValue(undefined) },
+    configurable: true,
+  });
+});
+
+describe("ShareDialog", () => {
+  test("opens existing shares and creates a link", async () => {
+    mockCreateShare.mockResolvedValue({ ...share, token: "tok2", url: "https://x.example/s/tok2" });
+    const onNotify = jest.fn();
+    render(<ShareDialog open file={file} onClose={jest.fn()} onNotify={onNotify} />);
+
+    await waitFor(() => expect(screen.getByText(share.url)).toBeInTheDocument());
+    fireEvent.click(screen.getByText(strings.createShareLink));
+    await waitFor(() => expect(mockCreateShare).toHaveBeenCalledWith("a.txt", undefined, undefined));
+    await waitFor(() =>
+      expect(onNotify).toHaveBeenCalledWith(translate("shareLinkCreated"), "success")
+    );
+  });
+
+  test("listShares error notifies", async () => {
+    mockListShares.mockRejectedValue(new Error("boom"));
+    const onNotify = jest.fn();
+    render(<ShareDialog open file={file} onClose={jest.fn()} onNotify={onNotify} />);
+    await waitFor(() => expect(onNotify).toHaveBeenCalledWith("boom", "error"));
+  });
+
+  test("copy existing link", async () => {
+    const onNotify = jest.fn();
+    render(<ShareDialog open file={file} onClose={jest.fn()} onNotify={onNotify} />);
+    fireEvent.click(await screen.findByText(strings.copy));
+    await waitFor(() =>
+      expect(onNotify).toHaveBeenCalledWith(translate("linkCopied"), "success")
+    );
+  });
+});

--- a/src/app/__tests__/SharesView.test.tsx
+++ b/src/app/__tests__/SharesView.test.tsx
@@ -1,0 +1,72 @@
+import React from "react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+import SharesView from "../../SharesView";
+import { listShares, revokeShare } from "../share";
+import { setLang, strings, translate } from "../strings";
+import { ShareInfo } from "../types";
+
+jest.mock("../share", () => {
+  const actual = jest.requireActual("../share");
+  return { ...actual, listShares: jest.fn(), revokeShare: jest.fn() };
+});
+
+const mockListShares = listShares as unknown as jest.Mock;
+const mockRevokeShare = revokeShare as unknown as jest.Mock;
+
+const share: ShareInfo = {
+  token: "tok1",
+  key: "a.txt",
+  name: "notes.txt",
+  expiresAt: null,
+  createdAt: "2026-01-01",
+  url: "https://x.example/s/tok1",
+};
+
+beforeEach(() => {
+  setLang("zh");
+  mockListShares.mockReset();
+  mockRevokeShare.mockReset();
+  Object.defineProperty(navigator, "clipboard", {
+    value: { writeText: jest.fn().mockResolvedValue(undefined) },
+    configurable: true,
+  });
+});
+
+describe("SharesView", () => {
+  test("empty state and go to files", async () => {
+    mockListShares.mockResolvedValue([]);
+    const onGoFiles = jest.fn();
+    render(<SharesView onNotify={jest.fn()} onGoFiles={onGoFiles} />);
+    await waitFor(() => expect(screen.getByText(strings.emptyShares)).toBeInTheDocument());
+    fireEvent.click(screen.getByText(strings.goToFiles));
+    expect(onGoFiles).toHaveBeenCalled();
+  });
+
+  test("lists shares and copies", async () => {
+    mockListShares.mockResolvedValue([share]);
+    const onNotify = jest.fn();
+    render(<SharesView onNotify={onNotify} />);
+    await waitFor(() => expect(screen.getByText("notes.txt")).toBeInTheDocument());
+    fireEvent.click(screen.getByText(strings.copy));
+    await waitFor(() =>
+      expect(onNotify).toHaveBeenCalledWith(translate("linkCopied"), "success")
+    );
+  });
+
+  test("load error notifies", async () => {
+    mockListShares.mockRejectedValue(new Error("nope"));
+    const onNotify = jest.fn();
+    render(<SharesView onNotify={onNotify} />);
+    await waitFor(() => expect(onNotify).toHaveBeenCalledWith("nope", "error"));
+  });
+
+  test("revoke error reloads", async () => {
+    mockListShares.mockResolvedValue([share]);
+    mockRevokeShare.mockRejectedValue(new Error("revoke-fail"));
+    const onNotify = jest.fn();
+    render(<SharesView onNotify={onNotify} />);
+    fireEvent.click(await screen.findByText(strings.revoke));
+    await waitFor(() => expect(onNotify).toHaveBeenCalledWith("revoke-fail", "error"));
+  });
+});

--- a/src/app/__tests__/TransferManager.test.tsx
+++ b/src/app/__tests__/TransferManager.test.tsx
@@ -1,0 +1,81 @@
+import React from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+
+import TransferManager from "../../TransferManager";
+import {
+  useTransferQueue,
+  useTransferQueueActions,
+  useTransferQueueGlobalPaused,
+} from "../transferQueue";
+import { setLang, strings } from "../strings";
+import { TransferTask } from "../types";
+
+jest.mock("../transferQueue", () => ({
+  useTransferQueue: jest.fn(),
+  useTransferQueueActions: jest.fn(),
+  useTransferQueueGlobalPaused: jest.fn(),
+}));
+
+const mockQueue = useTransferQueue as unknown as jest.Mock;
+const mockActionsHook = useTransferQueueActions as unknown as jest.Mock;
+const mockPaused = useTransferQueueGlobalPaused as unknown as jest.Mock;
+
+const failed: TransferTask = {
+  id: "t1",
+  type: "upload",
+  status: "failed",
+  name: "a.txt",
+  basedir: "",
+  remoteKey: "a.txt",
+  loaded: 1,
+  total: 10,
+  error: "boom",
+};
+
+beforeEach(() => {
+  setLang("zh");
+  mockQueue.mockReset();
+  mockActionsHook.mockReset();
+  mockPaused.mockReset();
+  mockPaused.mockReturnValue(false);
+  mockActionsHook.mockReturnValue({
+    retry: jest.fn(),
+    pause: jest.fn(),
+    resume: jest.fn(),
+    cancel: jest.fn(),
+    pauseAll: jest.fn(),
+    resumeAll: jest.fn(),
+    clearFailed: jest.fn(),
+    clearCompleted: jest.fn(),
+  });
+});
+
+describe("TransferManager", () => {
+  test("empty queue copy", () => {
+    mockQueue.mockReturnValue([]);
+    render(<TransferManager open onClose={jest.fn()} />);
+    expect(screen.getByText(strings.noUploadTasks)).toBeInTheDocument();
+  });
+
+  test("failed task retry and cancel", () => {
+    const actions = {
+      retry: jest.fn(),
+      pause: jest.fn(),
+      resume: jest.fn(),
+      cancel: jest.fn(),
+      pauseAll: jest.fn(),
+      resumeAll: jest.fn(),
+      clearFailed: jest.fn(),
+      clearCompleted: jest.fn(),
+    };
+    mockActionsHook.mockReturnValue(actions);
+    mockQueue.mockReturnValue([failed]);
+    render(<TransferManager open onClose={jest.fn()} />);
+    expect(screen.getByText("a.txt")).toBeInTheDocument();
+    expect(screen.getByText("boom")).toBeInTheDocument();
+    fireEvent.click(screen.getByText(strings.retry));
+    expect(actions.retry).toHaveBeenCalledWith("t1");
+    fireEvent.click(screen.getByText(strings.delete));
+    expect(actions.cancel).toHaveBeenCalledWith("t1");
+  });
+});

--- a/src/app/__tests__/TrashView.test.tsx
+++ b/src/app/__tests__/TrashView.test.tsx
@@ -1,0 +1,63 @@
+import React from "react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+import TrashView from "../../TrashView";
+import { listTrash, permanentDeleteTrash, restoreTrash } from "../trash";
+import { setLang, strings, translate } from "../strings";
+import { TrashItem } from "../types";
+
+jest.mock("../trash", () => ({
+  listTrash: jest.fn(),
+  permanentDeleteTrash: jest.fn(),
+  restoreTrash: jest.fn(),
+}));
+
+const mockListTrash = listTrash as unknown as jest.Mock;
+const mockPermanent = permanentDeleteTrash as unknown as jest.Mock;
+const mockRestore = restoreTrash as unknown as jest.Mock;
+
+const item: TrashItem = {
+  trashKey: "t1",
+  originalKey: "a.txt",
+  name: "a.txt",
+  deletedAt: "2026-01-01T00:00:00.000Z",
+  size: 12,
+};
+
+beforeEach(() => {
+  setLang("zh");
+  mockListTrash.mockReset();
+  mockPermanent.mockReset();
+  mockRestore.mockReset();
+});
+
+describe("TrashView", () => {
+  test("empty trash state", async () => {
+    mockListTrash.mockResolvedValue([]);
+    const onGoFiles = jest.fn();
+    render(<TrashView onNotify={jest.fn()} onGoFiles={onGoFiles} />);
+    await waitFor(() => expect(screen.getByText(strings.emptyTrash)).toBeInTheDocument());
+    fireEvent.click(screen.getByText(strings.goToFiles));
+    expect(onGoFiles).toHaveBeenCalled();
+  });
+
+  test("select and restore", async () => {
+    mockListTrash.mockResolvedValue([item]);
+    mockRestore.mockResolvedValue([{ trashKey: "t1", status: "restored" }]);
+    const onNotify = jest.fn();
+    render(<TrashView onNotify={onNotify} />);
+    fireEvent.click(await screen.findByText("a.txt"));
+    fireEvent.click(screen.getByText(strings.restoreBtn));
+    await waitFor(() =>
+      expect(onNotify).toHaveBeenCalledWith(translate("restoreDone"), "success")
+    );
+    expect(mockRestore).toHaveBeenCalledWith(["t1"]);
+  });
+
+  test("load error notifies", async () => {
+    mockListTrash.mockRejectedValue(new Error("trash-fail"));
+    const onNotify = jest.fn();
+    render(<TrashView onNotify={onNotify} />);
+    await waitFor(() => expect(onNotify).toHaveBeenCalledWith("trash-fail", "error"));
+  });
+});

--- a/src/app/__tests__/transferExtra.test.ts
+++ b/src/app/__tests__/transferExtra.test.ts
@@ -1,0 +1,234 @@
+import {
+  collectFilesFromDataTransfer,
+  davHrefToKey,
+  downloadArchive,
+  downloadFile,
+  fetchPath,
+  openFile,
+  processTransferTask,
+  selectDirectoryFiles,
+} from "../transfer";
+import { authFetch } from "../auth";
+import { setLang } from "../strings";
+
+jest.mock("p-limit", () => ({
+  __esModule: true,
+  default: () => (fn: () => Promise<unknown>) => fn(),
+}));
+
+jest.mock("../auth", () => ({
+  authFetch: jest.fn(),
+  basicAuthHeader: jest.fn(),
+}));
+
+const mockAuthFetch = authFetch as unknown as jest.Mock;
+
+function blobResponse(ok = true) {
+  return {
+    ok,
+    status: ok ? 200 : 500,
+    headers: { get: () => null },
+    blob: async () => new Blob(["data"]),
+    text: async () => (ok ? "" : "fail"),
+  } as unknown as Response;
+}
+
+beforeEach(() => {
+  mockAuthFetch.mockReset();
+  setLang("zh");
+  if (!(URL as any).createObjectURL) {
+    (URL as any).createObjectURL = jest.fn(() => "blob:x");
+  }
+  if (!(URL as any).revokeObjectURL) {
+    (URL as any).revokeObjectURL = jest.fn();
+  }
+});
+
+describe("davHrefToKey extra", () => {
+  test("invalid absolute URL falls back to /webdav/ slice", () => {
+    expect(davHrefToKey("not-a-url:/webdav/z.txt")).toBe("z.txt");
+  });
+});
+
+describe("fetchPath extra", () => {
+  test("non-ok throws", async () => {
+    mockAuthFetch.mockResolvedValue({
+      ok: false,
+      status: 500,
+      headers: { get: () => "application/xml" },
+      text: async () => "x",
+    });
+    await expect(fetchPath("")).rejects.toThrow("Failed to fetch");
+  });
+});
+
+describe("open/download", () => {
+  test("openFile success", async () => {
+    mockAuthFetch.mockResolvedValue(blobResponse(true));
+    const open = jest.fn();
+    window.open = open;
+    await openFile("a.txt");
+    expect(open).toHaveBeenCalled();
+  });
+
+  test("openFile failure", async () => {
+    mockAuthFetch.mockResolvedValue(blobResponse(false));
+    await expect(openFile("a.txt")).rejects.toThrow();
+  });
+
+  test("downloadFile success", async () => {
+    mockAuthFetch.mockResolvedValue(blobResponse(true));
+    const click = jest.fn();
+    const orig = document.createElement.bind(document);
+    jest.spyOn(document, "createElement").mockImplementation((tag: string) => {
+      const el = orig(tag);
+      if (tag === "a") (el as HTMLAnchorElement).click = click;
+      return el;
+    });
+    await downloadFile("a.txt");
+    expect(click).toHaveBeenCalled();
+    (document.createElement as jest.Mock).mockRestore();
+  });
+
+  test("downloadArchive failure", async () => {
+    mockAuthFetch.mockResolvedValue(blobResponse(false));
+    await expect(downloadArchive(["a.txt"])).rejects.toThrow();
+  });
+});
+
+describe("collectFilesFromDataTransfer extra", () => {
+  test("walks directory entry", async () => {
+    const file = new File(["x"], "a.txt");
+    const fileEntry = {
+      isFile: true,
+      isDirectory: false,
+      name: "a.txt",
+      file: (resolve: (f: File) => void) => resolve(file),
+    };
+    const dirEntry = {
+      isFile: false,
+      isDirectory: true,
+      name: "d",
+      createReader: () => {
+        let n = 0;
+        return {
+          readEntries: (resolve: (entries: unknown[]) => void) => {
+            if (n === 0) {
+              n += 1;
+              resolve([fileEntry]);
+            } else {
+              resolve([]);
+            }
+          },
+        };
+      },
+    };
+    const dt = {
+      files: [],
+      items: [{ webkitGetAsEntry: () => dirEntry }],
+    } as unknown as DataTransfer;
+    const files = await collectFilesFromDataTransfer(dt);
+    expect(files).toHaveLength(1);
+    expect(files[0].name).toBe("a.txt");
+  });
+});
+
+describe("selectDirectoryFiles", () => {
+  test("falls back to input when picker missing", async () => {
+    const origPicker = (window as any).showDirectoryPicker;
+    delete (window as any).showDirectoryPicker;
+    const orig = document.createElement.bind(document);
+    jest.spyOn(document, "createElement").mockImplementation((tag: string) => {
+      const el = orig(tag) as HTMLInputElement;
+      if (tag === "input") {
+        el.click = () => {
+          Object.defineProperty(el, "files", {
+            value: [new File(["a"], "picked.txt")],
+            configurable: true,
+          });
+          el.onchange?.(new Event("change") as any);
+        };
+      }
+      return el;
+    });
+    const files = await selectDirectoryFiles();
+    expect(files[0].name).toBe("picked.txt");
+    (document.createElement as jest.Mock).mockRestore();
+    if (origPicker) (window as any).showDirectoryPicker = origPicker;
+  });
+});
+
+describe("processTransferTask extra", () => {
+  test("small file upload via xhr", async () => {
+    class MockXHR {
+      upload = { onprogress: null as any };
+      status = 201;
+      responseText = "";
+      onload: any;
+      onerror: any;
+      onabort: any;
+      open() {}
+      setRequestHeader() {}
+      getAllResponseHeaders() {
+        return "";
+      }
+      abort() {}
+      send() {
+        this.onload?.();
+      }
+    }
+    (global as any).XMLHttpRequest = MockXHR;
+    const file = new File(["hello"], "plain.txt", { type: "text/plain" });
+    const res = await processTransferTask({
+      task: {
+        id: "1",
+        type: "upload",
+        status: "in-progress",
+        name: "plain.txt",
+        basedir: "",
+        remoteKey: "plain.txt",
+        loaded: 0,
+        total: 5,
+        file,
+      } as any,
+    });
+    expect(res.status).toBe(201);
+  });
+
+  test("xhr non-ok throws", async () => {
+    class MockXHR {
+      upload = { onprogress: null as any };
+      status = 500;
+      responseText = "nope";
+      onload: any;
+      onerror: any;
+      onabort: any;
+      open() {}
+      setRequestHeader() {}
+      getAllResponseHeaders() {
+        return "";
+      }
+      abort() {}
+      send() {
+        this.onload?.();
+      }
+    }
+    (global as any).XMLHttpRequest = MockXHR;
+    const file = new File(["hello"], "plain2.txt", { type: "text/plain" });
+    await expect(
+      processTransferTask({
+        task: {
+          id: "2",
+          type: "upload",
+          status: "in-progress",
+          name: "plain2.txt",
+          basedir: "",
+          remoteKey: "plain2.txt",
+          loaded: 0,
+          total: 5,
+          file,
+        } as any,
+      })
+    ).rejects.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary
- Add Jest/RTL unit tests for previously 0% UI surfaces: App, Main (happy/error listing, not 100%), PreviewDialog, TrashView, TransferManager, ApiKeysPanel, ExplorerBar, ShareDialog, SharesView.
- Extra `transfer.ts` coverage: open/download, DataTransfer walk, directory picker fallback, small-file xhr upload + error.
- No product behavior changes. Existing tests still pass (312).

## Coverage
- Before: ~37% statements (reported)
- After: **57.86% statements** / 52.08% branches / 50.11% functions / 58.58% lines
- Command: `CI=true npx react-scripts test --watchAll=false --coverage --coverageReporters=text-summary`

## Test plan
- [x] `CI=true npx react-scripts test --watchAll=false --coverage --coverageReporters=text-summary`
- [ ] CI green on this PR