### PR TITLE
refactor: 代码优化——后端收敛、Main 拆分 hooks、鉴权与渲染性能

### DIFF
--- a/IMPROVEMENT_PLAN.md
+++ b/IMPROVEMENT_PLAN.md
@@ -332,3 +332,56 @@
 | 第 4 批（P2） | C davflare-cli | 无，可全程并行 |
 
 每批验证：`npm run typecheck && npm run test:ci && npm run build && npm run test:e2e`；GUI 部分按 TEST_CASES.md 冒烟；CLI 另跑 `cli/e2e.sh`。
+
+---
+
+# 第四轮（2026-09-05）：代码优化 · 界面美化 · 测试覆盖率
+
+> 基于全仓调研（代码质量 / UI 现状 / 测试覆盖三线并查）制定，分三个 PR 落地：
+> `refactor/code-optimization`、`feat/ui-polish`、`test/coverage-boost`。
+> 关键结论：85% Lines 仅为前端 src/ 的口径（statements 82.4%、branches 75.7%），
+> functions/（8058 行）不在度量内、约 4400 行核心逻辑无单测；测试不进 CI、无 coverageThreshold。
+
+## A. 代码优化（refactor/code-optimization，本批落地）
+
+- **A1 后端重复逻辑收敛**：`jsonResponse` 5 份 → 统一 import `_apikey.ts`；`isAuthorized` 7 份 →
+  Basic-only 端点直用 `verifyBasicAuth`，Basic-or-key 端点统一 `isSessionOrKeyAuthorized`；
+  keys.ts 收编共享 `StoredApiKey`/`sha256Hex`/`listStoredKeys`。裸 `new Response("Unauthorized")` 全部走 `textResponse`。
+- **A2 WebDAV 鉴权 fail-closed**：`protocol.ts isAuthorized` 对空凭据一律拒绝（对齐 `_apikey.ts`）。
+- **A3 鉴权链路性能**：`listStoredKeys` 并行 get；`touchLastUsed` 60s 节流，避免每请求一次 R2 put。
+- **A4 工程细节**：`@cloudflare/workers-types` 升级消 7 处 R2 `include` @ts-ignore；
+  tsconfig 开启 `noUnusedLocals/noUnusedParameters/noImplicitOverride/noFallthroughCasesInSwitch`；删除 web-vitals 死依赖。
+- **A5 错误处理**：前端 `errorMessage()` 收敛 37 处 `(error as Error).message`（Error.message / Response.status / 兜底三态）。
+- **A6 Main.tsx 拆分**：1756 → ~1060 行；PathBar 独立；抽 `useFolderListing/useMultiSelect/useFolderCounts/
+  useKeyboardShortcuts/usePasteUpload/useDragDropUpload/useUploadInputs` + `app/interaction.ts` 纯函数。
+- **A7 渲染与网络**：FileGrid `React.memo`（回调 useCallback + emptyMessage useMemo 稳定 props）；
+  PreviewDialog/SitesView/ImagesView `React.lazy` 拆 chunk；新增 `POST /api/counts` 批量计数替代逐目录 PROPFIND 的 N+1。
+- **遗留**：CRA→Vite + Jest→Vitest + MUI v5→v7（原第二轮 A4）仍需独立分支；后端 JSON 错误格式统一涉及 API 兼容性，暂缓。
+
+## B. 界面美化（feat/ui-polish，本批落地）
+
+- **B1 一致性快赢**：`theme.motion` 动效 token + CssBaseline 全局 `prefers-reduced-motion` 兜底；
+  8 处橙色 alpha 字面量收敛；滚动条样式（webkit + scrollbar-width 亮暗双套）；`theme-color` 暗色 meta；
+  PreviewDialog 淡入过渡替代 `transitionDuration={0}`；`borderRadius: 999` 写法统一；MimeIcon 暗色提亮补全；缩略图 blur-up 淡入。
+- **B2 Ctrl+K 命令面板**：文件搜索（/api/search + 高亮 + 键盘选择）+ 动作命令注册表（上传/新建文件夹/切视图/切主题/切语言/跳转分享回收站）。
+- **B3 文件详情侧栏**：右 Drawer 大图预览 + 元数据（大小/时间/类型/路径）+ 快捷操作行。
+- **B4 分享管理收尾**：二维码（qrcode dataURL）+ 过期倒计时徽标 + 创建时间。
+- **B5 分享落地页**：`functions/share/[[token]].ts` 服务端渲染零脚本落地页（文件名/大小/分享时间 + 预览/下载），提取码表单亮暗双套，安全响应头不回退。
+- **B6 a11y**：skip-to-content、Header 改 AppBar、ConfirmDialog 聚焦安全按钮、网格 `role="grid"` 语义。
+
+## C. 测试覆盖率提升（test/coverage-boost，本批落地）
+
+- **C1 基础设施**：共享测试工具（jsonResponse 工厂 / renderMain + authFetch / localStorage helper / PROPFIND XML fixture）；jest `coverageThreshold`。
+- **C2 后端直测**：InMemoryBucket（mock R2）直测 functions/——webdav/protocol（条件请求/Range/LOCK/MOVE/内部前缀）、trash/shares/share token、upload 三段式、_middleware 安全边界。
+- **C3 前端洼地**：新 hooks、transfer.ts 分支、PreviewDialog、App.tsx；目标 lines 90% / branches 85%。
+- **C4 cli + CI**：vitest coverage 配置 + client/index 补测；GitHub Actions workflow（typecheck + test + build + e2e）。
+
+## 第四轮批次
+
+| 批次 | 内容 | PR |
+|------|------|----|
+| 第 1 批 | A1-A7 代码优化 | refactor/code-optimization |
+| 第 2 批 | B1-B6 界面美化 | feat/ui-polish |
+| 第 3 批 | C1-C4 测试覆盖率 | test/coverage-boost |
+
+每批验证：`npm run typecheck && npm run test:ci && npm run build && npm run test:e2e`；UI 批次做浏览器 GUI 冒烟。

--- a/functions/api/_apikey.ts
+++ b/functions/api/_apikey.ts
@@ -95,8 +95,8 @@ function isExpired(expiresAt: string | null | undefined) {
   return Number.isFinite(ts) && ts <= Date.now();
 }
 
