### PR TITLE
fix: 网页手点 QA 的交互 bug

### DIFF
--- a/functions/api/trash.ts
+++ b/functions/api/trash.ts
@@ -19,7 +19,8 @@ async function purgeExpiredTrash(bucket: R2Bucket, retentionDays: number) {
   const objects = await listObjects(bucket, TRASH_PREFIX);
   let purged = 0;
   for (const object of objects) {
-    if (!object.key.endsWith(".json")) continue;
+    const rest = object.key.slice(TRASH_PREFIX.length);
+    if (!rest.endsWith(".json") || rest.includes("/")) continue;
     if (purged >= PURGE_BATCH_MAX) break;
     const data = await bucket.get(object.key);
     if (data === null) continue;
@@ -32,7 +33,7 @@ async function purgeExpiredTrash(bucket: R2Bucket, retentionDays: number) {
     }
     const ts = Date.parse(deletedAt);
     if (!Number.isFinite(ts) || ts > cutoff) continue;
-    const trashId = object.key.slice(TRASH_PREFIX.length).replace(/\.json$/, "");
+    const trashId = rest.replace(/\.json$/, "");
     const descendants = await listObjects(bucket, `${TRASH_PREFIX}${trashId}/`);
     for (const item of descendants) {
       await bucket.delete(item.key);
@@ -87,16 +88,23 @@ async function listTrashItems(bucket: R2Bucket) {
   const items: Array<Record<string, unknown>> = [];
 
   for (const object of objects) {
-    if (!object.key.endsWith(".json")) continue;
+    const rest = object.key.slice(TRASH_PREFIX.length);
+    if (!rest.endsWith(".json") || rest.includes("/")) continue;
     const data = await bucket.get(object.key);
     if (data === null) continue;
-    const parsed = (await data.json()) as Record<string, unknown>;
+    let parsed: Record<string, unknown>;
+    try {
+      parsed = (await data.json()) as Record<string, unknown>;
+    } catch {
+      continue;
+    }
+    if (!parsed.originalKey) continue;
     items.push({
-      trashKey: object.key.slice(TRASH_PREFIX.length).replace(/\.json$/, ""),
+      trashKey: rest.replace(/\.json$/, ""),
       originalKey: parsed.originalKey,
       name: parsed.name || basename(String(parsed.originalKey || "")),
       deletedAt: parsed.deletedAt,
-      size: parsed.size || 0,
+      size: Number(parsed.size) || 0,
     });
   }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -52,17 +52,21 @@ const DEFAULT_SNACK_MS = 5000;
 const ERROR_SNACK_MS = 8000;
 
 function isTypingTarget(target: EventTarget | null) {
-  if (target instanceof HTMLInputElement) {
-    // 复选框/单选/按钮不是文本输入，键盘导航应继续生效
-    return !["checkbox", "radio", "button", "submit"].includes(target.type);
+  const el =
+    target instanceof HTMLElement
+      ? target
+      : document.activeElement instanceof HTMLElement
+      ? document.activeElement
+      : null;
+  if (!el) return false;
+  const field = el.closest("input, textarea, select, [contenteditable='true']");
+  if (field instanceof HTMLInputElement) {
+    return !["checkbox", "radio", "button", "submit"].includes(field.type);
   }
-  if (!(target instanceof HTMLElement)) return false;
-  const tag = target.tagName;
-  return (
-    tag === "TEXTAREA" ||
-    tag === "SELECT" ||
-    target.isContentEditable
-  );
+  if (field instanceof HTMLTextAreaElement || field instanceof HTMLSelectElement) {
+    return true;
+  }
+  return Boolean(field) || el.isContentEditable;
 }
 
 function AppContent({
@@ -142,11 +146,15 @@ function AppContent({
 
   useEffect(() => {
     const onKeyDown = (event: KeyboardEvent) => {
+      if (event.isComposing || event.key === "Process") return;
+      if (isTypingTarget(event.target) || isTypingTarget(document.activeElement)) {
+        return;
+      }
       const cmdK =
         (event.key === "k" || event.key === "K") &&
         (event.metaKey || event.ctrlKey);
       const slash = event.key === "/" && !event.metaKey && !event.ctrlKey && !event.altKey;
-      if (cmdK || (slash && !isTypingTarget(event.target))) {
+      if (cmdK || slash) {
         event.preventDefault();
         searchInputRef.current?.focus();
         searchInputRef.current?.select();
@@ -157,7 +165,7 @@ function AppContent({
   }, []);
 
   return (
-    <Stack sx={{ height: "100%", backgroundColor: "background.default" }}>
+    <Stack sx={{ height: "100%", minHeight: 0, overflow: "hidden", backgroundColor: "background.default" }}>
       <Header
         search={search}
         onSearchChange={setSearch}

--- a/src/FileActionSheet.tsx
+++ b/src/FileActionSheet.tsx
@@ -71,7 +71,15 @@ function FileActionSheet({
 
   const run = (action: FileAction) => {
     if (!file) return;
-    onAction(action, file);
+    const target = file;
+    onClose();
+    const openDialog =
+      action === "rename" ||
+      action === "share" ||
+      action === "delete" ||
+      action === "move";
+    if (openDialog) window.setTimeout(() => onAction(action, target), 0);
+    else onAction(action, target);
   };
 
   if (isPhone) {
@@ -126,6 +134,9 @@ function FileActionSheet({
       anchorReference="anchorPosition"
       anchorPosition={anchorPosition ?? { top: 0, left: 0 }}
       disableAutoFocusItem
+      disableAutoFocus
+      disableRestoreFocus
+      disableEnforceFocus
       onClick={(event) => event.stopPropagation()}
       MenuListProps={{ dense: false, sx: { minWidth: 180 } }}
     >

--- a/src/FileGrid.tsx
+++ b/src/FileGrid.tsx
@@ -397,6 +397,10 @@ function FileGrid({
             warmShadow(theme.palette.mode === "dark", "0 2px 10px", 0.16),
           opacity: 0,
           pointerEvents: "none",
+          ".file-card:hover &, .file-card:focus-within &": {
+            opacity: 1,
+            pointerEvents: "auto",
+          },
           transition: "opacity 0.15s ease",
         }}
         onPointerDown={stop}
@@ -412,6 +416,7 @@ function FileGrid({
   const itemList = (file: FileItem, index: number) => (
     <ListItemButton
       component="div"
+      className="file-card"
       selected={isSelected(file)}
       data-file-key={file.key}
       onPointerDown={markPointer}
@@ -511,6 +516,7 @@ function FileGrid({
 
   const itemTile = (file: FileItem, index: number) => (
     <Box
+      className="file-card"
       role="button"
       tabIndex={0}
       data-file-key={file.key}

--- a/src/Header.tsx
+++ b/src/Header.tsx
@@ -126,6 +126,7 @@ function Header({
         value={search}
         onChange={(event) => onSearchChange(event.target.value)}
         onKeyDown={(event) => {
+          event.stopPropagation();
           if (event.key === "Escape") {
             event.preventDefault();
             if (search) onSearchChange("");

--- a/src/Main.tsx
+++ b/src/Main.tsx
@@ -107,17 +107,26 @@ function saveFolderCountCache(counts: Record<string, number>) {
 }
 
 function isTypingTarget(target: EventTarget | null) {
-  if (target instanceof HTMLInputElement) {
-    // 复选框/单选/按钮不是文本输入，键盘导航应继续生效
-    return !["checkbox", "radio", "button", "submit"].includes(target.type);
+  const el =
+    target instanceof HTMLElement
+      ? target
+      : document.activeElement instanceof HTMLElement
+      ? document.activeElement
+      : null;
+  if (!el) return false;
+  const field = el.closest("input, textarea, select, [contenteditable='true']");
+  if (field instanceof HTMLInputElement) {
+    return !["checkbox", "radio", "button", "submit"].includes(field.type);
   }
-  if (!(target instanceof HTMLElement)) return false;
-  const tag = target.tagName;
-  return (
-    tag === "TEXTAREA" ||
-    tag === "SELECT" ||
-    target.isContentEditable
-  );
+  if (field instanceof HTMLTextAreaElement || field instanceof HTMLSelectElement) {
+    return true;
+  }
+  return Boolean(field) || el.isContentEditable;
+}
+
+function shouldIgnoreShortcuts(event: KeyboardEvent) {
+  if (event.isComposing || event.key === "Process") return true;
+  return isTypingTarget(event.target) || isTypingTarget(document.activeElement);
 }
 
 function parentKey(key: string) {
@@ -928,7 +937,7 @@ function Main({
 
   useEffect(() => {
     const onKeyDown = (event: KeyboardEvent) => {
-      if (isTypingTarget(event.target)) return;
+      if (shouldIgnoreShortcuts(event)) return;
       if (event.key === "Escape") {
         if (hasOpenOverlay()) return;
         if (selectedKeys.length || focusedKey) {
@@ -1112,13 +1121,13 @@ function Main({
           if (file.isDir) await downloadArchive([file.key]);
           else await downloadFile(file.key);
         } else if (action === "rename") {
-          setRenameTarget(file);
+          window.setTimeout(() => setRenameTarget(file), 50);
         } else if (action === "move") {
-          setMoveTarget([file.key]);
+          window.setTimeout(() => setMoveTarget([file.key]), 50);
         } else if (action === "delete") {
-          setConfirmDelete([file.key]);
+          window.setTimeout(() => setConfirmDelete([file.key]), 50);
         } else if (action === "share") {
-          setShareTarget(file);
+          window.setTimeout(() => setShareTarget(file), 50);
         } else if (action === "copy") {
           copyToClipboard([file.key]);
           onNotify(translate("copiedToClipboard"), "success");
@@ -1300,9 +1309,14 @@ function Main({
     input.type = "file";
     input.accept = "*/*";
     input.multiple = true;
-    input.onchange = async () => {
-      if (!input.files) return;
-      enqueueToCwd(Array.from(input.files));
+    input.value = "";
+    input.style.display = "none";
+    document.body.appendChild(input);
+    input.onchange = () => {
+      const picked = input.files ? Array.from(input.files) : [];
+      input.value = "";
+      input.remove();
+      if (picked.length) enqueueToCwd(picked);
     };
     input.click();
   };
@@ -1405,7 +1419,7 @@ function Main({
       </Box>
 
       {route.kind === "trash" && (
-        <Box onScroll={handleContentScroll} sx={{ flexGrow: 1, overflowY: "auto", pb: { xs: 8, sm: 0 } }}>
+        <Box onScroll={handleContentScroll} sx={{ flexGrow: 1, minHeight: 0, overflowY: "auto", pb: { xs: 8, sm: 0 } }}>
           <TrashView
             onNotify={onNotify}
             onGoFiles={() =>
@@ -1415,7 +1429,7 @@ function Main({
         </Box>
       )}
       {route.kind === "shares" && (
-        <Box onScroll={handleContentScroll} sx={{ flexGrow: 1, overflowY: "auto", pb: { xs: 8, sm: 0 } }}>
+        <Box onScroll={handleContentScroll} sx={{ flexGrow: 1, minHeight: 0, overflowY: "auto", pb: { xs: 8, sm: 0 } }}>
           <SharesView
             onNotify={onNotify}
             onGoFiles={() =>
@@ -1425,7 +1439,7 @@ function Main({
         </Box>
       )}
       {route.kind === "sites" && flags.sites && (
-        <Box onScroll={handleContentScroll} sx={{ flexGrow: 1, overflowY: "auto", pb: { xs: 8, sm: 0 } }}>
+        <Box onScroll={handleContentScroll} sx={{ flexGrow: 1, minHeight: 0, overflowY: "auto", pb: { xs: 8, sm: 0 } }}>
           <SitesView
             onNotify={onNotify}
             onGoFiles={() =>
@@ -1438,7 +1452,7 @@ function Main({
         </Box>
       )}
       {route.kind === "images" && flags.imageHost && (
-        <Box onScroll={handleContentScroll} sx={{ flexGrow: 1, overflowY: "auto", pb: { xs: 8, sm: 0 } }}>
+        <Box onScroll={handleContentScroll} sx={{ flexGrow: 1, minHeight: 0, overflowY: "auto", pb: { xs: 8, sm: 0 } }}>
           <ImagesView
             onNotify={onNotify}
             onGoFiles={() =>
@@ -1448,7 +1462,7 @@ function Main({
         </Box>
       )}
       {route.kind === "settings" && (
-        <Box onScroll={handleContentScroll} sx={{ flexGrow: 1, overflowY: "auto", pb: { xs: 8, sm: 0 } }}>
+        <Box onScroll={handleContentScroll} sx={{ flexGrow: 1, minHeight: 0, overflowY: "auto", pb: { xs: 8, sm: 0 } }}>
           <SettingsView onNotify={onNotify} />
         </Box>
       )}
@@ -1464,6 +1478,7 @@ function Main({
               onScroll={handleContentScroll}
               sx={{
                 flexGrow: 1,
+                minHeight: 0,
                 overflowY: "auto",
                 backgroundColor: "background.default",
                 pb: { xs: 8, sm: 0 },

--- a/src/SettingsView.tsx
+++ b/src/SettingsView.tsx
@@ -42,7 +42,7 @@ function SettingsView({ onNotify }: { onNotify: NotifyFn }) {
   };
 
   return (
-    <Box sx={{ px: 2, py: 2, maxWidth: 640 }}>
+    <Box sx={{ px: 2, py: 2, maxWidth: 640, minHeight: 0 }}>
       <Typography variant="h6" sx={{ mb: 0.5 }}>
         {strings.settingsTitle}
       </Typography>

--- a/src/ShareDialog.tsx
+++ b/src/ShareDialog.tsx
@@ -134,24 +134,14 @@ function ShareDialog({
                 {shares.map((share) => (
                   <ListItem
                     key={share.token}
-                    secondaryAction={
-                      <Button
-                        color="error"
-                        onClick={async () => {
-                          try {
-                            setShares((prev) =>
-                              prev.filter((item) => item.token !== share.token)
-                            );
-                            await revokeShare(share.token);
-                          } catch (error) {
-                            onNotify((error as Error).message, "error");
-                            await refresh();
-                          }
-                        }}
-                      >
-                        {strings.revoke}
-                      </Button>
-                    }
+                    alignItems="flex-start"
+                    sx={{
+                      display: "block",
+                      px: 0,
+                      py: 1.25,
+                      borderBottom: "1px solid",
+                      borderColor: "divider",
+                    }}
                   >
                     <ListItemText
                       primary={
@@ -168,15 +158,43 @@ function ShareDialog({
                       }
                       secondary={share.url}
                       secondaryTypographyProps={{
-                        sx: { wordBreak: "break-all" },
+                        sx: { wordBreak: "break-all", pr: 0 },
                       }}
                     />
-                    <Button
-                      startIcon={<ContentCopyIcon />}
-                      onClick={() => copy(share)}
-                    >
-                      {strings.copy}
-                    </Button>
+                    <Stack direction="row" spacing={1} sx={{ mt: 1 }}>
+                      <Button
+                        type="button"
+                        size="small"
+                        startIcon={<ContentCopyIcon />}
+                        onClick={(event) => {
+                          event.stopPropagation();
+                          copy(share);
+                        }}
+                      >
+                        {strings.copy}
+                      </Button>
+                      <Button
+                        type="button"
+                        size="small"
+                        color="error"
+                        onClick={async (event) => {
+                          event.stopPropagation();
+                          event.preventDefault();
+                          try {
+                            await revokeShare(share.token);
+                            setShares((prev) =>
+                              prev.filter((item) => item.token !== share.token)
+                            );
+                            onNotify(translate("shareLinkRevoked"), "success");
+                          } catch (error) {
+                            onNotify((error as Error).message, "error");
+                            await refresh();
+                          }
+                        }}
+                      >
+                        {strings.revoke}
+                      </Button>
+                    </Stack>
                   </ListItem>
                 ))}
               </List>

--- a/src/app/__tests__/ShareDialog.test.tsx
+++ b/src/app/__tests__/ShareDialog.test.tsx
@@ -79,4 +79,18 @@ describe("ShareDialog", () => {
       expect(onNotify).toHaveBeenCalledWith(translate("linkCopied"), "success")
     );
   });
+
+  test("revokes an existing share without closing via overlay", async () => {
+    mockRevokeShare.mockResolvedValue(undefined);
+    const onClose = jest.fn();
+    const onNotify = jest.fn();
+    render(<ShareDialog open file={file} onClose={onClose} onNotify={onNotify} />);
+    fireEvent.click(await screen.findByText(strings.revoke));
+    await waitFor(() => expect(mockRevokeShare).toHaveBeenCalledWith("tok1"));
+    await waitFor(() =>
+      expect(onNotify).toHaveBeenCalledWith(translate("shareLinkRevoked"), "success")
+    );
+    expect(onClose).not.toHaveBeenCalled();
+    expect(screen.queryByText(share.url)).not.toBeInTheDocument();
+  });
 });

--- a/src/app/__tests__/componentsExtra.test.tsx
+++ b/src/app/__tests__/componentsExtra.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 
 import EmptyState from "../../EmptyState";
 import FileActionSheet from "../../FileActionSheet";
@@ -84,7 +84,7 @@ describe("FileActionSheet", () => {
     contentType: "text/plain",
   };
 
-  test("桌面端点击菜单项触发 onAction", () => {
+  test("桌面端点击菜单项触发 onAction", async () => {
     const onAction = jest.fn();
     const onClose = jest.fn();
     render(
@@ -96,7 +96,8 @@ describe("FileActionSheet", () => {
       />
     );
     fireEvent.click(screen.getByText(strings.download));
-    expect(onAction).toHaveBeenCalledWith("download", file);
+    expect(onClose).toHaveBeenCalled();
+    await waitFor(() => expect(onAction).toHaveBeenCalledWith("download", file));
   });
 
   test("目录也渲染全部动作（当前无 filesOnly 动作）", () => {


### PR DESCRIPTION
## Summary
- 分享弹层：撤销先调 `revokeShare` 再更新列表，复制/撤销按钮放到链接下方，不再盖住 URL。
- 回收站：只把 `trash/{id}.json` 当条目，忽略目录里用户自己的 `.json`（0 字节残影）。
- 卡片 ⋯：菜单先关，重命名/分享/删除/移动延后一拍再开弹层，避免点穿。
- 搜索失焦/输入中：快捷键忽略输入框、`isComposing`；搜索框 `stopPropagation`。
- 设置页等面板 `minHeight: 0` + 外层 overflow，滚轮能滚。
- 上传：每次新建 input、选完清空并移除，避免选到旧文件。

## Test plan
- [ ] 分享弹层撤销后链接立刻消失，去分享页确认已撤；URL 不被按钮挡住
- [ ] 删一个文件，回收站只有一条真实记录
- [ ] 网格 ⋯ → 重命名，弹层稳定出现
- [ ] 搜索框打字、失焦后再按键，不会误触删除/返回
- [ ] 关弹层后点卡片不会点到预览/分享
- [ ] 连续两次上传同一文件都能选中
- [ ] 设置页滚轮能滚到底