### PR TITLE
docs: 可复现 hello-site Agent 剧本

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,27 @@ Share (expiry + extract code):
 - Owner Settings (`#/settings`) with five persistent feature switches (default all on)
 - `davflare-cli` for login / ls / mkdir / rm / mv / cp / sync ([cli/README.md](cli/README.md))
 - Optional Chrome MV3 extension in `extension/` (toolbar opens **your** instance; default zip does not change new tab)
-- Agent layouts on R2: `agents/{global|agent|agent/project}/{skills|rules|mcp}/` (`pull` / `push` tools; see [docs/agents.md](docs/agents.md))
+- Agent layouts on R2: `agents/{global|agent|agent/project}/{skills|rules|mcp}/` (`pull` / `push` tools; see [docs/agents.md](docs/agents.md)); reproducible demo in [`agents/examples/hello-site/`](agents/examples/hello-site/)
 - Chinese / English UI (globe icon in the header; defaults to browser language, persisted locally)
+
+## Try it in Cursor (copy-paste)
+
+1. Leave **API Key** + **MCP** + **Sites** on in `#/settings`. Create a key.
+2. Paste into Cursor `mcp.json` (replace host + key):
+
+```json
+{
+  "mcpServers": {
+    "davflare": {
+      "url": "https://<your-domain.com>/mcp",
+      "headers": { "Authorization": "Bearer <apiKey>" }
+    }
+  }
+}
+```
+
+3. Open this repo’s [`agents/examples/hello-site/`](agents/examples/hello-site/) and tell Cursor to follow `SKILL.md` (uses only `publish_site` / optional `image_upload`).
+4. When it finishes you get **`https://sites.<your-domain>/hello/`** (your real `SITES_HOST`). No public shared demo.
 
 ## Follow along
 
@@ -50,11 +69,11 @@ Three short paths. Use **your** bound host — there is no public live demo othe
 
 ### Publish a static site from Cursor
 
