### PR TITLE
test: 再补单测，覆盖率往 70%

### DIFF
--- a/src/app/__tests__/Main.test.tsx
+++ b/src/app/__tests__/Main.test.tsx
@@ -1,12 +1,24 @@
 import React from "react";
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 
 import Main from "../../Main";
 import { ClipboardProvider } from "../clipboard";
 import { DEFAULT_FEATURE_FLAGS, useFeatures } from "../features";
 import { useAuth } from "../auth";
-import { fetchPath } from "../transfer";
-import { setLang, strings } from "../strings";
+import {
+  collectFilesFromDataTransfer,
+  copyPaste,
+  createFolder,
+  downloadArchive,
+  downloadFile,
+  fetchFolderCounts,
+  fetchPath,
+  openFile,
+  searchFiles,
+  selectDirectoryFiles,
+} from "../transfer";
+import { moveToTrash, restoreTrash } from "../trash";
+import { setLang, strings, translate } from "../strings";
 
 jest.mock("../auth", () => ({
   useAuth: jest.fn(),
@@ -18,9 +30,10 @@ jest.mock("../features", () => {
   return { ...actual, useFeatures: jest.fn() };
 });
 
+const mockEnqueue = jest.fn();
 jest.mock("../transferQueue", () => ({
   useTransferQueue: () => [],
-  useUploadEnqueue: () => jest.fn(),
+  useUploadEnqueue: () => mockEnqueue,
 }));
 
 jest.mock("../transfer", () => ({
@@ -57,6 +70,17 @@ jest.mock("../../MimeIcon", () => ({ __esModule: true, default: () => <span /> }
 const mockUseAuth = useAuth as unknown as jest.Mock;
 const mockUseFeatures = useFeatures as unknown as jest.Mock;
 const mockFetchPath = fetchPath as unknown as jest.Mock;
+const mockSearch = searchFiles as unknown as jest.Mock;
+const mockCopyPaste = copyPaste as unknown as jest.Mock;
+const mockCreateFolder = createFolder as unknown as jest.Mock;
+const mockMoveTrash = moveToTrash as unknown as jest.Mock;
+const mockRestore = restoreTrash as unknown as jest.Mock;
+const mockCollect = collectFilesFromDataTransfer as unknown as jest.Mock;
+const mockSelectDir = selectDirectoryFiles as unknown as jest.Mock;
+const mockDownload = downloadFile as unknown as jest.Mock;
+const mockArchive = downloadArchive as unknown as jest.Mock;
+const mockOpen = openFile as unknown as jest.Mock;
+const mockCounts = fetchFolderCounts as unknown as jest.Mock;
 
 const file = {
   key: "a.txt",
@@ -65,6 +89,24 @@ const file = {
   size: 1,
   uploaded: "2026-01-01T00:00:00.000Z",
   contentType: "text/plain",
+};
+
+const folder = {
+  key: "docs",
+  name: "docs",
+  isDir: true,
+  size: 0,
+  uploaded: "2026-01-02T00:00:00.000Z",
+  contentType: "application/x-directory",
+};
+
+const hidden = {
+  key: ".DS_Store",
+  name: ".DS_Store",
+  isDir: false,
+  size: 1,
+  uploaded: "2026-01-03T00:00:00.000Z",
+  contentType: "application/octet-stream",
 };
 
 function renderMain(route: any = { kind: "folder", path: "" }, extra: Partial<React.ComponentProps<typeof Main>> = {}) {
@@ -79,6 +121,7 @@ function renderMain(route: any = { kind: "folder", path: "" }, extra: Partial<Re
     route,
     navigate: jest.fn(),
     onOpenApi: jest.fn(),
+    onContentScroll: jest.fn(),
     ...extra,
   };
   const result = render(
@@ -95,10 +138,15 @@ beforeAll(() => {
     unobserve() {}
     disconnect() {}
   };
+  Element.prototype.scrollIntoView = jest.fn();
+  Object.assign(navigator, {
+    clipboard: { writeText: jest.fn().mockResolvedValue(undefined) },
+  });
 });
 
 beforeEach(() => {
   setLang("zh");
+  mockEnqueue.mockReset();
   mockUseAuth.mockReturnValue({ username: "alice", login: jest.fn(), logout: jest.fn() });
   mockUseFeatures.mockReturnValue({
     flags: DEFAULT_FEATURE_FLAGS,
@@ -108,7 +156,28 @@ beforeEach(() => {
     config: { username: "alice", publicRead: false, sitesHost: null, flags: DEFAULT_FEATURE_FLAGS },
   });
   mockFetchPath.mockReset();
-  mockFetchPath.mockResolvedValue([file]);
+  mockFetchPath.mockResolvedValue([file, folder, hidden]);
+  mockSearch.mockReset();
+  mockSearch.mockResolvedValue({ items: [file], hasMore: false });
+  mockCopyPaste.mockReset();
+  mockCopyPaste.mockResolvedValue(undefined);
+  mockCreateFolder.mockReset();
+  mockCreateFolder.mockResolvedValue(undefined);
+  mockMoveTrash.mockReset();
+  mockMoveTrash.mockResolvedValue({ results: [{ id: "t1" }] });
+  mockRestore.mockReset();
+  mockRestore.mockResolvedValue(undefined);
+  mockCollect.mockReset();
+  mockCollect.mockResolvedValue([]);
+  mockSelectDir.mockReset();
+  mockSelectDir.mockResolvedValue([]);
+  mockDownload.mockReset();
+  mockDownload.mockResolvedValue(undefined);
+  mockArchive.mockReset();
+  mockArchive.mockResolvedValue(undefined);
+  mockOpen.mockReset();
+  mockCounts.mockResolvedValue({ docs: 2 });
+  sessionStorage.clear();
 });
 
 describe("Main", () => {
@@ -136,5 +205,193 @@ describe("Main", () => {
     await waitFor(() => expect(screen.getByText("a.txt")).toBeInTheDocument());
     fireEvent.click(screen.getByLabelText(strings.trash));
     expect(props.navigate).toHaveBeenCalledWith({ kind: "trash" });
+  });
+
+  test("sites/images/settings/trash stubs", async () => {
+    const { unmount } = renderMain({ kind: "sites" });
+    await waitFor(() => expect(screen.getByText("sites-stub")).toBeInTheDocument());
+    unmount();
+    const r2 = renderMain({ kind: "images" });
+    await waitFor(() => expect(screen.getByText("images-stub")).toBeInTheDocument());
+    r2.unmount();
+    const r3 = renderMain({ kind: "settings" });
+    await waitFor(() => expect(screen.getByText("settings-stub")).toBeInTheDocument());
+    r3.unmount();
+    renderMain({ kind: "trash" });
+    await waitFor(() => expect(screen.getByText("trash-stub")).toBeInTheDocument());
+  });
+
+  test("disabled sites/images flags bounce back to folder", async () => {
+    mockUseFeatures.mockReturnValue({
+      flags: { ...DEFAULT_FEATURE_FLAGS, sites: false, imageHost: false },
+      sitesHost: null,
+      updateFlags: jest.fn(),
+      refresh: jest.fn(),
+      config: { username: "alice", publicRead: false, sitesHost: null, flags: DEFAULT_FEATURE_FLAGS },
+    });
+    const { props } = renderMain({ kind: "sites" });
+    await waitFor(() =>
+      expect(props.navigate).toHaveBeenCalledWith({ kind: "folder", path: "" })
+    );
+  });
+
+  test("copy path, search scope, create folder, keyboard select/delete", async () => {
+    const onNotify = jest.fn();
+    const { props } = renderMain({ kind: "folder", path: "docs/" }, { onNotify });
+    mockFetchPath.mockResolvedValue([file]);
+    await waitFor(() => expect(screen.getByText("a.txt")).toBeInTheDocument());
+
+    fireEvent.click(screen.getByLabelText(strings.copyPath));
+    await waitFor(() =>
+      expect(onNotify).toHaveBeenCalledWith(translate("pathCopied"), "success")
+    );
+
+    fireEvent.click(screen.getByText(strings.searchAll));
+    fireEvent.click(screen.getByText(strings.createFolder));
+    fireEvent.change(screen.getByLabelText(strings.folderName), {
+      target: { value: "newdir" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: strings.create }));
+    await waitFor(() => expect(mockCreateFolder).toHaveBeenCalledWith("docs/", "newdir"));
+    await waitFor(() =>
+      expect(screen.queryByLabelText(strings.folderName)).not.toBeInTheDocument()
+    );
+
+    fireEvent.click(
+      screen.getByLabelText(translate("selectFileLabel", { name: "a.txt" }))
+    );
+    fireEvent.click(screen.getByRole("button", { name: strings.copy }));
+    expect(onNotify).toHaveBeenCalledWith(translate("copiedToClipboard"), "success");
+    fireEvent.click(screen.getByRole("button", { name: strings.delete }));
+    fireEvent.click(screen.getByRole("button", { name: strings.confirmAction }));
+    await waitFor(() => expect(mockMoveTrash).toHaveBeenCalled());
+  });
+
+  test("context menu copy/cut/download and open folder", async () => {
+    const onNotify = jest.fn();
+    const { props } = renderMain({ kind: "folder", path: "" }, { onNotify, view: "list" });
+    await waitFor(() => expect(screen.getByText("a.txt")).toBeInTheDocument());
+    fireEvent.click(
+      screen.getByLabelText(translate("fileActionsLabel", { name: "a.txt" }))
+    );
+    fireEvent.click(screen.getByRole("menuitem", { name: strings.copy }));
+    expect(onNotify).toHaveBeenCalledWith(translate("copiedToClipboard"), "success");
+
+    fireEvent.click(
+      screen.getByLabelText(translate("fileActionsLabel", { name: "a.txt" }))
+    );
+    fireEvent.click(screen.getByRole("menuitem", { name: strings.cut }));
+    expect(onNotify).toHaveBeenCalledWith(translate("cutToClipboard"), "success");
+
+    fireEvent.click(
+      screen.getByLabelText(translate("fileActionsLabel", { name: "a.txt" }))
+    );
+    fireEvent.click(screen.getByRole("menuitem", { name: strings.download }));
+    await waitFor(() => expect(mockDownload).toHaveBeenCalledWith("a.txt"));
+
+    fireEvent.click(screen.getByText("docs"));
+    expect(props.navigate).toHaveBeenCalledWith({ kind: "folder", path: "docs/" });
+  });
+
+  test("rename via F2 and paste clipboard", async () => {
+    const onNotify = jest.fn();
+    renderMain({ kind: "folder", path: "" }, { onNotify });
+    await waitFor(() => expect(screen.getByText("a.txt")).toBeInTheDocument());
+    fireEvent.click(
+      screen.getByLabelText(translate("selectFileLabel", { name: "a.txt" }))
+    );
+    fireEvent.keyDown(window, { key: "F2" });
+    await waitFor(() => expect(screen.getByLabelText(strings.name)).toBeInTheDocument());
+    fireEvent.change(screen.getByLabelText(strings.name), {
+      target: { value: "b.txt" },
+    });
+    fireEvent.click(screen.getByText(strings.ok));
+    await waitFor(() => expect(mockCopyPaste).toHaveBeenCalled());
+    await waitFor(() =>
+      expect(screen.queryByLabelText(strings.name)).not.toBeInTheDocument()
+    );
+
+    fireEvent.click(
+      screen.getByLabelText(translate("fileActionsLabel", { name: "a.txt" }))
+    );
+    fireEvent.click(screen.getByRole("menuitem", { name: strings.copy }));
+    const pasteBtn = screen.getByRole("button", { name: new RegExp(strings.paste) });
+    fireEvent.click(pasteBtn);
+    await waitFor(() => expect(mockCopyPaste).toHaveBeenCalled());
+  });
+
+  test("keyboard arrows, select all, escape, enter, backspace, delete", async () => {
+    const { props } = renderMain({ kind: "folder", path: "docs/" });
+    await waitFor(() => expect(screen.getByText("a.txt")).toBeInTheDocument());
+    fireEvent.keyDown(window, { key: "ArrowDown" });
+    fireEvent.keyDown(window, { key: " " });
+    fireEvent.keyDown(window, { key: "a", ctrlKey: true });
+    fireEvent.keyDown(window, { key: "Escape" });
+    fireEvent.keyDown(window, { key: "Home" });
+    fireEvent.keyDown(window, { key: "End" });
+    fireEvent.keyDown(window, { key: "Enter" });
+    fireEvent.keyDown(window, { key: "Backspace" });
+    expect(props.navigate).toHaveBeenCalled();
+    fireEvent.keyDown(window, { key: "Delete" });
+  });
+
+  test("window file paste and drag overlay", async () => {
+    const onNotify = jest.fn();
+    renderMain({ kind: "folder", path: "" }, { onNotify });
+    await waitFor(() => expect(screen.getByText("a.txt")).toBeInTheDocument());
+    const pasted = new File(["x"], "image.png", { type: "image/png" });
+    const pasteEvent = new Event("paste", { bubbles: true, cancelable: true });
+    Object.defineProperty(pasteEvent, "clipboardData", {
+      value: {
+        items: [{ kind: "file", getAsFile: () => pasted }],
+      },
+    });
+    Object.defineProperty(pasteEvent, "target", { value: document.body });
+    window.dispatchEvent(pasteEvent);
+    await waitFor(() => expect(mockEnqueue).toHaveBeenCalled());
+
+    mockCollect.mockResolvedValue([new File(["z"], "drop.txt")]);
+    const dt = { types: ["Files"], files: [] };
+    const enter = new Event("dragenter", { bubbles: true, cancelable: true });
+    Object.defineProperty(enter, "dataTransfer", { value: dt });
+    window.dispatchEvent(enter);
+    await waitFor(() => expect(screen.getByText(strings.dropToUpload)).toBeInTheDocument());
+    const drop = new Event("drop", { bubbles: true, cancelable: true });
+    Object.defineProperty(drop, "dataTransfer", { value: dt });
+    window.dispatchEvent(drop);
+    await waitFor(() => expect(mockCollect).toHaveBeenCalled());
+  });
+
+  test("global search uses searchFiles", async () => {
+    jest.useFakeTimers();
+    renderMain({ kind: "folder", path: "" }, { search: "hello" });
+    await act(async () => {
+      jest.advanceTimersByTime(350);
+    });
+    await waitFor(() => expect(mockSearch).toHaveBeenCalled());
+    jest.useRealTimers();
+  });
+
+  test("sort by size and date still lists files", async () => {
+    const { rerender, props } = renderMain(
+      { kind: "folder", path: "" },
+      { sort: { field: "size", order: "desc" } }
+    );
+    await waitFor(() => expect(screen.getByText("a.txt")).toBeInTheDocument());
+    rerender(
+      <ClipboardProvider>
+        <Main
+          {...props}
+          sort={{ field: "date", order: "asc" }}
+        />
+      </ClipboardProvider>
+    );
+    await waitFor(() => expect(screen.getByText("docs")).toBeInTheDocument());
+  });
+
+  test("username null skips listing", async () => {
+    mockUseAuth.mockReturnValue({ username: null, login: jest.fn(), logout: jest.fn() });
+    renderMain();
+    await waitFor(() => expect(mockFetchPath).not.toHaveBeenCalled());
   });
 });

--- a/src/app/__tests__/PreviewDialog.test.tsx
+++ b/src/app/__tests__/PreviewDialog.test.tsx
@@ -31,12 +31,8 @@ beforeEach(() => {
   setLang("zh");
   mockAuthFetch.mockReset();
   mockDownload.mockReset();
-  if (!URL.createObjectURL) {
-    (URL as any).createObjectURL = jest.fn(() => "blob:preview");
-  }
-  if (!URL.revokeObjectURL) {
-    (URL as any).revokeObjectURL = jest.fn();
-  }
+  (URL as any).createObjectURL = jest.fn(() => "blob:preview");
+  (URL as any).revokeObjectURL = jest.fn();
 });
 
 describe("PreviewDialog", () => {
@@ -108,5 +104,178 @@ describe("PreviewDialog", () => {
       />
     );
     expect(screen.queryByText(strings.share)).not.toBeInTheDocument();
+  });
+});
+
+
+function blobFetch(type: string) {
+  return {
+    ok: true,
+    headers: { get: () => null },
+    blob: async () => new Blob(["xx"], { type }),
+    body: null,
+  };
+}
+
+describe("PreviewDialog leftovers", () => {
+  test("image preview rotate, download, siblings", async () => {
+    mockAuthFetch.mockResolvedValue(blobFetch("image/png"));
+    const onSibling = jest.fn();
+    const img: FileItem = {
+      key: "a.png",
+      name: "a.png",
+      isDir: false,
+      size: 4,
+      uploaded: "",
+      contentType: "image/png",
+    };
+    const img2: FileItem = { ...img, key: "b.png", name: "b.png" };
+    render(
+      <PreviewDialog
+        file={img}
+        siblings={[img, img2]}
+        onSibling={onSibling}
+        onClose={jest.fn()}
+        onNotify={jest.fn()}
+        onShare={jest.fn()}
+        onRename={jest.fn()}
+        onDelete={jest.fn()}
+      />
+    );
+    await waitFor(() => expect(screen.getByLabelText(strings.nextFile)).toBeEnabled());
+    fireEvent.click(screen.getByLabelText(strings.nextFile));
+    expect(onSibling).toHaveBeenCalledWith(img2);
+    fireEvent.click(screen.getByText(strings.nextFile));
+    fireEvent.keyDown(window, { key: "ArrowRight" });
+    fireEvent.click(screen.getByText(strings.download));
+    expect(mockDownload).toHaveBeenCalled();
+  });
+
+  test("too-large text skips fetch", async () => {
+    const big: FileItem = {
+      key: "huge.txt",
+      name: "huge.txt",
+      isDir: false,
+      size: 5 * 1024 * 1024,
+      uploaded: "",
+      contentType: "text/plain",
+    };
+    render(
+      <PreviewDialog
+        file={big}
+        onClose={jest.fn()}
+        onNotify={jest.fn()}
+        onShare={jest.fn()}
+        onRename={jest.fn()}
+        onDelete={jest.fn()}
+      />
+    );
+    await waitFor(() =>
+      expect(screen.getByText(strings.previewTooLargeTitle)).toBeInTheDocument()
+    );
+    expect(mockAuthFetch).not.toHaveBeenCalled();
+  });
+
+  test("json parse warning and copy all", async () => {
+    const bytes = new TextEncoder().encode("{not json");
+    mockAuthFetch.mockResolvedValue({
+      ok: true,
+      headers: { get: () => null },
+      body: {
+        getReader: () => {
+          let done = false;
+          return {
+            read: async () => {
+              if (done) return { done: true, value: undefined };
+              done = true;
+              return { done: false, value: bytes };
+            },
+            cancel: async () => {},
+          };
+        },
+      },
+    });
+    Object.assign(navigator, {
+      clipboard: { writeText: jest.fn().mockResolvedValue(undefined) },
+    });
+    const jsonFile: FileItem = {
+      key: "a.json",
+      name: "a.json",
+      isDir: false,
+      size: 9,
+      uploaded: "",
+      contentType: "application/json",
+    };
+    const onNotify = jest.fn();
+    render(
+      <PreviewDialog
+        file={jsonFile}
+        onClose={jest.fn()}
+        onNotify={onNotify}
+        onShare={jest.fn()}
+        onRename={jest.fn()}
+        onDelete={jest.fn()}
+      />
+    );
+    await waitFor(() =>
+      expect(screen.getByText(strings.jsonParseFailed)).toBeInTheDocument()
+    );
+    fireEvent.click(screen.getByText(strings.copyAll));
+    await waitFor(() =>
+      expect(onNotify).toHaveBeenCalledWith(expect.any(String), "success")
+    );
+  });
+
+  test("video and pdf and audio urls", async () => {
+    mockAuthFetch.mockResolvedValue(blobFetch("video/mp4"));
+    const video: FileItem = {
+      key: "a.mp4",
+      name: "a.mp4",
+      isDir: false,
+      size: 4,
+      uploaded: "",
+      contentType: "video/mp4",
+    };
+    const { unmount } = render(
+      <PreviewDialog
+        file={video}
+        onClose={jest.fn()}
+        onNotify={jest.fn()}
+        onShare={jest.fn()}
+        onRename={jest.fn()}
+        onDelete={jest.fn()}
+      />
+    );
+    await waitFor(() => expect(screen.getByText("a.mp4")).toBeInTheDocument());
+    unmount();
+
+    mockAuthFetch.mockResolvedValue(blobFetch("audio/mpeg"));
+    const audio: FileItem = { ...video, key: "a.mp3", name: "a.mp3", contentType: "audio/mpeg" };
+    const r2 = render(
+      <PreviewDialog
+        file={audio}
+        onClose={jest.fn()}
+        onNotify={jest.fn()}
+        onShare={jest.fn()}
+        onRename={jest.fn()}
+        onDelete={jest.fn()}
+      />
+    );
+    await waitFor(() => expect(document.querySelector("audio")).toBeTruthy());
+    r2.unmount();
+
+    mockAuthFetch.mockResolvedValue(blobFetch("application/pdf"));
+    const pdf: FileItem = { ...video, key: "a.pdf", name: "a.pdf", contentType: "application/pdf" };
+    render(
+      <PreviewDialog
+        file={pdf}
+        onClose={jest.fn()}
+        onNotify={jest.fn()}
+        onShare={jest.fn()}
+        onRename={jest.fn()}
+        onDelete={jest.fn()}
+      />
+    );
+    await waitFor(() => expect(document.querySelector("iframe")).toBeTruthy());
   });
 });

--- a/src/app/__tests__/coverageViews.test.tsx
+++ b/src/app/__tests__/coverageViews.test.tsx
@@ -1,0 +1,286 @@
+import React from "react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+import ImagesView from "../../ImagesView";
+import SettingsView from "../../SettingsView";
+import SitesView from "../../SitesView";
+import { DEFAULT_FEATURE_FLAGS, useFeatures } from "../features";
+import { deleteImage, listImages, uploadImage } from "../images";
+import { deleteSite, listSites, updateSiteConfig } from "../sites";
+import { setLang, strings, translate } from "../strings";
+
+jest.mock("../features", () => {
+  const actual = jest.requireActual("../features");
+  return { ...actual, useFeatures: jest.fn() };
+});
+
+jest.mock("../sites", () => {
+  const actual = jest.requireActual("../sites");
+  return {
+    ...actual,
+    listSites: jest.fn(),
+    updateSiteConfig: jest.fn(),
+    deleteSite: jest.fn(),
+  };
+});
+
+jest.mock("../images", () => {
+  const actual = jest.requireActual("../images");
+  return {
+    ...actual,
+    listImages: jest.fn(),
+    uploadImage: jest.fn(),
+    deleteImage: jest.fn(),
+  };
+});
+
+const mockEnqueue = jest.fn();
+jest.mock("../transferQueue", () => ({
+  useUploadEnqueue: () => mockEnqueue,
+}));
+
+jest.mock("fflate", () => ({
+  unzip: (_data: Uint8Array, cb: (err: Error | null, out: Record<string, Uint8Array>) => void) => {
+    cb(null, {
+      "index.html": new Uint8Array([60, 104, 116, 109, 108, 62]),
+      "nested/app.js": new Uint8Array([1, 2, 3]),
+      "dir/": new Uint8Array([]),
+      "__MACOSX/._index.html": new Uint8Array([0]),
+    });
+  },
+}));
+
+const mockUseFeatures = useFeatures as unknown as jest.Mock;
+const mockListSites = listSites as unknown as jest.Mock;
+const mockUpdateSite = updateSiteConfig as unknown as jest.Mock;
+const mockDeleteSite = deleteSite as unknown as jest.Mock;
+const mockListImages = listImages as unknown as jest.Mock;
+const mockUploadImage = uploadImage as unknown as jest.Mock;
+const mockDeleteImage = deleteImage as unknown as jest.Mock;
+
+const hosted = {
+  id: "img1",
+  name: "photo.png",
+  size: 12,
+  uploaded: "2026-01-01T00:00:00.000Z",
+  contentType: "image/png",
+  url: "https://img.example/photo.png",
+  markdown: "![photo](https://img.example/photo.png)",
+};
+
+const site = {
+  slug: "blog",
+  spa: true,
+  stats: { objects: 3, size: 40, cachedAt: "2026-01-01T00:00:00.000Z" },
+};
+
+beforeEach(() => {
+  if (!(File.prototype as any).arrayBuffer) {
+    (File.prototype as any).arrayBuffer = function () {
+      return new Promise((resolve) => {
+        const reader = new FileReader();
+        reader.onload = () => resolve(reader.result);
+        reader.readAsArrayBuffer(this);
+      });
+    };
+  }
+  setLang("en");
+  mockEnqueue.mockReset();
+  mockUseFeatures.mockReset();
+  mockListSites.mockReset();
+  mockUpdateSite.mockReset();
+  mockDeleteSite.mockReset();
+  mockListImages.mockReset();
+  mockUploadImage.mockReset();
+  mockDeleteImage.mockReset();
+  mockUseFeatures.mockReturnValue({
+    flags: DEFAULT_FEATURE_FLAGS,
+    sitesHost: "sites.example.com",
+    updateFlags: jest.fn().mockResolvedValue(undefined),
+  });
+  Object.assign(navigator, {
+    clipboard: { writeText: jest.fn().mockResolvedValue(undefined) },
+  });
+});
+
+describe("SettingsView leftovers", () => {
+  test("toggles a flag and notifies success", async () => {
+    const onNotify = jest.fn();
+    const updateFlags = jest.fn().mockResolvedValue(undefined);
+    mockUseFeatures.mockReturnValue({
+      flags: DEFAULT_FEATURE_FLAGS,
+      sitesHost: null,
+      updateFlags,
+    });
+    render(<SettingsView onNotify={onNotify} />);
+    expect(screen.getByText(strings.imagesHostMissing)).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("checkbox", { name: strings.flagWebdav }));
+    await waitFor(() => expect(updateFlags).toHaveBeenCalledWith({ webdav: false }));
+    await waitFor(() =>
+      expect(onNotify).toHaveBeenCalledWith(strings.flagSaved, "success")
+    );
+  });
+
+  test("toggle failure notifies error", async () => {
+    const onNotify = jest.fn();
+    const updateFlags = jest.fn().mockRejectedValue(new Error("nope"));
+    mockUseFeatures.mockReturnValue({
+      flags: { ...DEFAULT_FEATURE_FLAGS, mcp: false },
+      sitesHost: "h",
+      updateFlags,
+    });
+    render(<SettingsView onNotify={onNotify} />);
+    fireEvent.click(screen.getByLabelText(strings.flagMcp));
+    await waitFor(() =>
+      expect(onNotify).toHaveBeenCalledWith("nope", "error")
+    );
+  });
+});
+
+describe("ImagesView leftovers", () => {
+  test("returns null when image host is off", () => {
+    mockUseFeatures.mockReturnValue({
+      flags: { ...DEFAULT_FEATURE_FLAGS, imageHost: false },
+      sitesHost: null,
+    });
+    const { container } = render(<ImagesView onNotify={jest.fn()} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  test("list error notifies", async () => {
+    mockListImages.mockRejectedValue(new Error("images-fail"));
+    const onNotify = jest.fn();
+    render(<ImagesView onNotify={onNotify} />);
+    await waitFor(() => expect(onNotify).toHaveBeenCalledWith("images-fail", "error"));
+  });
+
+  test("lists images, copies url/markdown, uploads, and deletes", async () => {
+    mockListImages.mockResolvedValue({
+      sitesHost: "sites.example.com",
+      images: [hosted],
+    });
+    mockUploadImage.mockResolvedValue({
+      ...hosted,
+      id: "img2",
+      name: "new.png",
+    });
+    mockDeleteImage.mockResolvedValue(undefined);
+    const onNotify = jest.fn();
+    const onGoFiles = jest.fn();
+    render(<ImagesView onNotify={onNotify} onGoFiles={onGoFiles} />);
+    await waitFor(() => expect(screen.getByText("photo.png")).toBeInTheDocument());
+
+    fireEvent.click(screen.getAllByRole("button", { name: strings.copyImageUrl })[0]);
+    await waitFor(() =>
+      expect(onNotify).toHaveBeenCalledWith(strings.imageUrlCopied, "success")
+    );
+    fireEvent.click(screen.getAllByRole("button", { name: strings.copyImageMarkdown })[0]);
+    await waitFor(() =>
+      expect(onNotify).toHaveBeenCalledWith(strings.imageMarkdownCopied, "success")
+    );
+
+    fireEvent.click(screen.getAllByRole("button", { name: strings.deleteImage })[0]);
+    fireEvent.click(screen.getAllByRole("button", { name: strings.deleteImage }).pop()!);
+    await waitFor(() => expect(mockDeleteImage).toHaveBeenCalledWith("img1"));
+    await waitFor(() =>
+      expect(onNotify).toHaveBeenCalledWith(strings.imageDeleted, "success")
+    );
+
+    const file = new File(["xx"], "x.png", { type: "image/png" });
+    const input = document.querySelector('input[type="file"]') as HTMLInputElement;
+    fireEvent.change(input, { target: { files: [file] } });
+    await waitFor(() => expect(mockUploadImage).toHaveBeenCalled());
+
+    fireEvent.drop(screen.getByText(strings.imagesTitle).closest("div")!.parentElement!, {
+      dataTransfer: { files: [new File(["not"], "notes.txt", { type: "text/plain" })], types: ["Files"] },
+    });
+    await waitFor(() =>
+      expect(onNotify).toHaveBeenCalledWith(strings.notAnImage, "error")
+    );
+  });
+
+  test("clipboard copy failure notifies", async () => {
+    mockListImages.mockResolvedValue({ sitesHost: "h", images: [hosted] });
+    (navigator.clipboard.writeText as jest.Mock).mockRejectedValue(new Error("denied"));
+    const onNotify = jest.fn();
+    render(<ImagesView onNotify={onNotify} />);
+    await waitFor(() => expect(screen.getByText("photo.png")).toBeInTheDocument());
+    fireEvent.click(screen.getAllByRole("button", { name: strings.copyImageUrl })[0]);
+    await waitFor(() =>
+      expect(onNotify).toHaveBeenCalledWith(strings.copyFailed2, "error")
+    );
+  });
+});
+
+describe("SitesView leftovers", () => {
+  test("list error notifies and empty go-files works", async () => {
+    mockListSites.mockRejectedValue(new Error("sites-fail"));
+    const onNotify = jest.fn();
+    const onGoFiles = jest.fn();
+    render(
+      <SitesView onNotify={onNotify} onGoFiles={onGoFiles} onManageFiles={jest.fn()} />
+    );
+    await waitFor(() => expect(onNotify).toHaveBeenCalledWith("sites-fail", "error"));
+  });
+
+  test("site actions: spa, copy, manage, delete, deploy zip", async () => {
+    mockListSites.mockResolvedValue({
+      sitesHost: "sites.example.com",
+      sites: [site],
+    });
+    mockUpdateSite.mockResolvedValue(undefined);
+    mockDeleteSite.mockResolvedValue(3);
+    const onNotify = jest.fn();
+    const onManage = jest.fn();
+    const open = jest.fn();
+    window.open = open;
+    render(
+      <SitesView onNotify={onNotify} onManageFiles={onManage} />
+    );
+    await waitFor(() => expect(screen.getByText("blog")).toBeInTheDocument());
+
+    fireEvent.click(screen.getByRole("checkbox", { name: strings.siteSpaLabel }));
+    await waitFor(() => expect(mockUpdateSite).toHaveBeenCalledWith("blog", false));
+
+    fireEvent.click(screen.getAllByRole("button", { name: strings.openSite })[0]);
+    expect(open).toHaveBeenCalled();
+
+    fireEvent.click(screen.getAllByRole("button", { name: strings.manageFiles })[0]);
+    expect(onManage).toHaveBeenCalledWith("blog");
+
+    fireEvent.click(screen.getAllByRole("button", { name: strings.copy })[0]);
+    await waitFor(() =>
+      expect(onNotify).toHaveBeenCalledWith(translate("linkCopied"), "success")
+    );
+
+    fireEvent.click(screen.getByText(strings.deleteSite));
+    fireEvent.click(screen.getAllByText(strings.deleteSite).pop()!);
+    await waitFor(() => expect(mockDeleteSite).toHaveBeenCalled());
+
+    fireEvent.click(screen.getByText(strings.deployZip));
+    const zipInput = document.querySelector('input[accept=".zip,application/zip"]') as HTMLInputElement;
+    const zip = new File([new Uint8Array([1, 2, 3, 4])], "site.zip", {
+      type: "application/zip",
+    });
+    fireEvent.change(zipInput, { target: { files: [zip] } });
+    await waitFor(() =>
+      expect(screen.getByText(zip.name)).toBeInTheDocument()
+    );
+    fireEvent.click(screen.getAllByText(strings.deployZip).pop()!);
+    await waitFor(() => expect(mockEnqueue).toHaveBeenCalled());
+    expect(mockDeleteSite).toHaveBeenCalled();
+  });
+
+  test("spa save failure reloads list", async () => {
+    mockListSites
+      .mockResolvedValueOnce({ sitesHost: "h", sites: [site] })
+      .mockResolvedValueOnce({ sitesHost: "h", sites: [site] })
+      .mockResolvedValue({ sitesHost: "h", sites: [site] });
+    mockUpdateSite.mockRejectedValue(new Error("spa-fail"));
+    const onNotify = jest.fn();
+    render(<SitesView onNotify={onNotify} onManageFiles={jest.fn()} />);
+    await waitFor(() => expect(screen.getByText("blog")).toBeInTheDocument());
+    fireEvent.click(screen.getByRole("checkbox", { name: strings.siteSpaLabel }));
+    await waitFor(() => expect(onNotify).toHaveBeenCalledWith("spa-fail", "error"));
+  });
+});

--- a/src/app/__tests__/features.test.ts
+++ b/src/app/__tests__/features.test.ts
@@ -17,7 +17,7 @@ function jsonResponse(body: unknown, ok = true, status = 200) {
     ok,
     status,
     json: async () => body,
-    text: async () => JSON.stringify(body),
+    text: async () => (ok ? JSON.stringify(body) : ""),
   } as unknown as Response;
 }
 
@@ -53,6 +53,17 @@ describe("parseAppConfig", () => {
       imageHost: false,
     });
   });
+
+  test("non-object payload and empty sitesHost fall back", () => {
+    expect(parseAppConfig(null)).toEqual({
+      username: "",
+      publicRead: false,
+      sitesHost: null,
+      flags: DEFAULT_FEATURE_FLAGS,
+    });
+    expect(parseAppConfig({ sitesHost: "" }).sitesHost).toBeNull();
+    expect(parseAppConfig({ publicRead: "yes" }).publicRead).toBe(false);
+  });
 });
 
 describe("config client", () => {
@@ -65,6 +76,21 @@ describe("config client", () => {
     expect(config.flags.webdav).toBe(true);
   });
 
+  test("fetchAppConfig throws on empty error body", async () => {
+    mockAuthFetch.mockResolvedValue(jsonResponse({}, false, 500));
+    await expect(fetchAppConfig()).rejects.toThrow();
+  });
+
+  test("fetchAppConfig uses response text when present", async () => {
+    mockAuthFetch.mockResolvedValue({
+      ok: false,
+      status: 500,
+      json: async () => ({}),
+      text: async () => "config-down",
+    } as unknown as Response);
+    await expect(fetchAppConfig()).rejects.toThrow("config-down");
+  });
+
   test("patchFeatureFlags PATCHes flags", async () => {
     mockAuthFetch.mockResolvedValue(
       jsonResponse({ username: "a", publicRead: false, webdav: false })
@@ -74,5 +100,15 @@ describe("config client", () => {
     expect(url).toBe("/api/config");
     expect(init.method).toBe("PATCH");
     expect(JSON.parse(init.body)).toEqual({ webdav: false });
+  });
+
+  test("patchFeatureFlags throws on failure", async () => {
+    mockAuthFetch.mockResolvedValue({
+      ok: false,
+      status: 400,
+      json: async () => ({}),
+      text: async () => "save-fail",
+    } as unknown as Response);
+    await expect(patchFeatureFlags({ mcp: false })).rejects.toThrow("save-fail");
   });
 });

--- a/src/app/__tests__/featuresProvider.test.tsx
+++ b/src/app/__tests__/featuresProvider.test.tsx
@@ -1,0 +1,107 @@
+import React from "react";
+import { act, render, screen, waitFor } from "@testing-library/react";
+
+import { authFetch, useAuth } from "../auth";
+import { FeaturesProvider, useFeatures } from "../features";
+
+jest.mock("../auth", () => ({
+  authFetch: jest.fn(),
+  useAuth: jest.fn(),
+}));
+
+const mockAuthFetch = authFetch as unknown as jest.Mock;
+const mockUseAuth = useAuth as unknown as jest.Mock;
+
+function Probe() {
+  const { flags, sitesHost, config, refresh, updateFlags } = useFeatures();
+  return (
+    <div>
+      <span data-testid="webdav">{String(flags.webdav)}</span>
+      <span data-testid="host">{sitesHost ?? "none"}</span>
+      <span data-testid="user">{config.username}</span>
+      <button type="button" onClick={() => refresh()}>
+        refresh
+      </button>
+      <button
+        type="button"
+        onClick={() => updateFlags({ webdav: false }).catch(() => {})}
+      >
+        patch
+      </button>
+    </div>
+  );
+}
+
+function jsonResponse(body: unknown, ok = true) {
+  return {
+    ok,
+    status: ok ? 200 : 500,
+    json: async () => body,
+    text: async () => (ok ? JSON.stringify(body) : "fail"),
+  } as unknown as Response;
+}
+
+beforeEach(() => {
+  mockAuthFetch.mockReset();
+  mockUseAuth.mockReset();
+});
+
+describe("FeaturesProvider", () => {
+  test("skips fetch when logged out and resets config", async () => {
+    mockUseAuth.mockReturnValue({ username: null });
+    render(
+      <FeaturesProvider>
+        <Probe />
+      </FeaturesProvider>
+    );
+    expect(screen.getByTestId("user")).toHaveTextContent("");
+    expect(mockAuthFetch).not.toHaveBeenCalled();
+  });
+
+  test("loads config, swallows refresh errors, and patches flags", async () => {
+    mockUseAuth.mockReturnValue({ username: "alice" });
+    mockAuthFetch
+      .mockResolvedValueOnce(
+        jsonResponse({
+          username: "alice",
+          publicRead: true,
+          sitesHost: "sites.example.com",
+          webdav: true,
+        })
+      )
+      .mockResolvedValueOnce(jsonResponse({}, false))
+      .mockResolvedValueOnce(
+        jsonResponse({
+          username: "alice",
+          publicRead: false,
+          sitesHost: "",
+          webdav: false,
+        })
+      );
+
+    render(
+      <FeaturesProvider>
+        <Probe />
+      </FeaturesProvider>
+    );
+
+    await waitFor(() =>
+      expect(screen.getByTestId("user")).toHaveTextContent("alice")
+    );
+    expect(screen.getByTestId("host")).toHaveTextContent("sites.example.com");
+
+    await act(async () => {
+      screen.getByText("refresh").click();
+    });
+    await waitFor(() => expect(mockAuthFetch).toHaveBeenCalledTimes(2));
+    expect(screen.getByTestId("user")).toHaveTextContent("alice");
+
+    await act(async () => {
+      screen.getByText("patch").click();
+    });
+    await waitFor(() =>
+      expect(screen.getByTestId("webdav")).toHaveTextContent("false")
+    );
+    expect(screen.getByTestId("host")).toHaveTextContent("none");
+  });
+});

--- a/src/app/__tests__/fileGridExtra.test.tsx
+++ b/src/app/__tests__/fileGridExtra.test.tsx
@@ -1,0 +1,127 @@
+import React from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { ThemeProvider, createTheme } from "@mui/material/styles";
+
+import FileGrid, { FileGridSkeleton } from "../../FileGrid";
+import { strings, translate } from "../strings";
+import { FileItem } from "../types";
+
+jest.mock("../../AuthThumbnail", () => ({
+  __esModule: true,
+  default: () => <span data-testid="auth-thumb" />,
+}));
+
+jest.mock("../../MimeIcon", () => ({
+  __esModule: true,
+  default: () => <span data-testid="mime-icon" />,
+}));
+
+const file: FileItem = {
+  key: "notes.txt",
+  name: "photo notes.txt",
+  isDir: false,
+  size: 128,
+  uploaded: "2026-01-01T00:00:00.000Z",
+  contentType: "text/plain",
+  thumbnail: "digest",
+};
+
+const folder: FileItem = {
+  key: "docs/",
+  name: "docs",
+  isDir: true,
+  size: 0,
+  uploaded: "2026-01-02T00:00:00.000Z",
+  contentType: "application/octet-stream",
+};
+
+function wrap(ui: React.ReactElement) {
+  return render(<ThemeProvider theme={createTheme()}>{ui}</ThemeProvider>);
+}
+
+describe("FileGrid extras", () => {
+  test("empty message", () => {
+    wrap(
+      <FileGrid
+        files={[]}
+        view="list"
+        selectedKeys={[]}
+        onToggleSelect={jest.fn()}
+        onNavigate={jest.fn()}
+        onOpen={jest.fn()}
+        onOpenMenu={jest.fn()}
+        emptyMessage={<div>empty-here</div>}
+      />
+    );
+    expect(screen.getByText("empty-here")).toBeInTheDocument();
+  });
+
+  test("grid tiles, highlight, checkbox, ctrl-click, drop, drag, quick actions", () => {
+    const onToggle = jest.fn();
+    const onDrop = jest.fn();
+    const onDownload = jest.fn();
+    const onShare = jest.fn();
+    const onDelete = jest.fn();
+    const onOpenMenu = jest.fn();
+    const onNavigate = jest.fn();
+    const onOpen = jest.fn();
+    wrap(
+      <FileGrid
+        files={[file, folder]}
+        view="grid"
+        selectedKeys={[file.key]}
+        dimmedKeys={new Set([folder.key])}
+        focusedKey={folder.key}
+        highlight="notes"
+        folderCounts={{ "docs/": 3 }}
+        onToggleSelect={onToggle}
+        onNavigate={onNavigate}
+        onOpen={onOpen}
+        onOpenMenu={onOpenMenu}
+        onDropOnFolder={onDrop}
+        onDownload={onDownload}
+        onShareFile={onShare}
+        onDeleteFile={onDelete}
+        density="standard"
+      />
+    );
+    expect(screen.getAllByText("notes").length).toBeGreaterThan(0);
+    expect(screen.getByTestId("auth-thumb")).toBeInTheDocument();
+
+    fireEvent.click(
+      screen.getByLabelText(translate("selectFileLabel", { name: folder.name }))
+    );
+    expect(onToggle).toHaveBeenCalledWith(folder.key, expect.anything());
+
+    fireEvent.click(screen.getByText(folder.name), { ctrlKey: true });
+    expect(onToggle).toHaveBeenCalled();
+
+    const folderTile = screen.getByText(folder.name).closest("[data-file-key]")!;
+    fireEvent.dragOver(folderTile);
+    fireEvent.drop(folderTile, {
+      dataTransfer: { getData: () => "x" },
+    });
+    expect(onDrop).toHaveBeenCalled();
+
+    fireEvent.contextMenu(folderTile);
+    expect(onOpenMenu).toHaveBeenCalled();
+
+    fireEvent.pointerDown(folderTile);
+    fireEvent.dragStart(folderTile, {
+      dataTransfer: { setData: jest.fn(), effectAllowed: "move" },
+    });
+
+    fireEvent.click(screen.getByLabelText(`${file.name} ${strings.download}`));
+    expect(onDownload).toHaveBeenCalled();
+    fireEvent.click(screen.getByLabelText(`${file.name} ${strings.share}`));
+    expect(onShare).toHaveBeenCalled();
+    fireEvent.click(screen.getByLabelText(`${file.name} ${strings.delete}`));
+    expect(onDelete).toHaveBeenCalled();
+  });
+
+  test("skeletons for list and grid", () => {
+    const { unmount } = wrap(<FileGridSkeleton view="list" density="compact" />);
+    unmount();
+    wrap(<FileGridSkeleton view="grid" density="standard" />);
+  });
+});

--- a/src/app/__tests__/transferCoverage.test.ts
+++ b/src/app/__tests__/transferCoverage.test.ts
@@ -1,0 +1,387 @@
+import {
+  blobDigest,
+  collectFilesFromDataTransfer,
+  davHrefToKey,
+  downloadArchive,
+  fetchPath,
+  generateThumbnail,
+  multipartUpload,
+  processTransferTask,
+  selectDirectoryFiles,
+  SIZE_LIMIT,
+} from "../transfer";
+import { authFetch, basicAuthHeader } from "../auth";
+import { setLang } from "../strings";
+
+jest.mock("p-limit", () => ({
+  __esModule: true,
+  default: () => (fn: () => Promise<unknown>) => fn(),
+}));
+
+jest.mock("../auth", () => ({
+  authFetch: jest.fn(),
+  basicAuthHeader: jest.fn(() => "Basic abc"),
+}));
+
+const mockAuthFetch = authFetch as unknown as jest.Mock;
+const mockBasic = basicAuthHeader as unknown as jest.Mock;
+
+function xmlResponse(body: string) {
+  return {
+    ok: true,
+    status: 207,
+    headers: {
+      get: (n: string) =>
+        n.toLowerCase() === "content-type" ? "application/xml; charset=utf-8" : null,
+    },
+    text: async () => body,
+  } as unknown as Response;
+}
+
+beforeEach(() => {
+  mockAuthFetch.mockReset();
+  mockBasic.mockReturnValue("Basic abc");
+  setLang("zh");
+  if (!(URL as any).createObjectURL) {
+    (URL as any).createObjectURL = jest.fn(() => "blob:x");
+  }
+  if (!(URL as any).revokeObjectURL) {
+    (URL as any).revokeObjectURL = jest.fn();
+  }
+});
+
+describe("davHrefToKey leftovers", () => {
+  test("invalid percent-encoding keeps segment", () => {
+    expect(davHrefToKey("/webdav/%E0%A4%A")).toContain("%E0");
+  });
+});
+
+describe("fetchPath leftovers", () => {
+  test("parses collection dirs, thumbnails, and skips empty href", async () => {
+    const xml = `<?xml version="1.0"?>
+<multistatus>
+  <response><href></href><propstat><prop/></propstat></response>
+  <response>
+    <href>/webdav/docs/</href>
+    <propstat><prop>
+      <resourcetype><collection/></resourcetype>
+    </prop></propstat>
+  </response>
+  <response>
+    <href>/webdav/pic.png</href>
+    <propstat><prop>
+      <getcontenttype>image/png</getcontenttype>
+      <getcontentlength>9</getcontentlength>
+      <getlastmodified></getlastmodified>
+      <thumbnail xmlns="flaredrive">abc</thumbnail>
+    </prop></propstat>
+  </response>
+</multistatus>`;
+    mockAuthFetch.mockResolvedValue(xmlResponse(xml));
+    const items = await fetchPath("");
+    const dir = items.find((i) => i.key === "docs");
+    const pic = items.find((i) => i.key === "pic.png");
+    expect(dir?.isDir).toBe(true);
+    expect(pic?.thumbnail).toBe("abc");
+    expect(pic?.uploaded).toBeTruthy();
+  });
+});
+
+describe("downloadArchive success", () => {
+  test("clicks an anchor", async () => {
+    mockAuthFetch.mockResolvedValue({
+      ok: true,
+      blob: async () => new Blob(["zip"]),
+      text: async () => "",
+    } as unknown as Response);
+    const click = jest.fn();
+    const orig = document.createElement.bind(document);
+    jest.spyOn(document, "createElement").mockImplementation((tag: string) => {
+      const el = orig(tag);
+      if (tag === "a") (el as HTMLAnchorElement).click = click;
+      return el;
+    });
+    await downloadArchive(["a.txt"], "pack.zip");
+    expect(click).toHaveBeenCalled();
+    (document.createElement as jest.Mock).mockRestore();
+  });
+});
+
+describe("blobDigest / generateThumbnail", () => {
+  test("hashes a blob", async () => {
+    const file = new File(["hello"], "a.bin");
+    if (!(file as any).arrayBuffer) {
+      (file as any).arrayBuffer = async () => new TextEncoder().encode("hello").buffer;
+    }
+    const hex = await blobDigest(file);
+    expect(hex).toMatch(/^[0-9a-f]{40}$/);
+  });
+
+  test("image thumbnail draws to canvas", async () => {
+    class MockImage {
+      onload: (() => void) | null = null;
+      onerror: (() => void) | null = null;
+      set src(_v: string) {
+        queueMicrotask(() => this.onload?.());
+      }
+    }
+    (global as any).Image = MockImage;
+    HTMLCanvasElement.prototype.getContext = jest.fn(() => ({
+      drawImage: jest.fn(),
+    })) as any;
+    HTMLCanvasElement.prototype.toBlob = function (cb: BlobCallback) {
+      cb(new Blob(["png"], { type: "image/png" }));
+    } as any;
+    const blob = await generateThumbnail(
+      new File(["xx"], "a.png", { type: "image/png" })
+    );
+    expect(blob).toBeInstanceOf(Blob);
+  });
+
+  test("image load failure rejects", async () => {
+    class MockImage {
+      onload: (() => void) | null = null;
+      onerror: (() => void) | null = null;
+      set src(_v: string) {
+        queueMicrotask(() => this.onerror?.());
+      }
+    }
+    (global as any).Image = MockImage;
+    HTMLCanvasElement.prototype.getContext = jest.fn(() => ({
+      drawImage: jest.fn(),
+    })) as any;
+    await expect(
+      generateThumbnail(new File(["xx"], "a.png", { type: "image/png" }))
+    ).rejects.toThrow("Image load failed");
+  });
+});
+
+describe("selectDirectoryFiles picker", () => {
+  afterEach(() => {
+    delete (window as any).showDirectoryPicker;
+  });
+
+  test("walks file handles", async () => {
+    (window as any).showDirectoryPicker = async () => ({
+      async *[Symbol.asyncIterator]() {},
+      values: async function* () {
+        yield {
+          kind: "file",
+          name: "a.txt",
+          getFile: async () => new File(["x"], "a.txt"),
+        };
+        yield {
+          kind: "directory",
+          name: "sub",
+          values: async function* () {
+            yield {
+              kind: "file",
+              name: "b.txt",
+              getFile: async () => new File(["y"], "b.txt"),
+            };
+          },
+        };
+      },
+    });
+    const files = await selectDirectoryFiles();
+    expect(files.map((f) => f.name).sort()).toEqual(["a.txt", "b.txt"]);
+  });
+
+  test("AbortError returns empty", async () => {
+    (window as any).showDirectoryPicker = async () => {
+      const err = new Error("no");
+      (err as any).name = "AbortError";
+      throw err;
+    };
+    await expect(selectDirectoryFiles()).resolves.toEqual([]);
+  });
+});
+
+describe("collectFilesFromDataTransfer file entry", () => {
+  test("walks a file entry without directory", async () => {
+    const file = new File(["x"], "solo.txt");
+    const dt = {
+      files: [],
+      items: [
+        {
+          webkitGetAsEntry: () => ({
+            isFile: true,
+            isDirectory: false,
+            name: "solo.txt",
+            file: (resolve: (f: File) => void) => resolve(file),
+          }),
+        },
+      ],
+    } as unknown as DataTransfer;
+    const files = await collectFilesFromDataTransfer(dt);
+    expect(files[0].name).toBe("solo.txt");
+  });
+});
+
+class MockXHR {
+  static mode: "ok" | "error" | "abort" | "zero" | "retry" | "204" = "ok";
+  static etag = '"etag-1"';
+  upload = { onprogress: null as any };
+  status = 201;
+  responseText = "ok";
+  onload: any;
+  onerror: any;
+  onabort: any;
+  open() {}
+  setRequestHeader() {}
+  getAllResponseHeaders() {
+    if (MockXHR.mode === "retry") return "retry-after: 0\r\nbadline\r\netag: " + MockXHR.etag;
+    return "etag: " + MockXHR.etag;
+  }
+  abort() {
+    this.onabort?.();
+  }
+  send() {
+    if (this.upload.onprogress) {
+      this.upload.onprogress({ loaded: 2, total: 2 });
+    }
+    if (MockXHR.mode === "error") {
+      this.onerror?.();
+      return;
+    }
+    if (MockXHR.mode === "abort") {
+      this.onabort?.();
+      return;
+    }
+    if (MockXHR.mode === "zero") {
+      this.status = 0;
+      this.onload?.();
+      return;
+    }
+    if (MockXHR.mode === "204") {
+      this.status = 204;
+      this.responseText = "ignored";
+      this.onload?.();
+      return;
+    }
+    this.status = 200;
+    this.onload?.();
+  }
+}
+
+describe("xhr / multipart leftovers", () => {
+  beforeEach(() => {
+    (global as any).XMLHttpRequest = MockXHR;
+    MockXHR.mode = "ok";
+  });
+
+  test("multipart upload completes parts", async () => {
+    mockAuthFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ uploadId: "u1" }),
+        text: async () => "",
+      } as unknown as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        text: async () => "done",
+      } as unknown as Response);
+    const file = new File(["ab"], "big.bin", { type: "application/octet-stream" });
+    Object.defineProperty(file, "size", { value: SIZE_LIMIT });
+    file.slice = jest.fn(() => new Blob(["ab"])) as any;
+    const onState = jest.fn();
+    const res = await multipartUpload("big.bin", file, {
+      onState,
+      onUploadProgress: jest.fn(),
+    });
+    expect(res.ok).toBe(true);
+    expect(onState).toHaveBeenCalled();
+  });
+
+  test("xhr network error", async () => {
+    MockXHR.mode = "error";
+    const file = new File(["hello"], "plain.txt", { type: "text/plain" });
+    await expect(
+      processTransferTask({
+        task: {
+          id: "1",
+          type: "upload",
+          status: "in-progress",
+          name: "plain.txt",
+          basedir: "",
+          remoteKey: "plain.txt",
+          loaded: 0,
+          total: 5,
+          file,
+        } as any,
+      })
+    ).rejects.toThrow();
+  });
+
+  test("xhr abort and status 0", async () => {
+    MockXHR.mode = "abort";
+    const file = new File(["hello"], "plain.txt", { type: "text/plain" });
+    await expect(
+      processTransferTask({
+        task: {
+          id: "1",
+          type: "upload",
+          status: "in-progress",
+          name: "plain.txt",
+          basedir: "",
+          remoteKey: "plain.txt",
+          loaded: 0,
+          total: 5,
+          file,
+        } as any,
+      })
+    ).rejects.toThrow("Aborted");
+
+    MockXHR.mode = "zero";
+    await expect(
+      processTransferTask({
+        task: {
+          id: "2",
+          type: "upload",
+          status: "in-progress",
+          name: "plain.txt",
+          basedir: "",
+          remoteKey: "plain.txt",
+          loaded: 0,
+          total: 5,
+          file,
+        } as any,
+      })
+    ).rejects.toThrow();
+  });
+
+  test("xhr 204 upload succeeds", async () => {
+    MockXHR.mode = "204";
+    const file = new File(["hello"], "plain.txt", { type: "text/plain" });
+    const res = await processTransferTask({
+      task: {
+        id: "3",
+        type: "upload",
+        status: "in-progress",
+        name: "plain.txt",
+        basedir: "",
+        remoteKey: "plain.txt",
+        loaded: 0,
+        total: 5,
+        file,
+      } as any,
+    });
+    expect(res.status).toBe(204);
+  });
+
+  test("processTransferTask with aborted signal before upload", async () => {
+    const controller = new AbortController();
+    controller.abort();
+    await expect(
+      processTransferTask({
+        task: {
+          type: "upload",
+          remoteKey: "a.txt",
+          file: new File(["a"], "a.txt", { type: "text/plain" }),
+        } as any,
+        signal: controller.signal,
+      })
+    ).rejects.toThrow("Aborted");
+  });
+});


### PR DESCRIPTION
## Summary
- 在 `test-coverage-70` 上继续补 RTL/Jest，覆盖 Main、transfer、ImagesView、SitesView、SettingsView、FileGrid、PreviewDialog、features 的剩余空洞。
- 无产品行为改动。

## Coverage
**Before (PR #40):** ~57.86% statements / 52% branches / 50% functions / 58.6% lines；47 suites / 312 tests

**After:** 76.96% statements / 71.32% branches / 68.48% functions / 78.81% lines；51 suites / 358 tests（全部通过）

## Test plan
- [x] `CI=true npx react-scripts test --watchAll=false --coverage --coverageReporters=text-summary`
- [ ] CI on this PR