-async function listStoredKeys(bucket: R2Bucket): Promise<StoredApiKey[]> {
-  const records: StoredApiKey[] = [];
+export async function listStoredKeys(bucket: R2Bucket): Promise<StoredApiKey[]> {
+  const jsonKeys: string[] = [];
   let cursor: string | undefined;
   do {
     const listing = await bucket.list({
@@ -104,19 +104,24 @@ async function listStoredKeys(bucket: R2Bucket): Promise<StoredApiKey[]> {
       cursor,
     });
     for (const object of listing.objects) {
-      if (!object.key.endsWith(".json")) continue;
-      const data = await bucket.get(object.key);
-      if (data === null) continue;
-      try {
-        records.push((await data.json()) as StoredApiKey);
-      } catch {
-        // skip corrupt metadata
-      }
+      if (object.key.endsWith(".json")) jsonKeys.push(object.key);
     }
     if (!listing.truncated) break;
     cursor = listing.cursor;
   } while (true);
-  return records;
+  // 每个密钥一次 get，并行取回；单个损坏的元数据跳过即可
+  const settled = await Promise.all(
+    jsonKeys.map(async (key): Promise<StoredApiKey | null> => {
+      const data = await bucket.get(key);
+      if (data === null) return null;
+      try {
+        return (await data.json()) as StoredApiKey;
+      } catch {
+        return null;
+      }
+    })
+  );
+  return settled.filter((record): record is StoredApiKey => record !== null);
 }
 
 export async function authorizeApiKey(
@@ -149,8 +154,15 @@ export async function authorizeApiKey(
   return matched;
 }
 
+// lastUsed 写节流：API 请求频繁时避免每个请求都产生一次 R2 put。
+const LAST_USED_WRITE_INTERVAL_MS = 60_000;
+
 export async function touchLastUsed(bucket: R2Bucket, record: StoredApiKey) {
   try {
+    const last = record.lastUsedAt ? Date.parse(record.lastUsedAt) : NaN;
+    if (Number.isFinite(last) && Date.now() - last < LAST_USED_WRITE_INTERVAL_MS) {
+      return;
+    }
     const next = { ...record, lastUsedAt: new Date().toISOString() };
     await bucket.put(`${KEYS_PREFIX}${record.id}.json`, JSON.stringify(next), {
       httpMetadata: { contentType: "application/json" },
@@ -158,6 +170,18 @@ export async function touchLastUsed(bucket: R2Bucket, record: StoredApiKey) {
   } catch {
     // last-used is best-effort
   }
+}
+
+/** Basic 会话与 API key 任一通过即可（MCP/脚本转发端点统一用这个）。 */
+export async function isSessionOrKeyAuthorized(
+  request: Request,
+  bucket: R2Bucket,
+  username: string,
+  password: string
+): Promise<boolean> {
+  if (verifyBasicAuth(request, username, password)) return true;
+  const keyAuth = await authorizeApiKey(request, bucket);
+  return !(keyAuth instanceof Response);
 }
 
 export function isInternalKey(key: string) {
@@ -242,7 +266,6 @@ export async function listDescendants(
     const listing = await bucket.list({
       prefix: `${dirKey}/`,
       cursor,
-      // @ts-ignore `include` is supported by R2 but missing from this types version.
       include: ["httpMetadata", "customMetadata"],
     });
     for (const object of listing.objects) {

--- a/functions/api/_zip.ts
+++ b/functions/api/_zip.ts
@@ -14,7 +14,6 @@ export async function listAllObjects(
     const listing = await bucket.list({
       prefix,
       cursor,
-      // @ts-ignore `include` is supported by R2 but missing from this types version.
       include: ["httpMetadata"],
     });
     objects.push(...listing.objects);

--- a/functions/api/archive.ts
+++ b/functions/api/archive.ts
@@ -1,5 +1,10 @@
 import { buildZipStream } from "./_zip";
-import { decodeRawPath, isInternalKey, verifyBasicAuth } from "./_apikey";
+import {
+  decodeRawPath,
+  isInternalKey,
+  textResponse,
+  verifyBasicAuth,
+} from "./_apikey";
 
 interface ArchiveEnv {
   BUCKET: R2Bucket;
@@ -11,7 +16,7 @@ export const onRequestPost: PagesFunction<ArchiveEnv> = async (context) => {
   const { request, env } = context;
 
   if (!verifyBasicAuth(request, env.WEBDAV_USERNAME, env.WEBDAV_PASSWORD)) {
-    return new Response("Unauthorized", { status: 401 });
+    return textResponse("Unauthorized", 401);
   }
 
   let selectedKeys: string[];

--- a/functions/api/config.ts
+++ b/functions/api/config.ts
@@ -1,4 +1,9 @@
-import { hasApiKeyHeader, verifyBasicAuth } from "./_apikey";
+import {
+  hasApiKeyHeader,
+  jsonResponse,
+  textResponse,
+  verifyBasicAuth,
+} from "./_apikey";
 import {
   loadFeatureFlags,
   normalizeFeatureFlags,
@@ -13,13 +18,6 @@ interface ConfigEnv {
   WEBDAV_PASSWORD: string;
   WEBDAV_PUBLIC_READ?: string;
   SITES_HOST?: string;
-}
-
-function jsonResponse(body: unknown, status = 200) {
-  return new Response(JSON.stringify(body), {
-    status,
-    headers: { "Content-Type": "application/json; charset=utf-8" },
-  });
 }
 
 export type ConfigWriteAuth = "ok" | "unauthorized" | "api-key-forbidden";
@@ -50,7 +48,7 @@ function configBody(
 export const onRequestGet: PagesFunction<ConfigEnv> = async (context) => {
   const { request, env } = context;
   if (!verifyBasicAuth(request, env.WEBDAV_USERNAME, env.WEBDAV_PASSWORD)) {
-    return new Response("Unauthorized", { status: 401 });
+    return textResponse("Unauthorized", 401);
   }
 
   const flags = await loadFeatureFlags(env.BUCKET);
@@ -68,7 +66,7 @@ export const onRequestPatch: PagesFunction<ConfigEnv> = async (context) => {
     return new Response("API keys cannot change feature flags", { status: 403 });
   }
   if (auth !== "ok") {
-    return new Response("Unauthorized", { status: 401 });
+    return textResponse("Unauthorized", 401);
   }
 
   let body: unknown;

--- a/functions/api/counts.ts
+++ b/functions/api/counts.ts
@@ -1,0 +1,78 @@
+import {
+  isInternalKey,
+  jsonResponse,
+  normalizeDirKey,
+  textResponse,
+  verifyBasicAuth,
+} from "./_apikey";
+
+interface CountsEnv {
+  BUCKET: R2Bucket;
+  WEBDAV_USERNAME: string;
+  WEBDAV_PASSWORD: string;
+}
+
+const MAX_COUNT_PATHS = 100;
+
+// 统计目录的直接子项数：objects（含目录标记）+ delimitedPrefixes（虚拟目录），
+// 与 PROPFIND Depth-1 的子项语义一致（不含目录自身），内部前缀排除。
+async function countDirectChildren(
+  bucket: R2Bucket,
+  key: string
+): Promise<number> {
+  let count = 0;
+  let cursor: string | undefined;
+  do {
+    const listing = await bucket.list({
+      prefix: `${key}/`,
+      delimiter: "/",
+      cursor,
+    });
+    for (const object of listing.objects) {
+      if (isInternalKey(object.key)) continue;
+      count += 1;
+    }
+    for (const prefix of listing.delimitedPrefixes) {
+      if (isInternalKey(prefix)) continue;
+      count += 1;
+    }
+    if (!listing.truncated) break;
+    cursor = listing.cursor;
+  } while (true);
+  return count;
+}
+
+/**
+ * POST /api/counts  { paths: string[] }
+ * 批量统计文件夹直接子项数，替代前端逐目录 PROPFIND 的 N+1 计数。
+ * 单个路径失败不进结果（前端保留占位文案）。
+ */
+export const onRequestPost: PagesFunction<CountsEnv> = async (context) => {
+  const { request, env } = context;
+  if (!verifyBasicAuth(request, env.WEBDAV_USERNAME, env.WEBDAV_PASSWORD)) {
+    return textResponse("Unauthorized", 401);
+  }
+
+  let body: { paths?: unknown };
+  try {
+    body = await request.json();
+  } catch {
+    return textResponse("Bad Request", 400);
+  }
+  const rawPaths = Array.isArray(body.paths) ? body.paths : [];
+  const paths = rawPaths.map(String).slice(0, MAX_COUNT_PATHS);
+
+  const counts: Record<string, number> = {};
+  await Promise.all(
+    paths.map(async (raw) => {
+      const key = normalizeDirKey(raw);
+      if (key instanceof Response) return;
+      try {
+        counts[key] = await countDirectChildren(env.BUCKET, key);
+      } catch {
+        // 单个目录统计失败静默跳过
+      }
+    })
+  );
+  return jsonResponse({ counts });
+};

--- a/functions/api/images.ts
+++ b/functions/api/images.ts
@@ -1,4 +1,8 @@
-import { authorizeApiKey, verifyBasicAuth } from "./_apikey";
+import {
+  isSessionOrKeyAuthorized,
+  jsonResponse,
+  textResponse,
+} from "./_apikey";
 import {
   IMAGE_PREFIX,
   createImageId,
@@ -19,22 +23,6 @@ interface ImagesEnv {
 }
 
 const MAX_IMAGE_BYTES = 20 * 1024 * 1024;
-
-function jsonResponse(body: unknown, status = 200) {
-  return new Response(JSON.stringify(body), {
-    status,
-    headers: { "Content-Type": "application/json; charset=utf-8" },
-  });
-}
-
-// 会话（Basic）与 API key 均可管图床：MCP image_* 工具以密钥转发到此端点
-async function isAuthorized(request: Request, env: ImagesEnv) {
-  if (verifyBasicAuth(request, env.WEBDAV_USERNAME, env.WEBDAV_PASSWORD)) {
-    return true;
-  }
-  const keyAuth = await authorizeApiKey(request, env.BUCKET);
-  return !(keyAuth instanceof Response);
-}
 
 function sanitizeName(name: string) {
   const cleaned = name.replace(/\\/g, "/").split("/").pop() || "";
@@ -91,7 +79,6 @@ async function listImages(
     const listing = await bucket.list({
       prefix: IMAGE_PREFIX,
       cursor,
-      // @ts-ignore `include` is supported by R2 but missing from this types version.
       include: ["httpMetadata", "customMetadata"],
     });
     for (const object of listing.objects) {
@@ -107,8 +94,13 @@ async function listImages(
 
 export const onRequestGet: PagesFunction<ImagesEnv> = async (context) => {
   const { request, env } = context;
-  if (!(await isAuthorized(request, env))) {
-    return new Response("Unauthorized", { status: 401 });
+  if (!(await isSessionOrKeyAuthorized(
+      request,
+      env.BUCKET,
+      env.WEBDAV_USERNAME,
+      env.WEBDAV_PASSWORD
+    ))) {
+    return textResponse("Unauthorized", 401);
   }
   const flags = await loadFeatureFlags(env.BUCKET);
   if (!flags.imageHost) {
@@ -121,8 +113,13 @@ export const onRequestGet: PagesFunction<ImagesEnv> = async (context) => {
 
 export const onRequestPost: PagesFunction<ImagesEnv> = async (context) => {
   const { request, env } = context;
-  if (!(await isAuthorized(request, env))) {
-    return new Response("Unauthorized", { status: 401 });
+  if (!(await isSessionOrKeyAuthorized(
+      request,
+      env.BUCKET,
+      env.WEBDAV_USERNAME,
+      env.WEBDAV_PASSWORD
+    ))) {
+    return textResponse("Unauthorized", 401);
   }
   const flags = await loadFeatureFlags(env.BUCKET);
   if (!flags.imageHost) {
@@ -184,8 +181,13 @@ export const onRequestPost: PagesFunction<ImagesEnv> = async (context) => {
 
 export const onRequestDelete: PagesFunction<ImagesEnv> = async (context) => {
   const { request, env } = context;
-  if (!(await isAuthorized(request, env))) {
-    return new Response("Unauthorized", { status: 401 });
+  if (!(await isSessionOrKeyAuthorized(
+      request,
+      env.BUCKET,
+      env.WEBDAV_USERNAME,
+      env.WEBDAV_PASSWORD
+    ))) {
+    return textResponse("Unauthorized", 401);
   }
   const flags = await loadFeatureFlags(env.BUCKET);
   if (!flags.imageHost) {

--- a/functions/api/keys.ts
+++ b/functions/api/keys.ts
@@ -1,26 +1,17 @@
+import {
+  KEYS_PREFIX,
+  StoredApiKey,
+  jsonResponse,
+  listStoredKeys,
+  sha256Hex,
+  textResponse,
+  verifyBasicAuth,
+} from "./_apikey";
+
 interface KeysEnv {
   BUCKET: R2Bucket;
   WEBDAV_USERNAME: string;
   WEBDAV_PASSWORD: string;
-}
-
-import { verifyBasicAuth } from "./_apikey";
-
-const KEYS_PREFIX = "_$flaredrive$/apikeys/";
-
-interface StoredApiKey {
-  id: string;
-  name: string;
-  prefix: string;
-  keyHash: string;
-  createdAt: string;
-  expiresAt: string | null;
-  createdBy?: string;
-  lastUsedAt?: string | null;
-}
-
-function isAuthorized(request: Request, env: KeysEnv) {
-  return verifyBasicAuth(request, env.WEBDAV_USERNAME, env.WEBDAV_PASSWORD);
 }
 
 function usernameFromBasic(request: Request): string {
@@ -33,13 +24,6 @@ function usernameFromBasic(request: Request): string {
   } catch {
     return "";
   }
-}
-
-function jsonResponse(body: unknown, status = 200) {
-  return new Response(JSON.stringify(body), {
-    status,
-    headers: { "Content-Type": "application/json; charset=utf-8" },
-  });
 }
 
 function createId() {
@@ -61,16 +45,6 @@ function keyPrefix(key: string) {
   return key.slice(0, Math.min(8, key.length));
 }
 
-async function sha256Hex(value: string) {
-  const digest = await crypto.subtle.digest(
-    "SHA-256",
-    new TextEncoder().encode(value)
-  );
-  return Array.from(new Uint8Array(digest))
-    .map((b) => b.toString(16).padStart(2, "0"))
-    .join("");
-}
-
 function publicKey(record: StoredApiKey) {
   return {
     id: record.id,
@@ -83,27 +57,8 @@ function publicKey(record: StoredApiKey) {
   };
 }
 
-async function listStoredKeys(bucket: R2Bucket): Promise<StoredApiKey[]> {
-  const records: StoredApiKey[] = [];
-  let cursor: string | undefined;
-  do {
-    const listing = await bucket.list({
-      prefix: KEYS_PREFIX,
-      cursor,
-    });
-    for (const object of listing.objects) {
-      if (!object.key.endsWith(".json")) continue;
-      const data = await bucket.get(object.key);
-      if (data === null) continue;
-      try {
-        records.push((await data.json()) as StoredApiKey);
-      } catch {
-        // skip corrupt metadata
-      }
-    }
-    if (!listing.truncated) break;
-    cursor = listing.cursor;
-  } while (true);
+async function listKeysSorted(bucket: R2Bucket): Promise<StoredApiKey[]> {
+  const records = await listStoredKeys(bucket);
   records.sort((a, b) =>
     String(b.createdAt || "").localeCompare(String(a.createdAt || ""))
   );
@@ -112,17 +67,17 @@ async function listStoredKeys(bucket: R2Bucket): Promise<StoredApiKey[]> {
 
 export const onRequestGet: PagesFunction<KeysEnv> = async (context) => {
   const { request, env } = context;
-  if (!isAuthorized(request, env)) {
-    return new Response("Unauthorized", { status: 401 });
+  if (!verifyBasicAuth(request, env.WEBDAV_USERNAME, env.WEBDAV_PASSWORD)) {
+    return textResponse("Unauthorized", 401);
   }
-  const keys = await listStoredKeys(env.BUCKET);
+  const keys = await listKeysSorted(env.BUCKET);
   return jsonResponse(keys.map(publicKey));
 };
 
 export const onRequestPost: PagesFunction<KeysEnv> = async (context) => {
   const { request, env } = context;
-  if (!isAuthorized(request, env)) {
-    return new Response("Unauthorized", { status: 401 });
+  if (!verifyBasicAuth(request, env.WEBDAV_USERNAME, env.WEBDAV_PASSWORD)) {
+    return textResponse("Unauthorized", 401);
   }
 
   let body: { name?: string; expiresInHours?: number | null; key?: string };
@@ -179,8 +134,8 @@ export const onRequestPost: PagesFunction<KeysEnv> = async (context) => {
 
 export const onRequestDelete: PagesFunction<KeysEnv> = async (context) => {
   const { request, env } = context;
-  if (!isAuthorized(request, env)) {
-    return new Response("Unauthorized", { status: 401 });
+  if (!verifyBasicAuth(request, env.WEBDAV_USERNAME, env.WEBDAV_PASSWORD)) {
+    return textResponse("Unauthorized", 401);
   }
 
   const id = new URL(request.url).searchParams.get("id");

--- a/functions/api/list.ts
+++ b/functions/api/list.ts
@@ -159,7 +159,6 @@ export const onRequestGet: PagesFunction<ListEnv> = async (context) => {
       delimiter: "/",
       cursor: cursorParam,
       limit,
-      // @ts-ignore `include` is supported by R2 but missing from this types version.
       include: ["httpMetadata", "customMetadata"],
     });
     collectPage(listing, folder, itemsByKey);
@@ -171,7 +170,6 @@ export const onRequestGet: PagesFunction<ListEnv> = async (context) => {
         prefix: folder,
         delimiter: "/",
         cursor,
-        // @ts-ignore `include` is supported by R2 but missing from this types version.
         include: ["httpMetadata", "customMetadata"],
       });
       collectPage(listing, folder, itemsByKey);

--- a/functions/api/search.ts
+++ b/functions/api/search.ts
@@ -1,4 +1,7 @@
-import { authorizeApiKey, verifyBasicAuth } from "./_apikey";
+import {
+  isSessionOrKeyAuthorized,
+  textResponse,
+} from "./_apikey";
 
 interface SearchEnv {
   BUCKET: R2Bucket;
@@ -6,20 +9,18 @@ interface SearchEnv {
   WEBDAV_PASSWORD: string;
 }
 
-// 会话（Basic）与 API key 均可搜索：MCP search 工具以密钥转发到此端点
-async function isAuthorized(request: Request, env: SearchEnv) {
-  if (verifyBasicAuth(request, env.WEBDAV_USERNAME, env.WEBDAV_PASSWORD)) {
-    return true;
-  }
-  const keyAuth = await authorizeApiKey(request, env.BUCKET);
-  return !(keyAuth instanceof Response);
-}
-
 export const onRequestGet: PagesFunction<SearchEnv> = async (context) => {
   const { request, env } = context;
 
-  if (!(await isAuthorized(request, env))) {
-    return new Response("Unauthorized", { status: 401 });
+  if (
+    !(await isSessionOrKeyAuthorized(
+      request,
+      env.BUCKET,
+      env.WEBDAV_USERNAME,
+      env.WEBDAV_PASSWORD
+    ))
+  ) {
+    return textResponse("Unauthorized", 401);
   }
 
   const url = new URL(request.url);
@@ -51,7 +52,6 @@ export const onRequestGet: PagesFunction<SearchEnv> = async (context) => {
     const listing = await env.BUCKET.list({
       cursor,
       limit: SCAN_PAGE,
-      // @ts-ignore `include` is supported by R2 but missing from this types version.
       include: ["httpMetadata", "customMetadata"],
     });
 

--- a/functions/api/shares.ts
+++ b/functions/api/shares.ts
@@ -1,8 +1,8 @@
 import {
-  authorizeApiKey,
   isCollectionObject,
   isInternalKey,
-  verifyBasicAuth,
+  isSessionOrKeyAuthorized,
+  textResponse,
 } from "./_apikey";
 
 interface SharesEnv {
@@ -12,15 +12,6 @@ interface SharesEnv {
 }
 
 const SHARES_PREFIX = "_$flaredrive$/shares/";
-
-// 会话（Basic）与 API key 均可管理分享：MCP/脚本侧需要以密钥创建与撤销分享
-async function isAuthorized(request: Request, env: SharesEnv) {
-  if (verifyBasicAuth(request, env.WEBDAV_USERNAME, env.WEBDAV_PASSWORD)) {
-    return true;
-  }
-  const keyAuth = await authorizeApiKey(request, env.BUCKET);
-  return !(keyAuth instanceof Response);
-}
 
 function basename(key: string) {
   return key.replace(/\/$/, "").split("/").pop() ?? "";
@@ -74,8 +65,13 @@ async function readShares(
 
 export const onRequestGet: PagesFunction<SharesEnv> = async (context) => {
   const { request, env } = context;
-  if (!(await isAuthorized(request, env))) {
-    return new Response("Unauthorized", { status: 401 });
+  if (!(await isSessionOrKeyAuthorized(
+      request,
+      env.BUCKET,
+      env.WEBDAV_USERNAME,
+      env.WEBDAV_PASSWORD
+    ))) {
+    return textResponse("Unauthorized", 401);
   }
   return new Response(JSON.stringify(await readShares(env.BUCKET, request)), {
     headers: { "Content-Type": "application/json" },
@@ -84,8 +80,13 @@ export const onRequestGet: PagesFunction<SharesEnv> = async (context) => {
 
 export const onRequestPost: PagesFunction<SharesEnv> = async (context) => {
   const { request, env } = context;
-  if (!(await isAuthorized(request, env))) {
-    return new Response("Unauthorized", { status: 401 });
+  if (!(await isSessionOrKeyAuthorized(
+      request,
+      env.BUCKET,
+      env.WEBDAV_USERNAME,
+      env.WEBDAV_PASSWORD
+    ))) {
+    return textResponse("Unauthorized", 401);
   }
 
   let body: { key?: string; expiresInHours?: number; extractCode?: string };
@@ -158,8 +159,13 @@ export const onRequestPost: PagesFunction<SharesEnv> = async (context) => {
 
 export const onRequestDelete: PagesFunction<SharesEnv> = async (context) => {
   const { request, env } = context;
-  if (!(await isAuthorized(request, env))) {
-    return new Response("Unauthorized", { status: 401 });
+  if (!(await isSessionOrKeyAuthorized(
+      request,
+      env.BUCKET,
+      env.WEBDAV_USERNAME,
+      env.WEBDAV_PASSWORD
+    ))) {
+    return textResponse("Unauthorized", 401);
   }
 
   const token = new URL(request.url).searchParams.get("token");

--- a/functions/api/sites.ts
+++ b/functions/api/sites.ts
@@ -6,7 +6,11 @@ import {
   normalizeSitesHost,
   siteConfigKey,
 } from "../_sites";
-import { authorizeApiKey, verifyBasicAuth } from "./_apikey";
+import {
+  isSessionOrKeyAuthorized,
+  jsonResponse,
+  textResponse,
+} from "./_apikey";
 
 interface SitesApiEnv {
   BUCKET: R2Bucket;
@@ -18,22 +22,6 @@ interface SitesApiEnv {
 const SITE_STATS_MAX_OBJECTS = 5000;
 const SITE_STATS_TTL_MS = 10 * 60 * 1000;
 const SITE_DELETE_MAX_OBJECTS = 5000;
-
-// 会话（Basic）与 API key 均可管理站点：MCP sites 工具以密钥转发到此端点
-async function isAuthorized(request: Request, env: SitesApiEnv) {
-  if (verifyBasicAuth(request, env.WEBDAV_USERNAME, env.WEBDAV_PASSWORD)) {
-    return true;
-  }
-  const keyAuth = await authorizeApiKey(request, env.BUCKET);
-  return !(keyAuth instanceof Response);
-}
-
-function jsonResponse(body: unknown, status = 200) {
-  return new Response(JSON.stringify(body), {
-    status,
-    headers: { "Content-Type": "application/json" },
-  });
-}
 
 async function listSiteSlugs(bucket: R2Bucket): Promise<string[]> {
   const slugs: string[] = [];
@@ -89,8 +77,13 @@ async function saveSiteConfig(bucket: R2Bucket, config: SiteConfig): Promise<voi
 
 export const onRequestGet: PagesFunction<SitesApiEnv> = async (context) => {
   const { request, env } = context;
-  if (!(await isAuthorized(request, env))) {
-    return new Response("Unauthorized", { status: 401 });
+  if (!(await isSessionOrKeyAuthorized(
+      request,
+      env.BUCKET,
+      env.WEBDAV_USERNAME,
+      env.WEBDAV_PASSWORD
+    ))) {
+    return textResponse("Unauthorized", 401);
   }
 
   const url = new URL(request.url);
@@ -120,8 +113,13 @@ export const onRequestGet: PagesFunction<SitesApiEnv> = async (context) => {
 
 export const onRequestPost: PagesFunction<SitesApiEnv> = async (context) => {
   const { request, env } = context;
-  if (!(await isAuthorized(request, env))) {
-    return new Response("Unauthorized", { status: 401 });
+  if (!(await isSessionOrKeyAuthorized(
+      request,
+      env.BUCKET,
+      env.WEBDAV_USERNAME,
+      env.WEBDAV_PASSWORD
+    ))) {
+    return textResponse("Unauthorized", 401);
   }
 
   let body: { slug?: string; spa?: boolean };
@@ -152,8 +150,13 @@ export const onRequestPost: PagesFunction<SitesApiEnv> = async (context) => {
 
 export const onRequestDelete: PagesFunction<SitesApiEnv> = async (context) => {
   const { request, env } = context;
-  if (!(await isAuthorized(request, env))) {
-    return new Response("Unauthorized", { status: 401 });
+  if (!(await isSessionOrKeyAuthorized(
+      request,
+      env.BUCKET,
+      env.WEBDAV_USERNAME,
+      env.WEBDAV_PASSWORD
+    ))) {
+    return textResponse("Unauthorized", 401);
   }
 
   const slug = (new URL(request.url).searchParams.get("slug") || "").trim().toLowerCase();

--- a/functions/api/trash.ts
+++ b/functions/api/trash.ts
@@ -1,4 +1,9 @@
-import { ensureFolderMarkers, isInternalKey, verifyBasicAuth } from "./_apikey";
+import {
+  ensureFolderMarkers,
+  isInternalKey,
+  textResponse,
+  verifyBasicAuth,
+} from "./_apikey";
 
 interface TrashEnv {
   BUCKET: R2Bucket;
@@ -50,10 +55,6 @@ function retentionDaysFrom(env: TrashEnv): number {
   return Number.isFinite(parsed) ? parsed : 30;
 }
 
-function isAuthorized(request: Request, env: TrashEnv) {
-  return verifyBasicAuth(request, env.WEBDAV_USERNAME, env.WEBDAV_PASSWORD);
-}
-
 function basename(key: string) {
   return key.replace(/\/$/, "").split("/").pop() ?? "";
 }
@@ -65,7 +66,6 @@ async function listObjects(bucket: R2Bucket, prefix: string) {
     const listing = await bucket.list({
       prefix,
       cursor,
-      // @ts-ignore `include` is supported by R2 but missing from this types version.
       include: ["httpMetadata", "customMetadata"],
     });
     objects.push(...listing.objects);
@@ -114,8 +114,8 @@ async function listTrashItems(bucket: R2Bucket) {
 
 export const onRequestGet: PagesFunction<TrashEnv> = async (context) => {
   const { request, env } = context;
-  if (!isAuthorized(request, env)) {
-    return new Response("Unauthorized", { status: 401 });
+  if (!verifyBasicAuth(request, env.WEBDAV_USERNAME, env.WEBDAV_PASSWORD)) {
+    return textResponse("Unauthorized", 401);
   }
   await purgeExpiredTrash(env.BUCKET, retentionDaysFrom(env));
   return new Response(
@@ -126,8 +126,8 @@ export const onRequestGet: PagesFunction<TrashEnv> = async (context) => {
 
 export const onRequestPost: PagesFunction<TrashEnv> = async (context) => {
   const { request, env } = context;
-  if (!isAuthorized(request, env)) {
-    return new Response("Unauthorized", { status: 401 });
+  if (!verifyBasicAuth(request, env.WEBDAV_USERNAME, env.WEBDAV_PASSWORD)) {
+    return textResponse("Unauthorized", 401);
   }
 
   const url = new URL(request.url);
@@ -139,8 +139,8 @@ export const onRequestPost: PagesFunction<TrashEnv> = async (context) => {
 
 export const onRequestDelete: PagesFunction<TrashEnv> = async (context) => {
   const { request, env } = context;
-  if (!isAuthorized(request, env)) {
-    return new Response("Unauthorized", { status: 401 });
+  if (!verifyBasicAuth(request, env.WEBDAV_USERNAME, env.WEBDAV_PASSWORD)) {
+    return textResponse("Unauthorized", 401);
   }
 
   let body: { trashKeys?: string[]; all?: boolean };

--- a/functions/api/upload.ts
+++ b/functions/api/upload.ts
@@ -7,7 +7,6 @@ import {
   jsonResponse,
   textResponse,
   touchLastUsed,
-  type StoredApiKey,
 } from "./_apikey";
 
 interface UploadEnv {

--- a/functions/webdav/protocol.ts
+++ b/functions/webdav/protocol.ts
@@ -2089,6 +2089,9 @@ function handleOptions(): Response {
 }
 
 function isAuthorized(authorizationHeader: string, username: string, password: string): boolean {
+  // fail closed：凭据未配置或为空时一律拒绝（与 api/_apikey.ts 的 verifyBasicAuth 对齐），
+  // 避免 btoa("undefined:undefined") / btoa(":") 这类固定值成为可被猜中的有效 Basic 头。
+  if (!username || !password) return false;
   const encoder = new TextEncoder();
   const header = encoder.encode(authorizationHeader);
   const expected = encoder.encode(`Basic ${utf8ToBase64(`${username}:${password}`)}`);

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,12 +24,11 @@
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-scripts": "5.0.1",
-        "typescript": "^5.5.3",
-        "web-vitals": "^2.1.4"
+        "typescript": "^5.5.3"
       },
       "devDependencies": {
         "@babel/plugin-proposal-private-property-in-object": "^7.21.11",
-        "@cloudflare/workers-types": "^4.20240620.0"
+        "@cloudflare/workers-types": "^5.20260905.1"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -2064,10 +2063,11 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw=="
     },
     "node_modules/@cloudflare/workers-types": {
-      "version": "4.20240620.0",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20240620.0.tgz",
-      "integrity": "sha512-CQD8YS6evRob7LChvIX3gE3zYo0KVgaLDOu1SwNP1BVIS2Sa0b+FC8S1e1hhrNN8/E4chYlVN+FDAgA4KRDUEQ==",
-      "dev": true
+      "version": "5.20260905.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-5.20260905.1.tgz",
+      "integrity": "sha512-ebDpVTgrnee245IRBTazyfjfmZas+HJehZyVQkKmUozsBN8RzvXXMI0XjjcT2rQjw+0USewfEGGLYiHO+TL0Sg==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0"
     },
     "node_modules/@csstools/normalize.css": {
       "version": "12.1.1",
@@ -17996,11 +17996,6 @@
       "dependencies": {
         "minimalistic-assert": "^1.0.0"
       }
-    },
-    "node_modules/web-vitals": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-2.1.4.tgz",
-      "integrity": "sha512-sVWcwhU5mX6crfI5Vd2dC4qchyTqxV8URinzt25XqVh+bHEPGH4C3NPrNionCP7Obx59wrYEbNlw4Z8sjALzZg=="
     },
     "node_modules/webidl-conversions": {
       "version": "6.1.0",

--- a/package.json
+++ b/package.json
@@ -7,20 +7,19 @@
     "@emotion/styled": "^11.11.5",
     "@mui/icons-material": "^5.15.21",
     "@mui/material": "^5.15.21",
-    "@xmldom/xmldom": "^0.8.11",
     "@testing-library/jest-dom": "^5.17.0",
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",
     "@types/node": "^20.14.9",
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",
+    "@xmldom/xmldom": "^0.8.11",
     "fflate": "^0.8.3",
     "p-limit": "^6.1.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-scripts": "5.0.1",
-    "typescript": "^5.5.3",
-    "web-vitals": "^2.1.4"
+    "typescript": "^5.5.3"
   },
   "scripts": {
     "start": "react-scripts start",
@@ -56,6 +55,6 @@
   },
   "devDependencies": {
     "@babel/plugin-proposal-private-property-in-object": "^7.21.11",
-    "@cloudflare/workers-types": "^4.20240620.0"
+    "@cloudflare/workers-types": "^5.20260905.1"
   }
 }

--- a/scripts/api-e2e.sh
+++ b/scripts/api-e2e.sh
@@ -124,6 +124,14 @@ assert_code "paged unique total = 5" "$TOTAL" "5"
 code=$(curl -s --noproxy '*' -o /tmp/o -w "%{http_code}" "$BASE/api/list?path=$DIR/paged/&limit=0" -H "$A")
 assert_code "limit=0 rejected" "$code" "400"
 
+echo "== counts 批量计数 =="
+code=$(curl -s --noproxy '*' -o /tmp/o.json -w "%{http_code}" -X POST "$BASE/api/counts" -H "$BASIC" -H "Content-Type: application/json" -d "{\"paths\":[\"$DIR/paged\",\"$DIR/nonexistent-dir\"]}")
+assert_code "counts 200" "$code" "200"
+assert_contains "counts paged dir = 5" "$(cat /tmp/o.json)" "\"$DIR/paged\":5"
+assert_contains "counts missing dir = 0" "$(cat /tmp/o.json)" "\"$DIR/nonexistent-dir\":0"
+code=$(curl -s --noproxy '*' -o /tmp/o -w "%{http_code}" -X POST "$BASE/api/counts" -H "$A" -H "Content-Type: application/json" -d '{"paths":["x"]}')
+assert_code "counts api key = 401" "$code" "401"
+
 echo "== 大文件分块上传（除末块外 ≥5MiB）=="
 P1BIN="/tmp/fd-suite-$$.p1.bin"; head -c 5242880 /dev/zero > "$P1BIN"
 P2BIN="/tmp/fd-suite-$$.p2.bin"; printf 'tail-content\n' > "$P2BIN"

--- a/src/ApiKeysPanel.tsx
+++ b/src/ApiKeysPanel.tsx
@@ -40,6 +40,7 @@ import { useFeatures } from "./app/features";
 import { NotifyFn } from "./app/notify";
 import { strings, translate } from "./app/strings";
 import { ApiKeyInfo } from "./app/types";
+import { errorMessage } from "./app/utils";
 
 function formatExpiry(expiresAt: string | null) {
   if (!expiresAt) return strings.apiNever;
@@ -90,7 +91,7 @@ function ApiKeysPanel({
     try {
       setKeys(await listApiKeys());
     } catch (error) {
-      onNotify((error as Error).message, "error");
+      onNotify(errorMessage(error), "error");
     } finally {
       setLoading(false);
     }
@@ -147,7 +148,7 @@ function ApiKeysPanel({
       await load();
       onNotify(translate("keyCreatedToast"), "success");
     } catch (error) {
-      onNotify((error as Error).message, "error");
+      onNotify(errorMessage(error), "error");
     } finally {
       setCreating(false);
     }
@@ -160,7 +161,7 @@ function ApiKeysPanel({
       await revokeApiKey(id);
       onNotify(translate("keyRevokedToast"), "success");
     } catch (error) {
-      onNotify((error as Error).message, "error");
+      onNotify(errorMessage(error), "error");
       await load();
     }
   };

--- a/src/FileGrid.tsx
+++ b/src/FileGrid.tsx
@@ -759,4 +759,6 @@ function thumbnail(file: FileItem, size: number) {
   );
 }
 
-export default FileGrid;
+// 浅比较 props：Main 侧回调均为 useCallback、emptyMessage 已 useMemo，
+// 对话框/菜单等无关状态更新时跳过整表重渲染。
+export default React.memo(FileGrid);

--- a/src/ImagesView.tsx
+++ b/src/ImagesView.tsx
@@ -25,7 +25,7 @@ import { useFeatures } from "./app/features";
 import { HostedImage, deleteImage, listImages, uploadImage } from "./app/images";
 import { NotifyFn } from "./app/notify";
 import { strings, translate } from "./app/strings";
-import { humanReadableSize } from "./app/utils";
+import { errorMessage, humanReadableSize } from "./app/utils";
 
 function isImageFile(file: File) {
   if (file.type.startsWith("image/")) return true;
@@ -51,7 +51,7 @@ function ImagesView({
       const data = await listImages();
       setImages(data.images);
     } catch (error) {
-      onNotify((error as Error).message, "error");
+      onNotify(errorMessage(error), "error");
     }
   }, [onNotify]);
 
@@ -78,7 +78,7 @@ function ImagesView({
         setImages((prev) => [created, ...prev.filter((item) => item.id !== created.id)]);
         onNotify(translate("uploadedToast", { name: created.name }), "success");
       } catch (error) {
-        onNotify((error as Error).message, "error");
+        onNotify(errorMessage(error), "error");
       }
     }
   };
@@ -101,7 +101,7 @@ function ImagesView({
       setImages((prev) => prev.filter((item) => item.id !== target.id));
       onNotify(strings.imageDeleted, "success");
     } catch (error) {
-      onNotify((error as Error).message, "error");
+      onNotify(errorMessage(error), "error");
     }
   };
 

--- a/src/Main.tsx
+++ b/src/Main.tsx
@@ -1,34 +1,15 @@
 import { isPreviewable } from "./app/preview";
 import React, {
+  Suspense,
+  lazy,
   useCallback,
   useEffect,
   useMemo,
   useRef,
   useState,
 } from "react";
-import {
-  Box,
-  Breadcrumbs,
-  Button,
-  CircularProgress,
-  IconButton,
-  Link,
-  Menu,
-  MenuItem,
-  Stack,
-  ToggleButton,
-  ToggleButtonGroup,
-  Tooltip,
-  Typography,
-} from "@mui/material";
-import {
-  ArrowBack as ArrowBackIcon,
-  ContentCopy as ContentCopyIcon,
-  ExpandMore as ExpandMoreIcon,
-  Folder as FolderIcon,
-  FolderOpen as FolderOpenIcon,
-  SearchOff as SearchOffIcon,
-} from "@mui/icons-material";
+import { Box, Button, CircularProgress, Stack, Typography } from "@mui/material";
+import { FolderOpen as FolderOpenIcon, SearchOff as SearchOffIcon } from "@mui/icons-material";
 
 import ConfirmDialog from "./ConfirmDialog";
 import CreateFolderDialog from "./CreateFolderDialog";
@@ -39,15 +20,13 @@ import FileGrid, { FileGridSkeleton } from "./FileGrid";
 import MobileNav from "./MobileNav";
 import MoveDialog from "./MoveDialog";
 import MultiSelectToolbar from "./MultiSelectToolbar";
-import PreviewDialog from "./PreviewDialog";
+import PathBar, { SearchScope } from "./PathBar";
 import RenameDialog from "./RenameDialog";
 import ShareDialog from "./ShareDialog";
 import SharesView from "./SharesView";
 import SettingsView from "./SettingsView";
-import SitesView from "./SitesView";
 import TextPadDrawer from "./TextPadDrawer";
 import TrashView from "./TrashView";
-import ImagesView from "./ImagesView";
 import WebDavPanel from "./WebDavPanel";
 import { useClipboard } from "./app/clipboard";
 import { NotifyFn } from "./app/notify";
@@ -62,335 +41,34 @@ import {
   createFolder,
   downloadArchive,
   downloadFile,
-  fetchFolderCounts,
   fetchPath,
   openFile,
-  searchFiles,
   selectDirectoryFiles,
 } from "./app/transfer";
 import { moveToTrash, restoreTrash } from "./app/trash";
-import { useAuth } from "./app/auth";
+import { transferKeys, useUploadInputs } from "./app/useUploadInputs";
+import { useDragDropUpload } from "./app/useDragDropUpload";
+import { useFolderCounts } from "./app/useFolderCounts";
+import { useFolderListing } from "./app/useFolderListing";
+import { useKeyboardShortcuts } from "./app/useKeyboardShortcuts";
+import { useMultiSelect } from "./app/useMultiSelect";
+import { usePasteUpload } from "./app/usePasteUpload";
 import { useFeatures } from "./app/features";
-import { useTransferQueue, useUploadEnqueue } from "./app/transferQueue";
 import { FileItem } from "./app/types";
-import {
-  basename,
-  fileTypeCategory,
-  formatListingSize,
-  isDirectory,
-  isJunkFileName,
-  uniqueName,
-  uniquifyUploadFiles,
-} from "./app/utils";
+import { errorMessage, fileTypeCategory, formatListingSize, isDirectory, isJunkFileName } from "./app/utils";
+import { parentKey } from "./app/interaction";
 
-export type SearchScope = "folder" | "global";
+// 重组件按需加载：只有真正打开预览 / 进入对应 section 时才拉取对应 chunk
+const PreviewDialog = lazy(() => import("./PreviewDialog"));
+const SitesView = lazy(() => import("./SitesView"));
+const ImagesView = lazy(() => import("./ImagesView"));
 
-const FOLDER_COUNT_CACHE_KEY = "flaredrive.folderCounts";
-const FOLDER_COUNT_FILL_MAX = 50;
-
-function loadFolderCountCache(): Record<string, number> {
-  try {
-    return JSON.parse(
-      sessionStorage.getItem(FOLDER_COUNT_CACHE_KEY) || "{}"
-    ) as Record<string, number>;
-  } catch {
-    return {};
-  }
-}
-
-function saveFolderCountCache(counts: Record<string, number>) {
-  try {
-    sessionStorage.setItem(FOLDER_COUNT_CACHE_KEY, JSON.stringify(counts));
-  } catch {
-    // 忽略持久化失败
-  }
-}
-
-function isTypingTarget(target: EventTarget | null) {
-  const el =
-    target instanceof HTMLElement
-      ? target
-      : document.activeElement instanceof HTMLElement
-      ? document.activeElement
-      : null;
-  if (!el) return false;
-  const field = el.closest("input, textarea, select, [contenteditable='true']");
-  if (field instanceof HTMLInputElement) {
-    return !["checkbox", "radio", "button", "submit"].includes(field.type);
-  }
-  if (field instanceof HTMLTextAreaElement || field instanceof HTMLSelectElement) {
-    return true;
-  }
-  return Boolean(field) || el.isContentEditable;
-}
-
-function shouldIgnoreShortcuts(event: KeyboardEvent) {
-  if (event.isComposing || event.key === "Process") return true;
-  return isTypingTarget(event.target) || isTypingTarget(document.activeElement);
-}
-
-function parentKey(key: string) {
-  const trimmed = key.replace(/\/$/, "");
-  const index = trimmed.lastIndexOf("/");
-  return index >= 0 ? trimmed.slice(0, index + 1) : "";
-}
-
-function stampPastedName(file: File) {
-  const subtype = (file.type.split("/")[1] || "png").replace("jpeg", "jpg");
-  const ext = subtype.split("+")[0] || "png";
-  const now = new Date();
-  const pad = (n: number) => String(n).padStart(2, "0");
-  return `${strings.pastedImage} ${now.getFullYear()}${pad(now.getMonth() + 1)}${pad(
-    now.getDate()
-  )}-${pad(now.getHours())}${pad(now.getMinutes())}${pad(now.getSeconds())}.${ext}`;
-}
-
-function dragHasFiles(event: DragEvent | React.DragEvent) {
-  const types = event.dataTransfer?.types;
-  if (!types) return false;
-  const list = Array.from(types as ArrayLike<string>);
-  if (list.includes("application/x-flaredrive")) return false;
-  return list.includes("Files");
-}
-
-function hasOpenOverlay() {
-  const nodes = document.querySelectorAll(".MuiModal-root");
-  for (let i = 0; i < nodes.length; i++) { const node = nodes[i];
-    if (node.getAttribute("aria-hidden") !== "true") return true;
-  }
-  return false;
-}
-
-function PathBar({
-  cwd,
-  onNavigate,
-  stats,
-  searchScope,
-  onSearchScopeChange,
-  searchQuery,
-  onNotify,
-}: {
-  cwd: string;
-  onNavigate: (path: string) => void;
-  stats: string;
-  searchScope: SearchScope;
-  onSearchScopeChange: (scope: SearchScope) => void;
-  searchQuery: string;
-  onNotify: NotifyFn;
-}) {
-  const parts = cwd.replace(/\/$/, "").split("/").filter(Boolean);
-  const atRoot = parts.length === 0;
-  const pathText = atRoot ? "/" : `/${parts.join("/")}/`;
-  const parentPath =
-    atRoot || parts.length === 1 ? "" : `${parts.slice(0, -1).join("/")}/`;
-  const [siblingsAnchor, setSiblingsAnchor] = useState<null | HTMLElement>(null);
-  const [siblings, setSiblings] = useState<FileItem[] | null>(null);
-  const openSiblings = async (event: React.MouseEvent<HTMLButtonElement>) => {
-    setSiblingsAnchor(event.currentTarget);
-    setSiblings(null);
-    try {
-      const items = await fetchPath(parentPath);
-      setSiblings(items.filter((item) => item.isDir));
-    } catch {
-      setSiblings([]);
-    }
-  };
-  const copyPath = async () => {
-    try {
-      await navigator.clipboard.writeText(pathText);
-      onNotify(translate("pathCopied"), "success");
-    } catch {
-      onNotify(translate("copyFailed"), "error");
-    }
-  };
-
+function SectionLoading() {
   return (
-    <Box sx={{ px: 1.5, pb: 1.25, pt: 0.25 }}>
-      <Box sx={{ display: "flex", alignItems: "center", gap: 0.5 }}>
-        <IconButton
-          size="small"
-          aria-label={strings.goUp}
-          disabled={atRoot}
-          onClick={() =>
-            onNavigate(parts.slice(0, -1).join("/") + (parts.length > 1 ? "/" : ""))
-          }
-          sx={{
-            visibility: atRoot ? "hidden" : "visible",
-            opacity: atRoot ? 0 : 1,
-            pointerEvents: atRoot ? "none" : "auto",
-          }}
-        >
-          <ArrowBackIcon fontSize="small" />
-        </IconButton>
-        <Breadcrumbs
-          separator="›"
-          sx={{
-            flexGrow: 1,
-            "& .MuiTypography-root": { fontWeight: 600, fontSize: "0.9rem" },
-            "& .MuiLink-root": { fontWeight: 500, fontSize: "0.9rem" },
-          }}
-        >
-          {parts.length === 0 ? (
-            <Typography color="text.primary">{strings.allFiles}</Typography>
-          ) : (
-            <Link component="button" onClick={() => onNavigate("")}>
-              {strings.allFiles}
-            </Link>
-          )}
-          {parts.map((part, index) =>
-            index === parts.length - 1 ? (
-              <Typography key={index} color="text.primary">
-                {part}
-              </Typography>
-            ) : (
-              <Link
-                key={index}
-                component="button"
-                onClick={() =>
-                  onNavigate(parts.slice(0, index + 1).join("/") + "/")
-                }
-              >
-                {part}
-              </Link>
-            )
-          )}
-        </Breadcrumbs>
-        <IconButton
-          size="small"
-          aria-label={strings.copyPath}
-          onClick={copyPath}
-          sx={{ flexShrink: 0 }}
-        >
-          <ContentCopyIcon fontSize="small" />
-        </IconButton>
-        {!atRoot && (
-          <Tooltip title={strings.siblingFolders}>
-            <IconButton
-              size="small"
-              aria-label={strings.siblingFolders}
-              onClick={openSiblings}
-              sx={{ flexShrink: 0, mr: -0.5 }}
-            >
-              <ExpandMoreIcon fontSize="small" />
-            </IconButton>
-          </Tooltip>
-        )}
-        <Menu
-          anchorEl={siblingsAnchor}
-          open={Boolean(siblingsAnchor)}
-          onClose={() => setSiblingsAnchor(null)}
-        >
-          {siblings === null && (
-            <MenuItem disabled>{strings.loading}</MenuItem>
-          )}
-          {siblings !== null && siblings.length === 0 && (
-            <MenuItem disabled>{strings.noSiblingFolder}</MenuItem>
-          )}
-          {siblings !== null &&
-            siblings.map((item) => (
-              <MenuItem
-                key={item.key}
-                selected={item.key === cwd.replace(/\/$/, "")}
-                onClick={() => {
-                  setSiblingsAnchor(null);
-                  onNavigate(item.key);
-                }}
-              >
-                <FolderIcon fontSize="small" sx={{ mr: 1, color: "primary.main" }} />
-                {item.name}
-              </MenuItem>
-            ))}
-        </Menu>
-      </Box>
-      <Box
-        sx={{
-          display: "flex",
-          alignItems: "center",
-          gap: 1,
-          flexWrap: "wrap",
-          paddingLeft: "40px",
-          minHeight: 32,
-        }}
-      >
-        <Typography
-          variant="caption"
-          color="text.secondary"
-          sx={{
-            px: 1,
-            py: 0.25,
-            borderRadius: "999px",
-            backgroundColor: "background.default",
-            fontVariantNumeric: "tabular-nums",
-          }}
-        >
-          {stats}
-        </Typography>
-        <Box sx={{ flexGrow: 1 }} />
-        <ToggleButtonGroup
-          exclusive
-          size="small"
-          value={searchScope}
-          onChange={(_, value: SearchScope | null) => {
-            if (value) onSearchScopeChange(value);
-          }}
-          aria-label={strings.searchScope}
-          sx={{
-            backgroundColor: "background.default",
-            "& .MuiToggleButton-root": {
-              border: "none",
-              px: 1.25,
-              py: 0.25,
-              fontSize: "0.75rem",
-              "&.Mui-selected": {
-                backgroundColor: "background.paper",
-                color: "primary.main",
-                boxShadow: (theme) =>
-                  warmShadow(theme.palette.mode === "dark", "0 1px 2px", 0.08),
-              },
-            },
-          }}
-        >
-          <ToggleButton value="folder">{strings.searchHere}</ToggleButton>
-          <ToggleButton value="global">{strings.searchAll}</ToggleButton>
-        </ToggleButtonGroup>
-      </Box>
-      {searchQuery ? (
-        <Typography
-          variant="body2"
-          color="text.secondary"
-          sx={{ paddingLeft: "40px", paddingTop: 0.5 }}
-        >
-          {searchScope === "global" ? strings.searchAll : strings.searchHere}：
-          {searchQuery}
-        </Typography>
-      ) : null}
+    <Box sx={{ display: "flex", justifyContent: "center", padding: 6 }}>
+      <CircularProgress size={28} />
     </Box>
   );
-}
-
-async function transferKeys(
-  keys: string[],
-  destination: string,
-  mode: "copy" | "cut"
-) {
-  let existing: FileItem[] = [];
-  try {
-    existing = await fetchPath(destination);
-  } catch {
-    existing = [];
-  }
-  const taken = new Set(existing.map((file) => file.name));
-
-  for (const key of keys) {
-    const name = basename(key);
-    if (mode === "cut") {
-      const parent = key.slice(0, key.length - name.length);
-      if (parent === destination) continue;
-    }
-    const targetName = uniqueName(name, taken);
-    await copyPaste(key, `${destination}${targetName}`, mode === "cut");
-    taken.add(targetName);
-  }
 }
 
 function Main({
@@ -424,16 +102,11 @@ function Main({
     cut: cutToClipboard,
     clear: clearClipboard,
   } = useClipboard();
-  const transferQueue = useTransferQueue();
-  const uploadEnqueue = useUploadEnqueue();
-  const { username } = useAuth();
+  const recents = useRecent();
+  const { flags } = useFeatures();
 
-  const [files, setFiles] = useState<FileItem[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [selectedKeys, setSelectedKeys] = useState<string[]>([]);
   const [debouncedSearch, setDebouncedSearch] = useState("");
-  const [searchHasMore, setSearchHasMore] = useState(false);
-  const [searchCursor, setSearchCursor] = useState<string | undefined>();
+  const [searchScope, setSearchScope] = useState<SearchScope>("folder");
   const [showCreateFolder, setShowCreateFolder] = useState(false);
   const [showTextPadDrawer, setShowTextPadDrawer] = useState(false);
   const [showWebDav, setShowWebDav] = useState(false);
@@ -447,12 +120,6 @@ function Main({
     "standard"
   );
   const [pendingOpen, setPendingOpen] = useState<string | null>(null);
-  const [folderCounts, setFolderCounts] = useState<Record<string, number>>(
-    loadFolderCountCache
-  );
-  const folderCountInFlight = useRef(new Set<string>());
-  const recents = useRecent();
-  const [searchScope, setSearchScope] = useState<SearchScope>("folder");
   const [contextMenu, setContextMenu] = useState<{
     x: number;
     y: number;
@@ -463,14 +130,27 @@ function Main({
   const [previewFile, setPreviewFile] = useState<FileItem | null>(null);
   const [confirmDelete, setConfirmDelete] = useState<string[] | null>(null);
   const [moveTarget, setMoveTarget] = useState<string[] | null>(null);
-  const [dropActive, setDropActive] = useState(false);
-  const [focusedKey, setFocusedKey] = useState<string | null>(null);
-  const selectionAnchor = useRef<string | null>(null);
   const lastFolderPath = useRef("");
-  const loadedListingKey = useRef<string | null>(null);
-  const dropDepth = useRef(0);
 
-  const { flags } = useFeatures();
+  // 跨 hook 的桥接：useFolderListing 在选择/计数 hook 之前声明，
+  // 通过 ref 转发其回调到后声明的 setter。
+  const folderCountsSetterRef = useRef<
+    (update: (prev: Record<string, number>) => Record<string, number>) => void
+  >(() => {});
+  const clearSelectionRef = useRef<() => void>(() => {});
+  const onListingLoaded = useCallback(
+    (path: string, count: number) => {
+      folderCountsSetterRef.current((prev) => ({ ...prev, [path]: count }));
+    },
+    []
+  );
+  const onListingChanged = useCallback(() => {
+    clearSelectionRef.current();
+  }, []);
+  const clearSelection = useCallback(() => {
+    clearSelectionRef.current();
+  }, []);
+
   const cwd = route.kind === "folder" ? route.path : lastFolderPath.current;
   const section: ExplorerSection =
     route.kind === "shares" ||
@@ -480,6 +160,28 @@ function Main({
     route.kind === "settings"
       ? route.kind
       : "folder";
+
+  const {
+    files,
+    listingPending,
+    isGlobalSearch,
+    loadListing,
+    searchHasMore,
+    loadMoreSentinelRef,
+  } = useFolderListing({
+    route,
+    cwd,
+    debouncedSearch,
+    searchScope,
+    onNotify,
+    onListingLoaded,
+    onListingChanged,
+  });
+
+  const { transferQueue, takenForCwd, enqueueToDir } = useUploadInputs({
+    cwd,
+    files,
+  });
 
   useEffect(() => {
     if (route.kind === "folder") lastFolderPath.current = route.path;
@@ -506,10 +208,6 @@ function Main({
   }, [cwd]);
 
   useEffect(() => {
-    setFocusedKey(null);
-  }, [cwd, section]);
-
-  useEffect(() => {
     const timer = window.setTimeout(() => {
       setDebouncedSearch(search.trim());
     }, 300);
@@ -521,73 +219,6 @@ function Main({
       navigate({ kind: "folder", path: lastFolderPath.current });
     }
   }, [navigate, route.kind, search]);
-
-  const isGlobalSearch = Boolean(debouncedSearch) && searchScope === "global";
-  const listingKey =
-    route.kind === "folder"
-      ? isGlobalSearch
-        ? `folder:${cwd}||search:${debouncedSearch}`
-        : `folder:${cwd}`
-      : route.kind;
-
-  const loadListing = useCallback(async () => {
-    if (route.kind !== "folder") {
-      setFiles([]);
-      setLoading(false);
-      loadedListingKey.current = listingKey;
-      return;
-    }
-    if (username === null) {
-      setFiles([]);
-      setLoading(false);
-      return;
-    }
-
-    const silent = loadedListingKey.current === listingKey;
-    if (!silent) setLoading(true);
-    try {
-      if (isGlobalSearch) {
-        const result = await searchFiles(debouncedSearch);
-        setFiles(result.items);
-        setSearchHasMore(result.hasMore);
-        setSearchCursor(result.nextCursor);
-      } else {
-        const items = await fetchPath(cwd);
-        setFiles(items);
-        setFolderCounts((prev) => ({
-          ...prev,
-          [cwd.replace(/\/$/, "")]: items.length,
-        }));
-        setSearchHasMore(false);
-        setSearchCursor(undefined);
-      }
-      const listingChanged = loadedListingKey.current !== listingKey;
-      loadedListingKey.current = listingKey;
-      if (listingChanged) setSelectedKeys([]);
-    } catch (error) {
-      const alreadyLoaded = loadedListingKey.current === listingKey;
-      loadedListingKey.current = listingKey;
-      if (!alreadyLoaded) setFiles([]);
-      onNotify((error as Error).message, "error", {
-        duration: 8000,
-        action: { label: strings.retry, onClick: () => loadListing() },
-      });
-    } finally {
-      setLoading(false);
-    }
-  }, [
-    cwd,
-    debouncedSearch,
-    listingKey,
-    onNotify,
-    route.kind,
-    isGlobalSearch,
-    username,
-  ]);
-
-  useEffect(() => {
-    loadListing();
-  }, [loadListing]);
 
   const activeUploads = transferQueue.filter(
     (task) =>
@@ -602,66 +233,6 @@ function Main({
     }
     previousActive.current = activeUploads;
   }, [activeUploads, loadListing]);
-
-  const [loadingMore, setLoadingMore] = useState(false);
-  const loadMoreSentinelRef = useRef<HTMLDivElement | null>(null);
-  const loadMore = useCallback(async () => {
-    if (!isGlobalSearch || !searchCursor || loadingMore) return;
-    setLoadingMore(true);
-    try {
-      const result = await searchFiles(debouncedSearch, searchCursor);
-      setFiles((prev) => [...prev, ...result.items]);
-      setSearchHasMore(result.hasMore);
-      setSearchCursor(result.nextCursor);
-    } catch (error) {
-      onNotify((error as Error).message, "error");
-    } finally {
-      setLoadingMore(false);
-    }
-  }, [
-    debouncedSearch,
-    isGlobalSearch,
-    loadingMore,
-    onNotify,
-    searchCursor,
-  ]);
-
-  // 全盘搜索触底自动加载：IO 为主，scroll 捕获阶段兜底（部分嵌入环境 IO 不发回调）
-  useEffect(() => {
-    if (!searchHasMore) return;
-    const node = loadMoreSentinelRef.current;
-    if (!node) return;
-
-    const maybeLoad = () => {
-      const rect = node.getBoundingClientRect();
-      if (rect.top < window.innerHeight + 200 && rect.bottom > -200) {
-        loadMore();
-      }
-    };
-    const observer = new IntersectionObserver(
-      (entries) => {
-        if (entries.some((entry) => entry.isIntersecting)) loadMore();
-      },
-      { rootMargin: "200px" }
-    );
-    observer.observe(node);
-
-    let lastCheck = 0;
-    const onScroll = () => {
-      // rAF 在部分嵌入环境会被暂停，直接用时间戳节流
-      const now = Date.now();
-      if (now - lastCheck < 150) return;
-      lastCheck = now;
-      maybeLoad();
-    };
-    window.addEventListener("scroll", onScroll, { passive: true, capture: true });
-    const initial = window.setTimeout(maybeLoad, 0);
-    return () => {
-      observer.disconnect();
-      window.removeEventListener("scroll", onScroll, { capture: true });
-      window.clearTimeout(initial);
-    };
-  }, [loadMore, searchHasMore]);
 
   const sortedFiles = useMemo(() => {
     const items = [...files];
@@ -727,80 +298,33 @@ function Main({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [visibleFiles, lang]);
 
+  const {
+    selectedKeys,
+    setSelectedKeys,
+    focusedKey,
+    setFocusedKey,
+    toggleSelect,
+    selectAll,
+    jumpFocused,
+    moveFocused,
+  } = useMultiSelect(visibleFiles);
+
+  useEffect(() => {
+    setFocusedKey(null);
+  }, [cwd, section, setFocusedKey]);
+
+  const { folderCounts, setFolderCounts } = useFolderCounts({
+    active: route.kind === "folder" && !isGlobalSearch,
+    visibleFiles,
+  });
+  folderCountsSetterRef.current = setFolderCounts;
+  clearSelectionRef.current = () => setSelectedKeys([]);
+
   useEffect(() => {
     if (focusedKey && !visibleFiles.some((file) => file.key === focusedKey)) {
       setFocusedKey(null);
     }
-  }, [focusedKey, visibleFiles]);
-
-  const scrollFocusedIntoView = useCallback((key: string) => {
-    const nodes = document.querySelectorAll<HTMLElement>("[data-file-key]");
-    for (let i = 0; i < nodes.length; i++) {
-      const node = nodes[i];
-      if (node.dataset.fileKey === key) {
-        node.scrollIntoView({ block: "nearest" });
-        return;
-      }
-    }
-  }, []);
-
-  const jumpFocused = useCallback(
-    (index: number, extendSelection: boolean) => {
-      if (!visibleFiles.length) return;
-      const clamped = Math.max(0, Math.min(index, visibleFiles.length - 1));
-      const next = visibleFiles[clamped];
-      setFocusedKey(next.key);
-      if (extendSelection) {
-        setSelectedKeys((prev) =>
-          prev.includes(next.key) ? prev : [...prev, next.key]
-        );
-      }
-      scrollFocusedIntoView(next.key);
-    },
-    [scrollFocusedIntoView, visibleFiles]
-  );
-
-  const moveFocused = useCallback(
-    (delta: number, extendSelection: boolean) => {
-      if (!visibleFiles.length) return;
-      const currentIndex = focusedKey
-        ? visibleFiles.findIndex((file) => file.key === focusedKey)
-        : -1;
-      jumpFocused(currentIndex + delta, extendSelection);
-    },
-    [focusedKey, jumpFocused, visibleFiles]
-  );
-
-  // 惰性补全可见文件夹的子项计数（缓存到 sessionStorage，重复进入不重复请求）
-  useEffect(() => {
-    if (route.kind !== "folder" || isGlobalSearch) return;
-    const targets = visibleFiles
-      .filter(
-        (file) =>
-          file.isDir &&
-          folderCounts[file.key] === undefined &&
-          !folderCountInFlight.current.has(file.key)
-      )
-      .slice(0, FOLDER_COUNT_FILL_MAX);
-    if (!targets.length) return;
-    for (const target of targets) folderCountInFlight.current.add(target.key);
-    let cancelled = false;
-    fetchFolderCounts(targets.map((target) => target.key)).then((counts) => {
-      for (const target of targets) {
-        folderCountInFlight.current.delete(target.key);
-      }
-      if (cancelled) return;
-      if (Object.keys(counts).length === 0) return;
-      setFolderCounts((prev) => {
-        const next = { ...prev, ...counts };
-        saveFolderCountCache(next);
-        return next;
-      });
-    });
-    return () => {
-      cancelled = true;
-    };
-  }, [folderCounts, isGlobalSearch, route.kind, visibleFiles]);
+  }, [focusedKey, setFocusedKey, visibleFiles]);
 
   const navigateFolder = useCallback(
     (path: string) => {
@@ -832,45 +356,6 @@ function Main({
     navigateFolder(key);
   }, [files, navigateFolder]);
 
-  const toggleSelect = useCallback(
-    (key: string, event?: { shiftKey?: boolean }) => {
-      setSelectedKeys((prev) => {
-        if (event?.shiftKey && selectionAnchor.current) {
-          const anchorIndex = visibleFiles.findIndex(
-            (file) => file.key === selectionAnchor.current
-          );
-          const targetIndex = visibleFiles.findIndex(
-            (file) => file.key === key
-          );
-          if (anchorIndex >= 0 && targetIndex >= 0) {
-            const [start, end] =
-              anchorIndex <= targetIndex
-                ? [anchorIndex, targetIndex]
-                : [targetIndex, anchorIndex];
-            const merged = new Set(prev);
-            for (const file of visibleFiles.slice(start, end + 1)) {
-              merged.add(file.key);
-            }
-            return [...merged];
-          }
-        }
-        return prev.includes(key)
-          ? prev.filter((item) => item !== key)
-          : [...prev, key];
-      });
-      selectionAnchor.current = key;
-    },
-    [visibleFiles]
-  );
-
-  const selectAll = useCallback(() => {
-    setSelectedKeys((prev) => {
-      const all = visibleFiles.map((file) => file.key);
-      if (prev.length === all.length) return [];
-      return all;
-    });
-  }, [visibleFiles]);
-
   const handleOpenMenu = useCallback(
     (position: { clientX: number; clientY: number }, file: FileItem) => {
       setContextMenu({
@@ -890,7 +375,7 @@ function Main({
       if (isPreviewable(file)) {
         setPreviewFile(file);
       } else {
-        openFile(key).catch((error) => onNotify((error as Error).message, "error"));
+        openFile(key).catch((error) => onNotify(errorMessage(error), "error"));
       }
     },
     [files, onNotify]
@@ -907,208 +392,38 @@ function Main({
     );
   }, [previewFile, visibleFiles]);
 
-  const takenForCwd = useMemo(() => {
-    const taken = new Set(files.map((item) => item.name));
-    for (const task of transferQueue) {
-      if (task.type !== "upload") continue;
-      if (task.basedir !== cwd) continue;
-      if (task.status === "canceled" || task.status === "completed") continue;
-      const rest = task.remoteKey.startsWith(cwd)
-        ? task.remoteKey.slice(cwd.length)
-        : task.name;
-      taken.add(rest.split("/").filter(Boolean)[0] || task.name);
-    }
-    return taken;
-  }, [cwd, files, transferQueue]);
-
-  const enqueueToDir = useCallback(
-    (incoming: File[], basedir: string, taken: Iterable<string>) => {
-      if (!incoming.length) return;
-      const unique = uniquifyUploadFiles(incoming, taken);
-      uploadEnqueue(...unique.map((file) => ({ file, basedir })));
-    },
-    [uploadEnqueue]
-  );
-
   const enqueueToCwd = useCallback(
     (incoming: File[]) => enqueueToDir(incoming, cwd, takenForCwd),
     [cwd, enqueueToDir, takenForCwd]
   );
 
-  useEffect(() => {
-    const onKeyDown = (event: KeyboardEvent) => {
-      if (shouldIgnoreShortcuts(event)) return;
-      if (event.key === "Escape") {
-        if (hasOpenOverlay()) return;
-        if (selectedKeys.length || focusedKey) {
-          event.preventDefault();
-          setSelectedKeys([]);
-          setFocusedKey(null);
-        }
-        return;
-      }
-      if (event.key === "ArrowDown" || event.key === "ArrowUp") {
-        if (hasOpenOverlay()) return;
-        event.preventDefault();
-        moveFocused(event.key === "ArrowDown" ? 1 : -1, event.shiftKey);
-        return;
-      }
-      if (event.key === "ArrowRight" || event.key === "ArrowLeft") {
-        if (hasOpenOverlay()) return;
-        event.preventDefault();
-        moveFocused(event.key === "ArrowRight" ? 1 : -1, event.shiftKey);
-        return;
-      }
-      if (event.key === "Home" || event.key === "End") {
-        if (hasOpenOverlay()) return;
-        event.preventDefault();
-        jumpFocused(
-          event.key === "Home" ? 0 : visibleFiles.length - 1,
-          event.shiftKey
-        );
-        return;
-      }
-      if (event.key === " " && focusedKey) {
-        if (hasOpenOverlay()) return;
-        event.preventDefault();
-        toggleSelect(focusedKey);
-        return;
-      }
-      if ((event.key === "a" || event.key === "A") && (event.metaKey || event.ctrlKey)) {
-        if (hasOpenOverlay()) return;
-        event.preventDefault();
-        selectAll();
-        return;
-      }
-      if (event.key === "F2") {
-        if (hasOpenOverlay()) return;
-        const activeKey = focusedKey ?? (selectedKeys.length === 1 ? selectedKeys[0] : null);
-        if (!activeKey) return;
-        const file = visibleFiles.find((item) => item.key === activeKey);
-        if (!file) return;
-        event.preventDefault();
-        setRenameTarget(file);
-        return;
-      }
-      if (event.key === "Backspace") {
-        // Backspace 语义是「返回上级」而不是删除，避免破坏性误触；Delete 才删除。
-        if (hasOpenOverlay()) return;
-        if (route.kind !== "folder" || !route.path) return;
-        event.preventDefault();
-        navigateFolder(parentKey(route.path));
-        return;
-      }
-      if (event.key === "Delete") {
-        if (hasOpenOverlay()) return;
-        const targets =
-          selectedKeys.length > 0
-            ? selectedKeys
-            : focusedKey
-            ? [focusedKey]
-            : [];
-        if (!targets.length) return;
-        event.preventDefault();
-        setConfirmDelete(targets);
-        return;
-      }
-      if (event.key === "Enter") {
-        if (hasOpenOverlay()) return;
-        const activeKey = focusedKey ?? (selectedKeys.length === 1 ? selectedKeys[0] : null);
-        if (!activeKey) return;
-        const file = visibleFiles.find((item) => item.key === activeKey);
-        if (!file) return;
-        event.preventDefault();
-        if (file.isDir) navigateFolder(file.key);
-        else handleOpen(file.key);
-      }
-    };
-    window.addEventListener("keydown", onKeyDown);
-    return () => window.removeEventListener("keydown", onKeyDown);
-  }, [
-    focusedKey,
-    handleOpen,
-    jumpFocused,
-    moveFocused,
-    navigateFolder,
+  useKeyboardShortcuts({
     route,
-    selectAll,
-    selectedKeys,
-    toggleSelect,
     visibleFiles,
-  ]);
+    selectedKeys,
+    focusedKey,
+    setSelectedKeys: clearSelection,
+    setFocusedKey,
+    moveFocused,
+    jumpFocused,
+    toggleSelect,
+    selectAll,
+    navigateFolder,
+    onOpen: handleOpen,
+    onRename: setRenameTarget,
+    onDelete: setConfirmDelete,
+  });
 
-  useEffect(() => {
-    const onPaste = (event: ClipboardEvent) => {
-      if (route.kind !== "folder") return;
-      if (isTypingTarget(event.target)) return;
-      if (hasOpenOverlay()) return;
-      const items = event.clipboardData?.items;
-      if (!items) return;
-      const pasted: File[] = [];
-      for (let i = 0; i < items.length; i++) {
-        const item = items[i];
-        if (item.kind !== "file") continue;
-        const file = item.getAsFile();
-        if (file) pasted.push(file);
-      }
-      if (!pasted.length) return;
-      event.preventDefault();
-      const named = pasted.map((file) => {
-        const generic =
-          file.type.startsWith("image/") &&
-          (!file.name || /^image\.(png|jpe?g|gif|webp|bmp)$/i.test(file.name));
-        if (!generic) return file;
-        return new File([file], stampPastedName(file), {
-          type: file.type,
-          lastModified: file.lastModified,
-        });
-      });
-      enqueueToCwd(named);
-      onNotify(translate("enqueuedUploads", { count: named.length }), "success");
-    };
-    window.addEventListener("paste", onPaste);
-    return () => window.removeEventListener("paste", onPaste);
-  }, [enqueueToCwd, onNotify, route.kind]);
+  usePasteUpload({
+    active: route.kind === "folder",
+    enqueueToCwd,
+    onNotify,
+  });
 
-  useEffect(() => {
-    if (route.kind !== "folder") {
-      dropDepth.current = 0;
-      setDropActive(false);
-      return;
-    }
-    const onEnter = (event: DragEvent) => {
-      if (!dragHasFiles(event)) return;
-      dropDepth.current += 1;
-      setDropActive(true);
-    };
-    const onLeave = () => {
-      dropDepth.current = Math.max(0, dropDepth.current - 1);
-      if (dropDepth.current === 0) setDropActive(false);
-    };
-    const onOver = (event: DragEvent) => {
-      if (!dragHasFiles(event)) return;
-      event.preventDefault();
-    };
-    const onDrop = async (event: DragEvent) => {
-      const wasFiles = dragHasFiles(event);
-      dropDepth.current = 0;
-      setDropActive(false);
-      if (!wasFiles || !event.dataTransfer) return;
-      event.preventDefault();
-      const dropped = await collectFilesFromDataTransfer(event.dataTransfer);
-      if (dropped.length) enqueueToCwd(dropped);
-    };
-    window.addEventListener("dragenter", onEnter);
-    window.addEventListener("dragleave", onLeave);
-    window.addEventListener("dragover", onOver);
-    window.addEventListener("drop", onDrop);
-    return () => {
-      window.removeEventListener("dragenter", onEnter);
-      window.removeEventListener("dragleave", onLeave);
-      window.removeEventListener("dragover", onOver);
-      window.removeEventListener("drop", onDrop);
-    };
-  }, [enqueueToCwd, route.kind]);
+  const dropActive = useDragDropUpload({
+    active: route.kind === "folder",
+    enqueueToCwd,
+  });
 
   const handleContextAction = useCallback(
     async (action: FileAction, file: FileItem) => {
@@ -1136,7 +451,7 @@ function Main({
           onNotify(translate("cutToClipboard"), "success");
         }
       } catch (error) {
-        onNotify((error as Error).message, "error");
+        onNotify(errorMessage(error), "error");
       }
     },
     [copyToClipboard, cutToClipboard, handleOpen, navigateFolder, onNotify]
@@ -1157,7 +472,7 @@ function Main({
       await runRename();
       onNotify(translate("renameDone"), "success");
     } catch (error) {
-      onNotify((error as Error).message, "error", {
+      onNotify(errorMessage(error), "error", {
         duration: 8000,
         action: { label: strings.retry, onClick: () => runRename().catch(() => {}) },
       });
@@ -1187,7 +502,7 @@ function Main({
                     onNotify(translate("undoDeleteDone"), "success");
                   })
                   .catch((error) =>
-                    onNotify((error as Error).message, "error")
+                    onNotify(errorMessage(error), "error")
                   )
                   .finally(() => loadListing());
               },
@@ -1195,7 +510,7 @@ function Main({
           : undefined,
       });
     } catch (error) {
-      onNotify((error as Error).message, "error", {
+      onNotify(errorMessage(error), "error", {
         action: {
           label: strings.retry,
           onClick: () => runDelete().then(() => loadListing()).catch(() => {}),
@@ -1220,7 +535,7 @@ function Main({
       await runPaste();
       onNotify(translate("pasteDone"), "success");
     } catch (error) {
-      onNotify((error as Error).message, "error", {
+      onNotify(errorMessage(error), "error", {
         duration: 8000,
         action: { label: strings.retry, onClick: () => runPaste().catch(() => {}) },
       });
@@ -1240,7 +555,7 @@ function Main({
       setSelectedKeys([]);
       onNotify(translate("moveDone"), "success");
     } catch (error) {
-      onNotify((error as Error).message, "error", {
+      onNotify(errorMessage(error), "error", {
         action: {
           label: strings.retry,
           onClick: () => runMove().then(() => loadListing()).catch(() => {}),
@@ -1282,7 +597,7 @@ function Main({
         setSelectedKeys([]);
         await loadListing();
       } catch (error) {
-        onNotify((error as Error).message, "error", {
+        onNotify(errorMessage(error), "error", {
           action: {
             label: strings.retry,
             onClick: () => runMove().then(() => loadListing()).catch(() => {}),
@@ -1304,7 +619,7 @@ function Main({
     enqueueToDir(droppedFiles, dest, taken);
   };
 
-  const openFilePicker = () => {
+  const openFilePicker = useCallback(() => {
     const input = document.createElement("input");
     input.type = "file";
     input.accept = "*/*";
@@ -1319,12 +634,57 @@ function Main({
       if (picked.length) enqueueToCwd(picked);
     };
     input.click();
-  };
+  }, [enqueueToCwd]);
 
-  const openFolderPicker = async () => {
+  const openFolderPicker = useCallback(async () => {
     const picked = await selectDirectoryFiles();
     if (picked.length) enqueueToCwd(picked);
-  };
+  }, [enqueueToCwd]);
+
+  const handleDownload = useCallback(
+    (file: FileItem) => {
+      (file.isDir
+        ? downloadArchive([file.key])
+        : downloadFile(file.key)
+      ).catch((error) => onNotify(errorMessage(error), "error"));
+    },
+    [onNotify]
+  );
+
+  const emptyMessage = useMemo(
+    () =>
+      debouncedSearch ? (
+        <EmptyState
+          variant="search"
+          icon={<SearchOffIcon />}
+          title={strings.noSearchResult}
+          description={strings.noSearchResultHint}
+          actions={
+            <Button variant="outlined" onClick={() => onSearchChange("")}>
+              {strings.clearSearch}
+            </Button>
+          }
+        />
+      ) : (
+        <EmptyState
+          variant="folder"
+          icon={<FolderOpenIcon />}
+          title={strings.noFiles}
+          description={strings.noFilesHint}
+          actions={
+            <>
+              <Button variant="contained" onClick={openFilePicker}>
+                {strings.upload}
+              </Button>
+              <Button variant="outlined" onClick={() => setShowCreateFolder(true)}>
+                {strings.createFolder}
+              </Button>
+            </>
+          }
+        />
+      ),
+    [debouncedSearch, onSearchChange, openFilePicker]
+  );
 
   const handleSectionChange = (next: ExplorerSection) => {
     onSearchChange("");
@@ -1341,10 +701,6 @@ function Main({
     clipboard && clipboard.keys.length > 0 && route.kind === "folder"
   );
 
-  const listingPending =
-    loading ||
-    (route.kind === "folder" && loadedListingKey.current !== listingKey);
-
   useEffect(() => {
     if (!pendingOpen || listingPending) return;
     const found = files.find((item) => item.key === pendingOpen);
@@ -1352,7 +708,7 @@ function Main({
       if (isPreviewable(found)) setPreviewFile(found);
       else {
         openFile(found.key).catch((error) =>
-          onNotify((error as Error).message, "error")
+          onNotify(errorMessage(error), "error")
         );
       }
     } else {
@@ -1440,25 +796,29 @@ function Main({
       )}
       {route.kind === "sites" && flags.sites && (
         <Box onScroll={handleContentScroll} sx={{ flexGrow: 1, minHeight: 0, overflowY: "auto", pb: { xs: 8, sm: 0 } }}>
-          <SitesView
-            onNotify={onNotify}
-            onGoFiles={() =>
-              navigate({ kind: "folder", path: lastFolderPath.current })
-            }
-            onManageFiles={(slug) =>
-              navigate({ kind: "folder", path: `sites/${slug}/` })
-            }
-          />
+          <Suspense fallback={<SectionLoading />}>
+            <SitesView
+              onNotify={onNotify}
+              onGoFiles={() =>
+                navigate({ kind: "folder", path: lastFolderPath.current })
+              }
+              onManageFiles={(slug) =>
+                navigate({ kind: "folder", path: `sites/${slug}/` })
+              }
+            />
+          </Suspense>
         </Box>
       )}
       {route.kind === "images" && flags.imageHost && (
         <Box onScroll={handleContentScroll} sx={{ flexGrow: 1, minHeight: 0, overflowY: "auto", pb: { xs: 8, sm: 0 } }}>
-          <ImagesView
-            onNotify={onNotify}
-            onGoFiles={() =>
-              navigate({ kind: "folder", path: lastFolderPath.current })
-            }
-          />
+          <Suspense fallback={<SectionLoading />}>
+            <ImagesView
+              onNotify={onNotify}
+              onGoFiles={() =>
+                navigate({ kind: "folder", path: lastFolderPath.current })
+              }
+            />
+          </Suspense>
         </Box>
       )}
       {route.kind === "settings" && (
@@ -1498,54 +858,10 @@ function Main({
                 onOpen={handleOpen}
                 onOpenMenu={handleOpenMenu}
                 onDropOnFolder={handleDropOnFolder}
-                onDownload={(file) => {
-                  (file.isDir
-                    ? downloadArchive([file.key])
-                    : downloadFile(file.key)
-                  ).catch((error) =>
-                    onNotify((error as Error).message, "error")
-                  );
-                }}
+                onDownload={handleDownload}
                 onShareFile={(file) => setShareTarget(file)}
                 onDeleteFile={(file) => setConfirmDelete([file.key])}
-                emptyMessage={
-                  debouncedSearch ? (
-                    <EmptyState
-                      variant="search"
-                      icon={<SearchOffIcon />}
-                      title={strings.noSearchResult}
-                      description={strings.noSearchResultHint}
-                      actions={
-                        <Button
-                          variant="outlined"
-                          onClick={() => onSearchChange("")}
-                        >
-                          {strings.clearSearch}
-                        </Button>
-                      }
-                    />
-                  ) : (
-                    <EmptyState
-                      variant="folder"
-                      icon={<FolderOpenIcon />}
-                      title={strings.noFiles}
-                      description={strings.noFilesHint}
-                      actions={
-                        <>
-                          <Button variant="contained" onClick={openFilePicker}>
-                            {strings.upload}
-                          </Button>
-                          <Button
-                            variant="outlined"
-                            onClick={() => setShowCreateFolder(true)}
-                          >
-                            {strings.createFolder}
-                          </Button>
-                        </>
-                      }
-                    />
-                  )
-                }
+                emptyMessage={emptyMessage}
               />
               {searchHasMore && (
                 <Stack
@@ -1588,7 +904,7 @@ function Main({
             onNotify(translate("folderCreated"), "success");
             await loadListing();
           } catch (error) {
-            onNotify((error as Error).message, "error");
+            onNotify(errorMessage(error), "error");
           }
         }}
       />
@@ -1655,30 +971,32 @@ function Main({
         </Box>
       )}
 
-      <PreviewDialog
-        file={previewFile}
-        siblings={previewSiblings}
-        onSibling={(file) => {
-          pushRecent({ key: file.key, name: file.name, isDir: false });
-          setPreviewFile(file);
-        }}
-        onClose={() => setPreviewFile(null)}
-        onNotify={onNotify}
-        onShare={() => {
-          if (previewFile) setShareTarget(previewFile);
-        }}
-        onRename={() => {
-          if (previewFile) {
-            setRenameTarget(previewFile);
-            setPreviewFile(null);
-          }
-        }}
-        onDelete={() => {
-          if (previewFile) {
-            setConfirmDelete([previewFile.key]);
-          }
-        }}
-      />
+      <Suspense fallback={null}>
+        <PreviewDialog
+          file={previewFile}
+          siblings={previewSiblings}
+          onSibling={(file) => {
+            pushRecent({ key: file.key, name: file.name, isDir: false });
+            setPreviewFile(file);
+          }}
+          onClose={() => setPreviewFile(null)}
+          onNotify={onNotify}
+          onShare={() => {
+            if (previewFile) setShareTarget(previewFile);
+          }}
+          onRename={() => {
+            if (previewFile) {
+              setRenameTarget(previewFile);
+              setPreviewFile(null);
+            }
+          }}
+          onDelete={() => {
+            if (previewFile) {
+              setConfirmDelete([previewFile.key]);
+            }
+          }}
+        />
+      </Suspense>
 
       <MoveDialog
         open={Boolean(moveTarget)}
@@ -1725,7 +1043,7 @@ function Main({
               await downloadArchive(selectedKeys);
             }
           } catch (error) {
-            onNotify((error as Error).message, "error");
+            onNotify(errorMessage(error), "error");
           }
         }}
         onRename={() => {

--- a/src/PathBar.tsx
+++ b/src/PathBar.tsx
@@ -1,0 +1,236 @@
+import React, { useState } from "react";
+import {
+  Box,
+  Breadcrumbs,
+  IconButton,
+  Link,
+  Menu,
+  MenuItem,
+  ToggleButton,
+  ToggleButtonGroup,
+  Tooltip,
+  Typography,
+} from "@mui/material";
+import {
+  ArrowBack as ArrowBackIcon,
+  ContentCopy as ContentCopyIcon,
+  ExpandMore as ExpandMoreIcon,
+  Folder as FolderIcon,
+} from "@mui/icons-material";
+
+import { NotifyFn } from "./app/notify";
+import { warmShadow } from "./app/theme";
+import { strings, translate } from "./app/strings";
+import { fetchPath } from "./app/transfer";
+import { FileItem } from "./app/types";
+
+export type SearchScope = "folder" | "global";
+
+function PathBar({
+  cwd,
+  onNavigate,
+  stats,
+  searchScope,
+  onSearchScopeChange,
+  searchQuery,
+  onNotify,
+}: {
+  cwd: string;
+  onNavigate: (path: string) => void;
+  stats: string;
+  searchScope: SearchScope;
+  onSearchScopeChange: (scope: SearchScope) => void;
+  searchQuery: string;
+  onNotify: NotifyFn;
+}) {
+  const parts = cwd.replace(/\/$/, "").split("/").filter(Boolean);
+  const atRoot = parts.length === 0;
+  const pathText = atRoot ? "/" : `/${parts.join("/")}/`;
+  const parentPath =
+    atRoot || parts.length === 1 ? "" : `${parts.slice(0, -1).join("/")}/`;
+  const [siblingsAnchor, setSiblingsAnchor] = useState<null | HTMLElement>(null);
+  const [siblings, setSiblings] = useState<FileItem[] | null>(null);
+  const openSiblings = async (event: React.MouseEvent<HTMLButtonElement>) => {
+    setSiblingsAnchor(event.currentTarget);
+    setSiblings(null);
+    try {
+      const items = await fetchPath(parentPath);
+      setSiblings(items.filter((item) => item.isDir));
+    } catch {
+      setSiblings([]);
+    }
+  };
+  const copyPath = async () => {
+    try {
+      await navigator.clipboard.writeText(pathText);
+      onNotify(translate("pathCopied"), "success");
+    } catch {
+      onNotify(translate("copyFailed"), "error");
+    }
+  };
+
+  return (
+    <Box sx={{ px: 1.5, pb: 1.25, pt: 0.25 }}>
+      <Box sx={{ display: "flex", alignItems: "center", gap: 0.5 }}>
+        <IconButton
+          size="small"
+          aria-label={strings.goUp}
+          disabled={atRoot}
+          onClick={() =>
+            onNavigate(parts.slice(0, -1).join("/") + (parts.length > 1 ? "/" : ""))
+          }
+          sx={{
+            visibility: atRoot ? "hidden" : "visible",
+            opacity: atRoot ? 0 : 1,
+            pointerEvents: atRoot ? "none" : "auto",
+          }}
+        >
+          <ArrowBackIcon fontSize="small" />
+        </IconButton>
+        <Breadcrumbs
+          separator="›"
+          sx={{
+            flexGrow: 1,
+            "& .MuiTypography-root": { fontWeight: 600, fontSize: "0.9rem" },
+            "& .MuiLink-root": { fontWeight: 500, fontSize: "0.9rem" },
+          }}
+        >
+          {parts.length === 0 ? (
+            <Typography color="text.primary">{strings.allFiles}</Typography>
+          ) : (
+            <Link component="button" onClick={() => onNavigate("")}>
+              {strings.allFiles}
+            </Link>
+          )}
+          {parts.map((part, index) =>
+            index === parts.length - 1 ? (
+              <Typography key={index} color="text.primary">
+                {part}
+              </Typography>
+            ) : (
+              <Link
+                key={index}
+                component="button"
+                onClick={() =>
+                  onNavigate(parts.slice(0, index + 1).join("/") + "/")
+                }
+              >
+                {part}
+              </Link>
+            )
+          )}
+        </Breadcrumbs>
+        <IconButton
+          size="small"
+          aria-label={strings.copyPath}
+          onClick={copyPath}
+          sx={{ flexShrink: 0 }}
+        >
+          <ContentCopyIcon fontSize="small" />
+        </IconButton>
+        {!atRoot && (
+          <Tooltip title={strings.siblingFolders}>
+            <IconButton
+              size="small"
+              aria-label={strings.siblingFolders}
+              onClick={openSiblings}
+              sx={{ flexShrink: 0, mr: -0.5 }}
+            >
+              <ExpandMoreIcon fontSize="small" />
+            </IconButton>
+          </Tooltip>
+        )}
+        <Menu
+          anchorEl={siblingsAnchor}
+          open={Boolean(siblingsAnchor)}
+          onClose={() => setSiblingsAnchor(null)}
+        >
+          {siblings === null && (
+            <MenuItem disabled>{strings.loading}</MenuItem>
+          )}
+          {siblings !== null && siblings.length === 0 && (
+            <MenuItem disabled>{strings.noSiblingFolder}</MenuItem>
+          )}
+          {siblings !== null &&
+            siblings.map((item) => (
+              <MenuItem
+                key={item.key}
+                selected={item.key === cwd.replace(/\/$/, "")}
+                onClick={() => {
+                  setSiblingsAnchor(null);
+                  onNavigate(item.key);
+                }}
+              >
+                <FolderIcon fontSize="small" sx={{ mr: 1, color: "primary.main" }} />
+                {item.name}
+              </MenuItem>
+            ))}
+        </Menu>
+      </Box>
+      <Box
+        sx={{
+          display: "flex",
+          alignItems: "center",
+          gap: 1,
+          flexWrap: "wrap",
+          paddingLeft: "40px",
+          minHeight: 32,
+        }}
+      >
+        <Typography
+          variant="caption"
+          color="text.secondary"
+          sx={{
+            px: 1,
+            py: 0.25,
+            borderRadius: "999px",
+            backgroundColor: "background.default",
+            fontVariantNumeric: "tabular-nums",
+          }}
+        >
+          {stats}
+        </Typography>
+        <Box sx={{ flexGrow: 1 }} />
+        <ToggleButtonGroup
+          exclusive
+          size="small"
+          value={searchScope}
+          onChange={(_, value: SearchScope | null) => {
+            if (value) onSearchScopeChange(value);
+          }}
+          aria-label={strings.searchScope}
+          sx={{
+            backgroundColor: "background.default",
+            "& .MuiToggleButton-root": {
+              border: "none",
+              px: 1.25,
+              py: 0.25,
+              fontSize: "0.75rem",
+              "&.Mui-selected": {
+                backgroundColor: "background.paper",
+                color: "primary.main",
+                boxShadow: (theme) =>
+                  warmShadow(theme.palette.mode === "dark", "0 1px 2px", 0.08),
+              },
+            },
+          }}
+        >
+          <ToggleButton value="folder">{strings.searchHere}</ToggleButton>
+          <ToggleButton value="global">{strings.searchAll}</ToggleButton>
+        </ToggleButtonGroup>
+      </Box>
+      {searchQuery ? (
+        <Typography
+          variant="body2"
+          color="text.secondary"
+          sx={{ paddingLeft: "40px", paddingTop: 0.5 }}
+        >
+          {searchScope === "global" ? strings.searchAll : strings.searchHere}：
+          {searchQuery}
+        </Typography>
+      ) : null}
+    </Box>
+  );
+}
+
+export default PathBar;

--- a/src/PreviewDialog.tsx
+++ b/src/PreviewDialog.tsx
@@ -48,7 +48,7 @@ import { strings, translate } from "./app/strings";
 import { Z_INDEX, warmShadow } from "./app/theme";
 import { FileItem } from "./app/types";
 import { downloadFile } from "./app/transfer";
-import { encodeKey, humanReadableSize } from "./app/utils";
+import { encodeKey, errorMessage, humanReadableSize } from "./app/utils";
 
 const LINE_NUMBER_CAP = 2000;
 const HIGHLIGHT_MAX_BYTES = 1024 * 1024;
@@ -298,7 +298,7 @@ function PreviewDialog({
         setUrl(objectUrl);
       } catch (error) {
         if (canceled || (error as Error).name === "AbortError") return;
-        onNotify((error as Error).message, "error");
+        onNotify(errorMessage(error), "error");
       } finally {
         if (!canceled) setLoading(false);
       }
@@ -359,7 +359,7 @@ function PreviewDialog({
       }
       await downloadFile(file.key);
     } catch (error) {
-      onNotify((error as Error).message, "error");
+      onNotify(errorMessage(error), "error");
     }
   };
 

--- a/src/SettingsView.tsx
+++ b/src/SettingsView.tsx
@@ -12,6 +12,7 @@ import {
 import { FeatureFlagName, FeatureFlags, useFeatures } from "./app/features";
 import { NotifyFn } from "./app/notify";
 import { strings } from "./app/strings";
+import { errorMessage } from "./app/utils";
 
 const SWITCHES: Array<{
   key: FeatureFlagName;
@@ -35,7 +36,7 @@ function SettingsView({ onNotify }: { onNotify: NotifyFn }) {
       await updateFlags({ [key]: value } as Partial<FeatureFlags>);
       onNotify(strings.flagSaved, "success");
     } catch (error) {
-      onNotify((error as Error).message || strings.flagSaveFailed, "error");
+      onNotify(errorMessage(error) || strings.flagSaveFailed, "error");
     } finally {
       setPending(null);
     }

--- a/src/ShareDialog.tsx
+++ b/src/ShareDialog.tsx
@@ -24,6 +24,7 @@ import ContentCopyIcon from "@mui/icons-material/ContentCopy";
 import { createShare, formatShareClipboard, listShares, revokeShare } from "./app/share";
 import { NotifyFn } from "./app/notify";
 import { FileItem, ShareInfo } from "./app/types";
+import { errorMessage } from "./app/utils";
 
 function ShareDialog({
   open,
@@ -47,7 +48,7 @@ function ShareDialog({
       const all = await listShares();
       setShares(all.filter((share) => share.key === file.key));
     } catch (error) {
-      onNotify((error as Error).message, "error");
+      onNotify(errorMessage(error), "error");
     }
   };
 
@@ -78,7 +79,7 @@ function ShareDialog({
         // ignore; user can still copy from the list
       }
     } catch (error) {
-      onNotify((error as Error).message, "error");
+      onNotify(errorMessage(error), "error");
     } finally {
       setLoading(false);
     }
@@ -187,7 +188,7 @@ function ShareDialog({
                             );
                             onNotify(translate("shareLinkRevoked"), "success");
                           } catch (error) {
-                            onNotify((error as Error).message, "error");
+                            onNotify(errorMessage(error), "error");
                             await refresh();
                           }
                         }}

--- a/src/SharesView.tsx
+++ b/src/SharesView.tsx
@@ -19,6 +19,7 @@ import EmptyState from "./EmptyState";
 import { formatShareClipboard, listShares, revokeShare } from "./app/share";
 import { NotifyFn } from "./app/notify";
 import { ShareInfo } from "./app/types";
+import { errorMessage } from "./app/utils";
 
 function SharesView({
   onNotify,
@@ -35,7 +36,7 @@ function SharesView({
     try {
       setShares(await listShares());
     } catch (error) {
-      onNotify((error as Error).message, "error");
+      onNotify(errorMessage(error), "error");
     } finally {
       setLoading(false);
     }
@@ -120,7 +121,7 @@ function SharesView({
                         await revokeShare(token);
                         onNotify(translate("shareLinkRevoked"), "success");
                       } catch (error) {
-                        onNotify((error as Error).message, "error");
+                        onNotify(errorMessage(error), "error");
                         await load();
                       }
                     }}

--- a/src/SitesView.tsx
+++ b/src/SitesView.tsx
@@ -34,7 +34,7 @@ import { NotifyFn } from "./app/notify";
 import { SiteInfo, SitesResponse, deleteSite, listSites, siteUrl, updateSiteConfig } from "./app/sites";
 import { strings, translate } from "./app/strings";
 import { useUploadEnqueue } from "./app/transferQueue";
-import { humanReadableSize } from "./app/utils";
+import { errorMessage, humanReadableSize } from "./app/utils";
 
 /** 把 zip 条目路径规范成站点目录下的安全相对路径；不安全（穿越/绝对路径）返回 null。 */
 function safeArchivePath(path: string): string | null {
@@ -242,7 +242,7 @@ function SitesView({
       try {
         setData(await listSites(withStats));
       } catch (error) {
-        if (!withStats) onNotify((error as Error).message, "error");
+        if (!withStats) onNotify(errorMessage(error), "error");
       }
     },
     [onNotify]
@@ -269,7 +269,7 @@ function SitesView({
       await updateSiteConfig(site.slug, spa);
       onNotify(translate("siteConfigSaved"), "success");
     } catch (error) {
-      onNotify((error as Error).message, "error");
+      onNotify(errorMessage(error), "error");
       await load(false);
     }
   };
@@ -304,7 +304,7 @@ function SitesView({
       setDeploySite(null);
       setDeployFile(null);
     } catch (error) {
-      onNotify((error as Error).message, "error");
+      onNotify(errorMessage(error), "error");
     } finally {
       setDeploying(false);
     }
@@ -319,7 +319,7 @@ function SitesView({
       onNotify(translate("siteDeleted", { name: site.slug, count: deleted }), "success");
       await load(false);
     } catch (error) {
-      onNotify((error as Error).message, "error");
+      onNotify(errorMessage(error), "error");
     }
   };
 

--- a/src/TransferManager.tsx
+++ b/src/TransferManager.tsx
@@ -154,7 +154,7 @@ function TransferManager({
             />
             <Typography variant="body2" color="text.secondary">
               {translate("overallProgress")}：{humanReadableSize(loaded)} / {humanReadableSize(total)}
-              {overallSpeed > 0 && taskStatusText(uploads, overallSpeed, overallEta)}
+              {overallSpeed > 0 && taskStatusText(overallSpeed, overallEta)}
             </Typography>
             <Stack spacing={2}>
               {uploads.map((task) => {
@@ -272,11 +272,7 @@ function TransferManager({
   );
 }
 
-function taskStatusText(
-  uploads: TransferTask[],
-  overallSpeed: number,
-  overallEta: string
-) {
+function taskStatusText(overallSpeed: number, overallEta: string) {
   const speed = humanReadableSpeed(overallSpeed);
   const parts = [speed, overallEta ? translate("etaRemaining", { time: overallEta }) : ""].filter(Boolean);
   return parts.length ? ` · ${parts.join(" · ")}` : "";

--- a/src/TrashView.tsx
+++ b/src/TrashView.tsx
@@ -28,7 +28,7 @@ import {
 import { NotifyFn } from "./app/notify";
 import { strings, translate } from "./app/strings";
 import { TrashItem } from "./app/types";
-import { humanReadableSize } from "./app/utils";
+import { errorMessage, humanReadableSize } from "./app/utils";
 
 function TrashView({
   onNotify,
@@ -50,7 +50,7 @@ function TrashView({
       setItems(await listTrash());
       setSelected([]);
     } catch (error) {
-      onNotify((error as Error).message, "error");
+      onNotify(errorMessage(error), "error");
     } finally {
       setLoading(false);
     }
@@ -84,7 +84,7 @@ function TrashView({
         onNotify(translate("restoreDone"), "success");
       }
     } catch (error) {
-      onNotify((error as Error).message, "error");
+      onNotify(errorMessage(error), "error");
     } finally {
       await load();
     }
@@ -95,7 +95,7 @@ function TrashView({
       await permanentDeleteTrash(selected);
       onNotify(translate("permanentDeletedToast"), "success");
     } catch (error) {
-      onNotify((error as Error).message, "error");
+      onNotify(errorMessage(error), "error");
     } finally {
       setConfirm(null);
       await load();
@@ -107,7 +107,7 @@ function TrashView({
       await permanentDeleteTrash([], true);
       onNotify(translate("trashClearedToast"), "success");
     } catch (error) {
-      onNotify((error as Error).message, "error");
+      onNotify(errorMessage(error), "error");
     } finally {
       setConfirm(null);
       await load();

--- a/src/WebDavPanel.tsx
+++ b/src/WebDavPanel.tsx
@@ -16,6 +16,7 @@ import ContentCopyIcon from "@mui/icons-material/ContentCopy";
 import { authFetch } from "./app/auth";
 import { NotifyFn } from "./app/notify";
 import { strings, translate } from "./app/strings";
+import { errorMessage } from "./app/utils";
 
 interface WebDavInfo {
   username: string;
@@ -46,7 +47,7 @@ function WebDavPanel({
         if (!canceled) setInfo(data);
       })
       .catch((error) => {
-        if (!canceled) onNotify((error as Error).message, "error");
+        if (!canceled) onNotify(errorMessage(error), "error");
       })
       .finally(() => {
         if (!canceled) setLoading(false);

--- a/src/app/__tests__/App.test.tsx
+++ b/src/app/__tests__/App.test.tsx
@@ -1,13 +1,11 @@
-import React from "react";
 import { fireEvent, render, screen } from "@testing-library/react";
 
 import App, { enqueueSnack, SnackbarMessage } from "../../App";
 import { setLang, strings } from "../strings";
 
 jest.mock("../transferQueue", () => {
-  const React = require("react");
   return {
-    TransferQueueProvider: ({ children }: { children: React.ReactNode }) => children,
+    TransferQueueProvider: ({ children }: { children: JSX.Element }) => children,
     useTransferQueue: () => [],
     useTransferQueueActions: () => ({}),
     useTransferQueueGlobalPaused: () => false,

--- a/src/app/__tests__/Main.test.tsx
+++ b/src/app/__tests__/Main.test.tsx
@@ -237,7 +237,7 @@ describe("Main", () => {
 
   test("copy path, search scope, create folder, keyboard select/delete", async () => {
     const onNotify = jest.fn();
-    const { props } = renderMain({ kind: "folder", path: "docs/" }, { onNotify });
+    renderMain({ kind: "folder", path: "docs/" }, { onNotify });
     mockFetchPath.mockResolvedValue([file]);
     await waitFor(() => expect(screen.getByText("a.txt")).toBeInTheDocument());
 

--- a/src/app/__tests__/transfer.test.ts
+++ b/src/app/__tests__/transfer.test.ts
@@ -139,18 +139,29 @@ describe("transfer / searchFiles", () => {
 });
 
 describe("transfer / fetchFolderCounts", () => {
-  test("并发统计并静默失败项", async () => {
-    const xmlFor = (path: string) => `<?xml version="1.0"?><multistatus>
-  <response><href>/webdav/${path}/</href><propstat><prop><resourcetype><collection/></resourcetype></prop></propstat></response>
-  <response><href>/webdav/${path}/a.txt</href><propstat><prop><getcontenttype>text/plain</getcontenttype><getcontentlength>1</getcontentlength></prop></propstat></response>
-</multistatus>`;
-    mockAuthFetch.mockImplementation(async (url: string) => {
-      const path = String(url).split("/webdav/")[1] ?? "";
-      if (path.includes("bad")) return jsonResponse({}, false, 500);
-      return xmlResponse(xmlFor(path));
+  test("批量端点一次取回全部计数", async () => {
+    mockAuthFetch.mockImplementation(async (url: string, init?: RequestInit) => {
+      expect(String(url)).toBe("/api/counts");
+      expect(init?.method).toBe("POST");
+      const body = JSON.parse(String(init?.body)) as { paths: string[] };
+      expect(body.paths).toEqual(["a", "bad"]);
+      return jsonResponse({ counts: { a: 3, "bad-x": 0 } }, true, 200);
     });
-    const counts = await fetchFolderCounts(["a", "bad"], 2);
-    expect(counts).toEqual({ a: 1 });
+    const counts = await fetchFolderCounts(["a", "bad"]);
+    expect(counts).toEqual({ a: 3, "bad-x": 0 });
+  });
+
+  test("端点失败时返回空对象", async () => {
+    mockAuthFetch.mockImplementation(async () => jsonResponse({}, false, 500));
+    const counts = await fetchFolderCounts(["a"]);
+    expect(counts).toEqual({});
+  });
+
+  test("空列表不发请求", async () => {
+    mockAuthFetch.mockClear();
+    const counts = await fetchFolderCounts([]);
+    expect(counts).toEqual({});
+    expect(mockAuthFetch).not.toHaveBeenCalled();
   });
 });
 

--- a/src/app/__tests__/transferQueue.test.tsx
+++ b/src/app/__tests__/transferQueue.test.tsx
@@ -1,5 +1,4 @@
 import { act, renderHook } from "@testing-library/react";
-import React from "react";
 
 import { processTransferTask } from "../transfer";
 import {

--- a/src/app/__tests__/utils.test.ts
+++ b/src/app/__tests__/utils.test.ts
@@ -1,4 +1,4 @@
-import { dictionary, setLang, translate } from "../strings";
+import { dictionary, setLang } from "../strings";
 import {
   basename,
   encodeKey,

--- a/src/app/interaction.ts
+++ b/src/app/interaction.ts
@@ -1,0 +1,60 @@
+import type * as React from "react";
+
+import { strings } from "./strings";
+
+// 键盘/粘贴/拖拽等全局交互的判定辅助，供 Main 与各 hooks 共用。
+
+export function isTypingTarget(target: EventTarget | null) {
+  const el =
+    target instanceof HTMLElement
+      ? target
+      : document.activeElement instanceof HTMLElement
+      ? document.activeElement
+      : null;
+  if (!el) return false;
+  const field = el.closest("input, textarea, select, [contenteditable='true']");
+  if (field instanceof HTMLInputElement) {
+    return !["checkbox", "radio", "button", "submit"].includes(field.type);
+  }
+  if (field instanceof HTMLTextAreaElement || field instanceof HTMLSelectElement) {
+    return true;
+  }
+  return Boolean(field) || el.isContentEditable;
+}
+
+export function shouldIgnoreShortcuts(event: KeyboardEvent) {
+  if (event.isComposing || event.key === "Process") return true;
+  return isTypingTarget(event.target) || isTypingTarget(document.activeElement);
+}
+
+export function parentKey(key: string) {
+  const trimmed = key.replace(/\/$/, "");
+  const index = trimmed.lastIndexOf("/");
+  return index >= 0 ? trimmed.slice(0, index + 1) : "";
+}
+
+export function stampPastedName(file: File) {
+  const subtype = (file.type.split("/")[1] || "png").replace("jpeg", "jpg");
+  const ext = subtype.split("+")[0] || "png";
+  const now = new Date();
+  const pad = (n: number) => String(n).padStart(2, "0");
+  return `${strings.pastedImage} ${now.getFullYear()}${pad(now.getMonth() + 1)}${pad(
+    now.getDate()
+  )}-${pad(now.getHours())}${pad(now.getMinutes())}${pad(now.getSeconds())}.${ext}`;
+}
+
+export function dragHasFiles(event: DragEvent | React.DragEvent) {
+  const types = event.dataTransfer?.types;
+  if (!types) return false;
+  const list = Array.from(types as ArrayLike<string>);
+  if (list.includes("application/x-flaredrive")) return false;
+  return list.includes("Files");
+}
+
+export function hasOpenOverlay() {
+  const nodes = document.querySelectorAll(".MuiModal-root");
+  for (let i = 0; i < nodes.length; i++) { const node = nodes[i];
+    if (node.getAttribute("aria-hidden") !== "true") return true;
+  }
+  return false;
+}

--- a/src/app/strings.ts
+++ b/src/app/strings.ts
@@ -299,6 +299,14 @@ const entries: Record<string, Entry> = {  searchPlaceholder: { zh: "搜索文件
   moveHere: { zh: "移动到此处", en: "Move here" },
   etaRemaining: { zh: "剩余 {time}", en: "{time} left" },
   etaSeconds: { zh: "{n} 秒", en: "{n}s" },
+  requestFailed: {
+    zh: "操作失败，请重试",
+    en: "Operation failed, please retry",
+  },
+  requestFailedStatus: {
+    zh: "操作失败（HTTP {status}），请重试",
+    en: "Operation failed (HTTP {status}), please retry",
+  },
   etaMinSec: { zh: "{m} 分 {s} 秒", en: "{m}m {s}s" },
   etaHourMin: { zh: "{h} 时 {m} 分", en: "{h}h {m}m" },
   justNow: { zh: "刚刚", en: "Just now" },

--- a/src/app/transfer.ts
+++ b/src/app/transfer.ts
@@ -102,28 +102,24 @@ export interface SearchResponse {
   nextCursor?: string;
 }
 
-// 并发统计一批文件夹的直接子项数（惰性计数），失败的键不出现在结果里
+// 批量统计文件夹的直接子项数（惰性计数）：单次 POST /api/counts 拿回全部，
+// 失败整体返回空（调用方保留占位文案）
 export async function fetchFolderCounts(
-  keys: string[],
-  concurrency = 3
+  keys: string[]
 ): Promise<Record<string, number>> {
-  const results: Record<string, number> = {};
-  const queue = [...keys];
-  const workers = Array.from(
-    { length: Math.max(1, Math.min(concurrency, queue.length)) },
-    async () => {
-      while (queue.length) {
-        const key = queue.shift()!;
-        try {
-          results[key] = (await fetchPath(key)).length;
-        } catch {
-          // 单个失败静默，前端保留占位文案
-        }
-      }
-    }
-  );
-  await Promise.all(workers);
-  return results;
+  if (!keys.length) return {};
+  try {
+    const res = await authFetch("/api/counts", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ paths: keys.slice(0, 100) }),
+    });
+    if (!res.ok) return {};
+    const data = (await res.json()) as { counts?: Record<string, number> };
+    return data.counts ?? {};
+  } catch {
+    return {};
+  }
 }
 
 export async function searchFiles(

--- a/src/app/useDragDropUpload.ts
+++ b/src/app/useDragDropUpload.ts
@@ -1,0 +1,56 @@
+import { useEffect, useRef, useState } from "react";
+
+import { collectFilesFromDataTransfer } from "./transfer";
+import { dragHasFiles } from "./interaction";
+
+// 全窗口拖拽上传：dragenter/leave 计数防抖控制遮罩显隐，drop 收集文件入队。
+export function useDragDropUpload(options: {
+  active: boolean;
+  enqueueToCwd: (files: File[]) => void;
+}) {
+  const { active, enqueueToCwd } = options;
+  const [dropActive, setDropActive] = useState(false);
+  const dropDepth = useRef(0);
+
+  useEffect(() => {
+    if (!active) {
+      dropDepth.current = 0;
+      setDropActive(false);
+      return;
+    }
+    const onEnter = (event: DragEvent) => {
+      if (!dragHasFiles(event)) return;
+      dropDepth.current += 1;
+      setDropActive(true);
+    };
+    const onLeave = () => {
+      dropDepth.current = Math.max(0, dropDepth.current - 1);
+      if (dropDepth.current === 0) setDropActive(false);
+    };
+    const onOver = (event: DragEvent) => {
+      if (!dragHasFiles(event)) return;
+      event.preventDefault();
+    };
+    const onDrop = async (event: DragEvent) => {
+      const wasFiles = dragHasFiles(event);
+      dropDepth.current = 0;
+      setDropActive(false);
+      if (!wasFiles || !event.dataTransfer) return;
+      event.preventDefault();
+      const dropped = await collectFilesFromDataTransfer(event.dataTransfer);
+      if (dropped.length) enqueueToCwd(dropped);
+    };
+    window.addEventListener("dragenter", onEnter);
+    window.addEventListener("dragleave", onLeave);
+    window.addEventListener("dragover", onOver);
+    window.addEventListener("drop", onDrop);
+    return () => {
+      window.removeEventListener("dragenter", onEnter);
+      window.removeEventListener("dragleave", onLeave);
+      window.removeEventListener("dragover", onOver);
+      window.removeEventListener("drop", onDrop);
+    };
+  }, [active, enqueueToCwd]);
+
+  return dropActive;
+}

--- a/src/app/useFolderCounts.ts
+++ b/src/app/useFolderCounts.ts
@@ -1,0 +1,69 @@
+import { useEffect, useRef, useState } from "react";
+
+import { fetchFolderCounts } from "./transfer";
+import { FileItem } from "./types";
+
+const FOLDER_COUNT_CACHE_KEY = "flaredrive.folderCounts";
+const FOLDER_COUNT_FILL_MAX = 50;
+
+function loadFolderCountCache(): Record<string, number> {
+  try {
+    return JSON.parse(
+      sessionStorage.getItem(FOLDER_COUNT_CACHE_KEY) || "{}"
+    ) as Record<string, number>;
+  } catch {
+    return {};
+  }
+}
+
+function saveFolderCountCache(counts: Record<string, number>) {
+  try {
+    sessionStorage.setItem(FOLDER_COUNT_CACHE_KEY, JSON.stringify(counts));
+  } catch {
+    // 忽略持久化失败
+  }
+}
+
+// 惰性补全可见文件夹的子项计数（缓存到 sessionStorage，重复进入不重复请求）
+export function useFolderCounts(options: {
+  active: boolean;
+  visibleFiles: FileItem[];
+}) {
+  const { active, visibleFiles } = options;
+  const [folderCounts, setFolderCounts] = useState<Record<string, number>>(
+    loadFolderCountCache
+  );
+  const inFlight = useRef(new Set<string>());
+
+  useEffect(() => {
+    if (!active) return;
+    const targets = visibleFiles
+      .filter(
+        (file) =>
+          file.isDir &&
+          folderCounts[file.key] === undefined &&
+          !inFlight.current.has(file.key)
+      )
+      .slice(0, FOLDER_COUNT_FILL_MAX);
+    if (!targets.length) return;
+    for (const target of targets) inFlight.current.add(target.key);
+    let cancelled = false;
+    fetchFolderCounts(targets.map((target) => target.key)).then((counts) => {
+      for (const target of targets) {
+        inFlight.current.delete(target.key);
+      }
+      if (cancelled) return;
+      if (Object.keys(counts).length === 0) return;
+      setFolderCounts((prev) => {
+        const next = { ...prev, ...counts };
+        saveFolderCountCache(next);
+        return next;
+      });
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [folderCounts, active, visibleFiles]);
+
+  return { folderCounts, setFolderCounts };
+}

--- a/src/app/useFolderListing.ts
+++ b/src/app/useFolderListing.ts
@@ -1,0 +1,169 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import { NotifyFn } from "./notify";
+import { Route } from "./route";
+import { fetchPath, searchFiles } from "./transfer";
+import { useAuth } from "./auth";
+import { FileItem } from "./types";
+import { errorMessage } from "./utils";
+import { strings } from "./strings";
+import type { SearchScope } from "../PathBar";
+
+// 目录列表 / 全盘搜索的加载模型：防抖后的关键词、静默刷新、
+// 触底自动加载（IntersectionObserver + scroll 捕获兜底）都在这里收口。
+export function useFolderListing(options: {
+  route: Route;
+  cwd: string;
+  debouncedSearch: string;
+  searchScope: SearchScope;
+  onNotify: NotifyFn;
+  /** 目录加载成功后回报条目数（用于父目录卡片计数缓存） */
+  onListingLoaded: (path: string, count: number) => void;
+  /** listingKey 变化导致数据刷新时清空选中 */
+  onListingChanged: () => void;
+}) {
+  const { route, cwd, debouncedSearch, searchScope, onNotify } = options;
+  const { username } = useAuth();
+
+  const [files, setFiles] = useState<FileItem[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [searchHasMore, setSearchHasMore] = useState(false);
+  const [searchCursor, setSearchCursor] = useState<string | undefined>();
+  const [loadingMore, setLoadingMore] = useState(false);
+  const loadedListingKey = useRef<string | null>(null);
+
+  const isGlobalSearch = Boolean(debouncedSearch) && searchScope === "global";
+  const listingKey =
+    route.kind === "folder"
+      ? isGlobalSearch
+        ? `folder:${cwd}||search:${debouncedSearch}`
+        : `folder:${cwd}`
+      : route.kind;
+
+  const loadListing = useCallback(async () => {
+    if (route.kind !== "folder") {
+      setFiles([]);
+      setLoading(false);
+      loadedListingKey.current = listingKey;
+      return;
+    }
+    if (username === null) {
+      setFiles([]);
+      setLoading(false);
+      return;
+    }
+
+    const silent = loadedListingKey.current === listingKey;
+    if (!silent) setLoading(true);
+    try {
+      if (isGlobalSearch) {
+        const result = await searchFiles(debouncedSearch);
+        setFiles(result.items);
+        setSearchHasMore(result.hasMore);
+        setSearchCursor(result.nextCursor);
+      } else {
+        const items = await fetchPath(cwd);
+        setFiles(items);
+        options.onListingLoaded(cwd.replace(/\/$/, ""), items.length);
+        setSearchHasMore(false);
+        setSearchCursor(undefined);
+      }
+      const listingChanged = loadedListingKey.current !== listingKey;
+      loadedListingKey.current = listingKey;
+      if (listingChanged) options.onListingChanged();
+    } catch (error) {
+      const alreadyLoaded = loadedListingKey.current === listingKey;
+      loadedListingKey.current = listingKey;
+      if (!alreadyLoaded) setFiles([]);
+      onNotify(errorMessage(error), "error", {
+        duration: 8000,
+        action: { label: strings.retry, onClick: () => loadListing() },
+      });
+    } finally {
+      setLoading(false);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [
+    cwd,
+    debouncedSearch,
+    isGlobalSearch,
+    listingKey,
+    onNotify,
+    route.kind,
+    username,
+  ]);
+
+  useEffect(() => {
+    loadListing();
+  }, [loadListing]);
+
+  const loadMore = useCallback(async () => {
+    if (!isGlobalSearch || !searchCursor || loadingMore) return;
+    setLoadingMore(true);
+    try {
+      const result = await searchFiles(debouncedSearch, searchCursor);
+      setFiles((prev) => [...prev, ...result.items]);
+      setSearchHasMore(result.hasMore);
+      setSearchCursor(result.nextCursor);
+    } catch (error) {
+      onNotify(errorMessage(error), "error");
+    } finally {
+      setLoadingMore(false);
+    }
+  }, [debouncedSearch, isGlobalSearch, loadingMore, onNotify, searchCursor]);
+
+  const loadMoreSentinelRef = useRef<HTMLDivElement | null>(null);
+
+  // 全盘搜索触底自动加载：IO 为主，scroll 捕获阶段兜底（部分嵌入环境 IO 不发回调）
+  useEffect(() => {
+    if (!searchHasMore) return;
+    const node = loadMoreSentinelRef.current;
+    if (!node) return;
+
+    const maybeLoad = () => {
+      const rect = node.getBoundingClientRect();
+      if (rect.top < window.innerHeight + 200 && rect.bottom > -200) {
+        loadMore();
+      }
+    };
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries.some((entry) => entry.isIntersecting)) loadMore();
+      },
+      { rootMargin: "200px" }
+    );
+    observer.observe(node);
+
+    let lastCheck = 0;
+    const onScroll = () => {
+      // rAF 在部分嵌入环境会被暂停，直接用时间戳节流
+      const now = Date.now();
+      if (now - lastCheck < 150) return;
+      lastCheck = now;
+      maybeLoad();
+    };
+    window.addEventListener("scroll", onScroll, { passive: true, capture: true });
+    const initial = window.setTimeout(maybeLoad, 0);
+    return () => {
+      observer.disconnect();
+      window.removeEventListener("scroll", onScroll, { capture: true });
+      window.clearTimeout(initial);
+    };
+  }, [loadMore, searchHasMore]);
+
+  const listingPending =
+    loading || (route.kind === "folder" && loadedListingKey.current !== listingKey);
+
+  return {
+    files,
+    setFiles,
+    listingKey,
+    listingPending,
+    isGlobalSearch,
+    loadListing,
+    loadMore,
+    loadingMore,
+    loadMoreSentinelRef,
+    searchHasMore,
+  };
+}

--- a/src/app/useKeyboardShortcuts.ts
+++ b/src/app/useKeyboardShortcuts.ts
@@ -1,0 +1,149 @@
+import { useEffect } from "react";
+
+import { hasOpenOverlay, parentKey, shouldIgnoreShortcuts } from "./interaction";
+import { Route } from "./route";
+import { FileItem } from "./types";
+
+export interface KeyboardShortcutsParams {
+  route: Route;
+  visibleFiles: FileItem[];
+  selectedKeys: string[];
+  focusedKey: string | null;
+  setSelectedKeys: (update: string[]) => void;
+  setFocusedKey: (key: string | null) => void;
+  moveFocused: (delta: number, extendSelection: boolean) => void;
+  jumpFocused: (index: number, extendSelection: boolean) => void;
+  toggleSelect: (key: string) => void;
+  selectAll: () => void;
+  navigateFolder: (path: string) => void;
+  onOpen: (key: string) => void;
+  onRename: (file: FileItem) => void;
+  onDelete: (keys: string[]) => void;
+}
+
+// 全局键盘导航：方向键/Home/End 移动焦点，Space 选择，Ctrl+A 全选，
+// F2 重命名，Delete 删除，Enter 打开，Backspace 返回上级，Escape 清空选择。
+export function useKeyboardShortcuts(params: KeyboardShortcutsParams) {
+  const {
+    route,
+    visibleFiles,
+    selectedKeys,
+    focusedKey,
+    setSelectedKeys,
+    setFocusedKey,
+    moveFocused,
+    jumpFocused,
+    toggleSelect,
+    selectAll,
+    navigateFolder,
+    onOpen,
+    onRename,
+    onDelete,
+  } = params;
+
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (shouldIgnoreShortcuts(event)) return;
+      if (event.key === "Escape") {
+        if (hasOpenOverlay()) return;
+        if (selectedKeys.length || focusedKey) {
+          event.preventDefault();
+          setSelectedKeys([]);
+          setFocusedKey(null);
+        }
+        return;
+      }
+      if (event.key === "ArrowDown" || event.key === "ArrowUp") {
+        if (hasOpenOverlay()) return;
+        event.preventDefault();
+        moveFocused(event.key === "ArrowDown" ? 1 : -1, event.shiftKey);
+        return;
+      }
+      if (event.key === "ArrowRight" || event.key === "ArrowLeft") {
+        if (hasOpenOverlay()) return;
+        event.preventDefault();
+        moveFocused(event.key === "ArrowRight" ? 1 : -1, event.shiftKey);
+        return;
+      }
+      if (event.key === "Home" || event.key === "End") {
+        if (hasOpenOverlay()) return;
+        event.preventDefault();
+        jumpFocused(
+          event.key === "Home" ? 0 : visibleFiles.length - 1,
+          event.shiftKey
+        );
+        return;
+      }
+      if (event.key === " " && focusedKey) {
+        if (hasOpenOverlay()) return;
+        event.preventDefault();
+        toggleSelect(focusedKey);
+        return;
+      }
+      if ((event.key === "a" || event.key === "A") && (event.metaKey || event.ctrlKey)) {
+        if (hasOpenOverlay()) return;
+        event.preventDefault();
+        selectAll();
+        return;
+      }
+      if (event.key === "F2") {
+        if (hasOpenOverlay()) return;
+        const activeKey = focusedKey ?? (selectedKeys.length === 1 ? selectedKeys[0] : null);
+        if (!activeKey) return;
+        const file = visibleFiles.find((item) => item.key === activeKey);
+        if (!file) return;
+        event.preventDefault();
+        onRename(file);
+        return;
+      }
+      if (event.key === "Backspace") {
+        // Backspace 语义是「返回上级」而不是删除，避免破坏性误触；Delete 才删除。
+        if (hasOpenOverlay()) return;
+        if (route.kind !== "folder" || !route.path) return;
+        event.preventDefault();
+        navigateFolder(parentKey(route.path));
+        return;
+      }
+      if (event.key === "Delete") {
+        if (hasOpenOverlay()) return;
+        const targets =
+          selectedKeys.length > 0
+            ? selectedKeys
+            : focusedKey
+            ? [focusedKey]
+            : [];
+        if (!targets.length) return;
+        event.preventDefault();
+        onDelete(targets);
+        return;
+      }
+      if (event.key === "Enter") {
+        if (hasOpenOverlay()) return;
+        const activeKey = focusedKey ?? (selectedKeys.length === 1 ? selectedKeys[0] : null);
+        if (!activeKey) return;
+        const file = visibleFiles.find((item) => item.key === activeKey);
+        if (!file) return;
+        event.preventDefault();
+        if (file.isDir) navigateFolder(file.key);
+        else onOpen(file.key);
+      }
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [
+    focusedKey,
+    jumpFocused,
+    moveFocused,
+    navigateFolder,
+    onDelete,
+    onOpen,
+    onRename,
+    route,
+    selectAll,
+    selectedKeys,
+    setFocusedKey,
+    setSelectedKeys,
+    toggleSelect,
+    visibleFiles,
+  ]);
+}

--- a/src/app/useMultiSelect.ts
+++ b/src/app/useMultiSelect.ts
@@ -1,0 +1,98 @@
+import { useCallback, useRef, useState } from "react";
+
+import { FileItem } from "./types";
+
+// 多选 + 焦点导航模型：Shift 范围选择、全选切换、焦点移动与滚动定位。
+export function useMultiSelect(visibleFiles: FileItem[]) {
+  const [selectedKeys, setSelectedKeys] = useState<string[]>([]);
+  const [focusedKey, setFocusedKey] = useState<string | null>(null);
+  const selectionAnchor = useRef<string | null>(null);
+
+  const scrollFocusedIntoView = useCallback((key: string) => {
+    const nodes = document.querySelectorAll<HTMLElement>("[data-file-key]");
+    for (let i = 0; i < nodes.length; i++) {
+      const node = nodes[i];
+      if (node.dataset.fileKey === key) {
+        node.scrollIntoView({ block: "nearest" });
+        return;
+      }
+    }
+  }, []);
+
+  const jumpFocused = useCallback(
+    (index: number, extendSelection: boolean) => {
+      if (!visibleFiles.length) return;
+      const clamped = Math.max(0, Math.min(index, visibleFiles.length - 1));
+      const next = visibleFiles[clamped];
+      setFocusedKey(next.key);
+      if (extendSelection) {
+        setSelectedKeys((prev) =>
+          prev.includes(next.key) ? prev : [...prev, next.key]
+        );
+      }
+      scrollFocusedIntoView(next.key);
+    },
+    [scrollFocusedIntoView, visibleFiles]
+  );
+
+  const moveFocused = useCallback(
+    (delta: number, extendSelection: boolean) => {
+      if (!visibleFiles.length) return;
+      const currentIndex = focusedKey
+        ? visibleFiles.findIndex((file) => file.key === focusedKey)
+        : -1;
+      jumpFocused(currentIndex + delta, extendSelection);
+    },
+    [focusedKey, jumpFocused, visibleFiles]
+  );
+
+  const toggleSelect = useCallback(
+    (key: string, event?: { shiftKey?: boolean }) => {
+      setSelectedKeys((prev) => {
+        if (event?.shiftKey && selectionAnchor.current) {
+          const anchorIndex = visibleFiles.findIndex(
+            (file) => file.key === selectionAnchor.current
+          );
+          const targetIndex = visibleFiles.findIndex(
+            (file) => file.key === key
+          );
+          if (anchorIndex >= 0 && targetIndex >= 0) {
+            const [start, end] =
+              anchorIndex <= targetIndex
+                ? [anchorIndex, targetIndex]
+                : [targetIndex, anchorIndex];
+            const merged = new Set(prev);
+            for (const file of visibleFiles.slice(start, end + 1)) {
+              merged.add(file.key);
+            }
+            return [...merged];
+          }
+        }
+        return prev.includes(key)
+          ? prev.filter((item) => item !== key)
+          : [...prev, key];
+      });
+      selectionAnchor.current = key;
+    },
+    [visibleFiles]
+  );
+
+  const selectAll = useCallback(() => {
+    setSelectedKeys((prev) => {
+      const all = visibleFiles.map((file) => file.key);
+      if (prev.length === all.length) return [];
+      return all;
+    });
+  }, [visibleFiles]);
+
+  return {
+    selectedKeys,
+    setSelectedKeys,
+    focusedKey,
+    setFocusedKey,
+    toggleSelect,
+    selectAll,
+    jumpFocused,
+    moveFocused,
+  };
+}

--- a/src/app/usePasteUpload.ts
+++ b/src/app/usePasteUpload.ts
@@ -1,0 +1,47 @@
+import { useEffect } from "react";
+
+import { isTypingTarget, stampPastedName } from "./interaction";
+import { NotifyFn } from "./notify";
+import { translate } from "./strings";
+
+// 粘贴上传：监听全局 paste 事件，把剪贴板里的文件入队到当前目录；
+// 无名图片（截图等）自动按时间戳命名。
+export function usePasteUpload(options: {
+  active: boolean;
+  enqueueToCwd: (files: File[]) => void;
+  onNotify: NotifyFn;
+}) {
+  const { active, enqueueToCwd, onNotify } = options;
+
+  useEffect(() => {
+    if (!active) return;
+    const onPaste = (event: ClipboardEvent) => {
+      if (isTypingTarget(event.target)) return;
+      const items = event.clipboardData?.items;
+      if (!items) return;
+      const pasted: File[] = [];
+      for (let i = 0; i < items.length; i++) {
+        const item = items[i];
+        if (item.kind !== "file") continue;
+        const file = item.getAsFile();
+        if (file) pasted.push(file);
+      }
+      if (!pasted.length) return;
+      event.preventDefault();
+      const named = pasted.map((file) => {
+        const generic =
+          file.type.startsWith("image/") &&
+          (!file.name || /^image\.(png|jpe?g|gif|webp|bmp)$/i.test(file.name));
+        if (!generic) return file;
+        return new File([file], stampPastedName(file), {
+          type: file.type,
+          lastModified: file.lastModified,
+        });
+      });
+      enqueueToCwd(named);
+      onNotify(translate("enqueuedUploads", { count: named.length }), "success");
+    };
+    window.addEventListener("paste", onPaste);
+    return () => window.removeEventListener("paste", onPaste);
+  }, [active, enqueueToCwd, onNotify]);
+}

--- a/src/app/useUploadInputs.ts
+++ b/src/app/useUploadInputs.ts
@@ -1,0 +1,65 @@
+import { useCallback, useMemo } from "react";
+
+import { copyPaste, fetchPath } from "./transfer";
+import { useTransferQueue, useUploadEnqueue } from "./transferQueue";
+import { basename, uniqueName, uniquifyUploadFiles } from "./utils";
+import { FileItem } from "./types";
+
+/** 把剪贴板的一组 key 复制/剪切到目标目录，重名自动追加序号。 */
+export async function transferKeys(
+  keys: string[],
+  destination: string,
+  mode: "copy" | "cut"
+) {
+  let existing: FileItem[] = [];
+  try {
+    existing = await fetchPath(destination);
+  } catch {
+    existing = [];
+  }
+  const taken = new Set(existing.map((file) => file.name));
+
+  for (const key of keys) {
+    const name = basename(key);
+    if (mode === "cut") {
+      const parent = key.slice(0, key.length - name.length);
+      if (parent === destination) continue;
+    }
+    const targetName = uniqueName(name, taken);
+    await copyPaste(key, `${destination}${targetName}`, mode === "cut");
+    taken.add(targetName);
+  }
+}
+
+// 上传入队的各入口：文件选择器、文件夹选择器、重名规避（含进行中任务占位）。
+export function useUploadInputs(options: { cwd: string; files: FileItem[] }) {
+  const { cwd, files } = options;
+  const transferQueue = useTransferQueue();
+  const uploadEnqueue = useUploadEnqueue();
+
+  // 当前目录已被文件与进行中上传占用的名字
+  const takenForCwd = useMemo(() => {
+    const taken = new Set(files.map((item) => item.name));
+    for (const task of transferQueue) {
+      if (task.type !== "upload") continue;
+      if (task.basedir !== cwd) continue;
+      if (task.status === "canceled" || task.status === "completed") continue;
+      const rest = task.remoteKey.startsWith(cwd)
+        ? task.remoteKey.slice(cwd.length)
+        : task.name;
+      taken.add(rest.split("/").filter(Boolean)[0] || task.name);
+    }
+    return taken;
+  }, [cwd, files, transferQueue]);
+
+  const enqueueToDir = useCallback(
+    (incoming: File[], basedir: string, taken: Iterable<string>) => {
+      if (!incoming.length) return;
+      const unique = uniquifyUploadFiles(incoming, taken);
+      uploadEnqueue(...unique.map((file) => ({ file, basedir })));
+    },
+    [uploadEnqueue]
+  );
+
+  return { transferQueue, uploadEnqueue, takenForCwd, enqueueToDir };
+}

--- a/src/app/utils.ts
+++ b/src/app/utils.ts
@@ -166,3 +166,20 @@ export function uniquifyUploadFiles(files: File[], taken: Iterable<string>): Fil
     });
   });
 }
+
+// 统一从 catch 的 unknown 里提取可展示的文案：Error 取 message，
+// Response-like 取状态码，其余兜底固定提示。
+export function errorMessage(error: unknown): string {
+  if (error instanceof Error && error.message) return error.message;
+  if (
+    typeof error === "object" &&
+    error !== null &&
+    "status" in error &&
+    typeof (error as { status: unknown }).status === "number"
+  ) {
+    return translate("requestFailedStatus", {
+      status: String((error as { status: number }).status),
+    });
+  }
+  return translate("requestFailed");
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -92,13 +92,13 @@
     // "noImplicitThis": true,                           /* Enable error reporting when 'this' is given the type 'any'. */
     // "useUnknownInCatchVariables": true,               /* Default catch clause variables as 'unknown' instead of 'any'. */
     // "alwaysStrict": true,                             /* Ensure 'use strict' is always emitted. */
-    // "noUnusedLocals": true,                           /* Enable error reporting when local variables aren't read. */
-    // "noUnusedParameters": true,                       /* Raise an error when a function parameter isn't read. */
+    "noUnusedLocals": true,                            /* Enable error reporting when local variables aren't read. */
+    "noUnusedParameters": true,                       /* Raise an error when a function parameter isn't read. */
     // "exactOptionalPropertyTypes": true,               /* Interpret optional property types as written, rather than adding 'undefined'. */
     // "noImplicitReturns": true,                        /* Enable error reporting for codepaths that do not explicitly return in a function. */
-    // "noFallthroughCasesInSwitch": true,               /* Enable error reporting for fallthrough cases in switch statements. */
+    "noFallthroughCasesInSwitch": true,               /* Enable error reporting for fallthrough cases in switch statements. */
     // "noUncheckedIndexedAccess": true,                 /* Add 'undefined' to a type when accessed using an index. */
-    // "noImplicitOverride": true,                       /* Ensure overriding members in derived classes are marked with an override modifier. */
+    "noImplicitOverride": true,                       /* Ensure overriding members in derived classes are marked with an override modifier. */
     // "noPropertyAccessFromIndexSignature": true,       /* Enforces using indexed accessors for keys declared using an indexed type. */
     // "allowUnusedLabels": true,                        /* Disable error reporting for unused labels. */
     // "allowUnreachableCode": true,                     /* Disable error reporting for unreachable code. */


### PR DESCRIPTION
## 概述
第四轮改进计划第一部分（[IMPROVEMENT_PLAN.md 第四轮 A 组](https://github.com/fanchenggang/Davflare/blob/refactor/code-optimization/IMPROVEMENT_PLAN.md)）：代码优化，行为不变。

## 改动
### 后端收敛与安全
- **重复逻辑收敛**：`jsonResponse` 5 份、`isAuthorized` 7 份统一到 `functions/api/_apikey.ts`；`keys.ts` 收编共享 `StoredApiKey`/`sha256Hex`/`listStoredKeys`；裸 `new Response("Unauthorized")` ×19 全部走 `textResponse`（body/status 不变）。
- **安全修复**：`webdav/protocol.ts` 的 `isAuthorized` 补空凭据 fail-closed——凭据未配置时一律拒绝，消除 `btoa("undefined:undefined")` 类可猜中头（与 `_apikey.ts` 的 `verifyBasicAuth` 对齐）。

### 性能
- `authorizeApiKey`：密钥 get 并行化；`touchLastUsed` 增加 60s 节流，**消除每个 API 请求一次 R2 put**。
- 新增 `POST /api/counts` 批量子项计数端点，替代前端逐目录 PROPFIND 计数的 N+1（一次请求拿回全部）。
- `FileGrid` 包 `React.memo`（Main 侧回调 useCallback + emptyMessage useMemo）；`PreviewDialog`/`SitesView`/`ImagesView` 改 `React.lazy`——主包 702KB → 684KB + 4 个按需 chunk。

### 结构
- **Main.tsx 1756 → 1057 行**：PathBar 独立成文件；抽出 `useFolderListing` / `useMultiSelect` / `useFolderCounts` / `useKeyboardShortcuts` / `usePasteUpload` / `useDragDropUpload` / `useUploadInputs` 与 `app/interaction.ts` 纯函数模块。

### 工程细节
- `@cloudflare/workers-types` 升级（4.20240620 → 5.20260905），消掉全部 7 处 R2 `include` 的 `@ts-ignore`。
- tsconfig 开启 `noUnusedLocals` / `noUnusedParameters` / `noImplicitOverride` / `noFallthroughCasesInSwitch`（清理 6 处随之暴露的未使用符号）。
- 前端 `errorMessage()` 工具收敛 37 处 `(error as Error).message`（Error / Response.status / 兜底三态，新增 2 个 i18n 键）；删除 `web-vitals` 死依赖。

## 验证
- `npm run typecheck` ✅
- `npm run test:ci`：**51 套件 / 429 用例全过**（fetchFolderCounts 3 个用例按新端点语义重写）
- `npm run build` ✅（代码分割生效）
- `npm run test:e2e`：**150 项断言全过**（含新增 counts 4 项）

## 遗留（后续 PR）
- CRA→Vite + Jest→Vitest + MUI v5→v7（原第二轮 A4，需独立分支全量回归）
- 后端 JSON 错误格式统一（涉及 API 兼容性，需与客户端协商）