-1. In `#/settings`, leave **API Key** and **MCP** on. Create a key (account menu → API keys) and paste it into Cursor `mcp.json` as in [MCP](#mcp).
-2. Ask Cursor (copy-paste):
+1. Wire MCP as in [Try it in Cursor](#try-it-in-cursor-copy-paste). Bind Pages env `SITES_HOST` and redeploy.
+2. Ask Cursor (copy-paste), with `agents/examples/hello-site/` in context:
 
    ```
-   Upload this folder to sites/hello/ on Davflare (mkdir parents, overwrite same names). Then call sites_config for slug hello if this is an SPA.
+   Follow agents/examples/hello-site/SKILL.md: upload index.html, then publish_site slug=hello from that folder. Done when https://<SITES_HOST>/hello/ returns 200.
    ```
 
 3. Open `https://<SITES_HOST>/hello/` on the hostname you bound to **this** Pages project. Until `SITES_HOST` is set and redeployed, that URL will not open.
@@ -70,6 +89,12 @@ Three short paths. Use **your** bound host — there is no public live demo othe
 1. Open `#/settings` from the account menu.
 2. The five switches are WebDAV, MCP, API Key, Sites, and Image host (all default on). Stored files are not deleted when a switch is off.
 3. MCP depends on API Key: if Key is off, `/mcp` is 404 even if MCP is on. Sites and image-host public URLs also need `SITES_HOST`.
+
+### Mount WebDAV with rclone (optional)
+
+1. In rclone: `rclone config` → New remote → type `webdav` → URL `https://<your-domain.com>/webdav` → vendor `other` → user/pass = your Pages `WEBDAV_USERNAME` / `WEBDAV_PASSWORD`.
+2. Leave the WebDAV switch on in `#/settings`.
+3. `rclone ls davflare:` (or whatever you named the remote) should list the drive root.
 
 ## Deploy
 
@@ -214,7 +239,7 @@ On the sites host, `/i/{id}` is matched **before** slug static sites. The image-
 
 ## Agent layouts
 
-Skills, rules, and MCP snippets live on R2 under `agents/`. v2 `pull` / `push` walk that tree (or use the web UI). Merge order: project > agent > global. Never store raw API keys in `mcp.json` — use `${env:DAVFLARE_API_KEY}`. Cursor local paths: [docs/agents.md](docs/agents.md).
+Skills, rules, and MCP snippets live on R2 under `agents/`. Repo demo: [`agents/examples/hello-site/`](agents/examples/hello-site/). v2 `pull` / `push` walk the R2 tree (or use the web UI). Merge order: project > agent > global. Never store raw API keys in `mcp.json` — use `${env:DAVFLARE_API_KEY}`. Cursor local paths: [docs/agents.md](docs/agents.md).
 
 ## Development & testing
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -39,8 +39,27 @@
 - 拥有者设置页（`#/settings`）五个功能开关（默认全部开启，持久化到 R2）
 - `davflare-cli`：login / ls / mkdir / rm / mv / cp / sync（[cli/README.md](cli/README.md)）
 - 可选 Chrome MV3 扩展（`extension/`）：工具栏打开**你自己的**实例；默认 zip **不会**改 Chrome 新标签页
-- Agent 目录约定：`agents/{global|agent|agent/project}/{skills|rules|mcp}/`（`pull` / `push` 工具，见 [docs/agents.zh-CN.md](docs/agents.zh-CN.md)）
+- Agent 目录约定：`agents/{global|agent|agent/project}/{skills|rules|mcp}/`（`pull` / `push` 工具，见 [docs/agents.zh-CN.md](docs/agents.zh-CN.md)）；可复现示例见 [`agents/examples/hello-site/`](agents/examples/hello-site/)
 - 中 / 英界面（标题栏地球图标；默认跟随浏览器语言，并保存在本地）
+
+## 用 Cursor 试一把（复制即用）
+
+1. `#/settings` 保持 **API Key**、**MCP**、**静态站点** 打开，创建一把密钥。
+2. 粘贴到 Cursor 的 `mcp.json`（换成你的域名和密钥）：
+
+```json
+{
+  "mcpServers": {
+    "davflare": {
+      "url": "https://<your-domain.com>/mcp",
+      "headers": { "Authorization": "Bearer <apiKey>" }
+    }
+  }
+}
+```
+
+3. 打开本仓库 [`agents/examples/hello-site/`](agents/examples/hello-site/)，让 Cursor 按 `SKILL.md` 做（只用现有 `publish_site`，可选 `image_upload`）。
+4. 跑完得到 **`https://sites.<你的域>/hello/`**（你真实的 `SITES_HOST`）。没有别人能打开的公共演示站。
 
 ## 跟着做
 
@@ -48,11 +67,11 @@
 
 ### 用 Cursor 对话发布静态站
 
-1. 在 `#/settings` 保持 **API Key** 和 **MCP** 打开。创建一把密钥（账号菜单 → 开放接口），按 [MCP](#mcp) 写进 Cursor 的 `mcp.json`。
-2. 对 Cursor 说（可直接粘贴）：
+1. 按 [用 Cursor 试一把](#用-cursor-试一把复制即用) 配好 MCP，并绑定 Pages 环境变量 `SITES_HOST` 后重新部署。
+2. 对 Cursor 说（可直接粘贴），上下文带上 `agents/examples/hello-site/`：
 
    ```
-   把这个文件夹上传到 Davflare 的 sites/hello/（自动建父目录，同名覆盖）。如果是 SPA，再对 slug hello 调用 sites_config。
+   按 agents/examples/hello-site/SKILL.md 做：上传 index.html，再 publish_site slug=hello。完成标准：https://<SITES_HOST>/hello/ 返回 200。
    ```
 
 3. 在你绑到**本** Pages 项目的主机上打开 `https://<SITES_HOST>/hello/`。未设置 `SITES_HOST` 并重新部署之前，这个地址打不开。
@@ -68,6 +87,12 @@
 1. 从账号菜单打开 `#/settings`。
 2. 五个开关是 WebDAV、MCP、API Key、静态站点、图床（默认全部开启）。关闭开关不会删除已有文件。
 3. MCP 依赖 API Key：Key 关闭时，即使 MCP 打开，`/mcp` 也是 404。站点和图床的公开地址还需要 `SITES_HOST`。
+
+### 用 rclone 挂 WebDAV（可选）
+
+1. `rclone config` → New remote → 类型 `webdav` → URL `https://<your-domain.com>/webdav` → vendor `other` → 用户名/密码 = Pages 里的 `WEBDAV_USERNAME` / `WEBDAV_PASSWORD`。
+2. `#/settings` 里保持 WebDAV 开关打开。
+3. `rclone ls davflare:`（远程名随你）应能列出网盘根目录。
 
 ## 部署
 
@@ -212,7 +237,7 @@ Chrome Manifest V3 辅助扩展，用来打开**你自己部署的** Davflare。
 
 ## Agent 目录
 
-skills / rules / MCP 片段放在 R2 的 `agents/` 下。v2 的 `pull` / `push` 会走这棵树（也可用网页端）。合并顺序：project 覆盖 agent 覆盖 global。`mcp.json` 里不要存明文密钥，用 `${env:DAVFLARE_API_KEY}`。Cursor 落地路径见 [docs/agents.zh-CN.md](docs/agents.zh-CN.md)。
+skills / rules / MCP 片段放在 R2 的 `agents/` 下。仓库示例：[`agents/examples/hello-site/`](agents/examples/hello-site/)。v2 的 `pull` / `push` 会走这棵树（也可用网页端）。合并顺序：project 覆盖 agent 覆盖 global。`mcp.json` 里不要存明文密钥，用 `${env:DAVFLARE_API_KEY}`。Cursor 落地路径见 [docs/agents.zh-CN.md](docs/agents.zh-CN.md)。
 
 ## 开发与测试
 

--- a/agents/examples/hello-site/SKILL.md
+++ b/agents/examples/hello-site/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: hello-site
+description: Reproduce a Davflare static site with existing MCP tools only (publish_site / image_upload). Use when onboarding or demoing “chat → site”.
+---
+
+# Hello site (reproducible)
+
+Goal: from Cursor chat, publish this folder so
+`https://sites.<your-domain>/hello/` serves a real page.
+No new APIs — only tools already on `/mcp`.
+
+## Prerequisites
+
+1. Davflare deployed; `#/settings` leaves **API Key**, **MCP**, **Sites** (and **Image host** if you want a hero image) on.
+2. Pages env `SITES_HOST` = your sites hostname only (e.g. `sites.example.com`), then redeploy.
+3. Cursor `mcp.json` points at `https://<drive-host>/mcp` with a Bearer API key (see README).
+
+## Steps (copy into the agent)
+
+1. Read `agents/examples/hello-site/index.html` from this repo (or paste its contents).
+2. Upload it into a drive folder, e.g. `examples/hello-site/index.html` (`mkdir` + `upload`, encoding `utf8`).
+3. Call **`publish_site`** with `slug: "hello"` and `source: "examples/hello-site"`.
+4. Open `https://<SITES_HOST>/hello/` — you should see the hello page.
+5. Optional: call **`image_upload`** with a small PNG (base64), then edit the HTML to use the returned Markdown / URL and `publish_site` again.
+
+## Do not
+
+- Do not invent new MCP tools.
+- Do not put raw API keys in files under `agents/` (`${env:...}` only).
+- Do not publish to a slug you do not own on a shared demo.
+
+## Done when
+
+`https://<SITES_HOST>/hello/` returns **200** with the hello markup.

--- a/agents/examples/hello-site/index.html
+++ b/agents/examples/hello-site/index.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>hello — Davflare</title>
+    <style>
+      :root {
+        color-scheme: light dark;
+        font-family: system-ui, sans-serif;
+      }
+      body {
+        margin: 0;
+        min-height: 100vh;
+        display: grid;
+        place-items: center;
+        background: #f6f7f9;
+        color: #111;
+      }
+      @media (prefers-color-scheme: dark) {
+        body {
+          background: #111;
+          color: #f3f4f6;
+        }
+      }
+      main {
+        max-width: 28rem;
+        padding: 1.5rem;
+        text-align: center;
+      }
+      h1 {
+        margin: 0 0 0.5rem;
+        font-size: 1.75rem;
+      }
+      p {
+        margin: 0;
+        line-height: 1.5;
+        opacity: 0.85;
+      }
+      code {
+        font-size: 0.9em;
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1>hello</h1>
+      <p>
+        Published with Davflare MCP
+        <code>publish_site</code>.
+      </p>
+    </main>
+  </body>
+</html>

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -1,5 +1,7 @@
 # Davflare agent layouts (v2)
 
+Repo-only demo (not the R2 tree): [`agents/examples/hello-site/`](../agents/examples/hello-site/) — reproducible `publish_site` / `image_upload` playbook.
+
 Store Cursor (and later Codex / Claude / OpenCode) **skills**, **rules**, and **MCP** snippets on R2 using a fixed directory tree. v2 adds MCP `pull` / `push` that walk this tree (the web UI still works). No file watcher. Secrets are not stored as files.
 
 Merge order when the same name exists at more than one layer: **project > agent > global**.

--- a/docs/agents.zh-CN.md
+++ b/docs/agents.zh-CN.md
@@ -1,5 +1,7 @@
 # Davflare Agent 目录约定（v2）
 
+仓库示例（不在 R2 树里）：[`agents/examples/hello-site/`](../agents/examples/hello-site/) —— 可复现的 `publish_site` / `image_upload` 剧本。
+
 把 Cursor（以及后续 Codex / Claude / OpenCode）的 **skills**、**rules**、**MCP 片段**按固定目录放进 R2。v2 增加 MCP `pull` / `push` 自动走这棵树（网页端仍可用）。不做文件监听。密钥不当文件存。
 
 同名文件的合并顺序：**project 覆盖 agent 覆盖 global**。


### PR DESCRIPTION
## Summary
- 仓库新增 `agents/examples/hello-site/`：`SKILL.md` + 最小 `index.html`，约定只用现有 `publish_site` / 可选 `image_upload`。
- README 中英首页增加「复制即用」Cursor `mcp.json`（约 8 行）和「跑完得到 `https://sites.<你的域>/hello/`」。
- 可选 rclone 挂 WebDAV 三步；`docs/agents*` 链到该示例。
- 不新开 API；本机改，未走 Cursor cloud agent。

## Test plan
- [ ] 打开 `agents/examples/hello-site/SKILL.md`，步骤可读
- [ ] README 复制 MCP 配置后路径清晰
- [ ] 按剧本 `publish_site` 后 `https://<SITES_HOST>/hello/` 可打开（需已绑 SITES_HOST）