### PR TITLE
test: 覆盖率体系——后端直测、前端补测、CI 与四个真 bug 修复

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,77 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  frontend:
+    name: Frontend (typecheck / test / build)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Typecheck
+        run: npm run typecheck
+
+      - name: Unit tests
+        run: npm run test:ci
+
+      - name: Build
+        run: npm run build
+
+  cli:
+    name: CLI (vitest)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: cli
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: cli/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Test
+        run: npm test
+
+  e2e:
+    name: E2E (wrangler pages dev + api-e2e)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      # scripts/run-e2e.sh 通过 npx 调 wrangler；这里先装一个固定大版本，
+      # 避免 CI 每次漂移到未知的新版 wrangler。
+      - name: Install pinned wrangler
+        run: npm install --no-save wrangler@4
+
+      - name: Build + run e2e suite
+        run: npm run test:e2e

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+legacy-peer-deps=true

--- a/TESTING.md
+++ b/TESTING.md
@@ -258,3 +258,17 @@ npx wrangler pages dev build       # http://localhost:8788，前端 + functions 
 | 文档 | README(.zh-CN).md 功能列表与分享链接行为说明（默认落地页 / ?download=1 直链 / ?raw=1 内联）、docs/API(.zh-CN).md Shares 端点行为重写、e2e 断言计数更新（79 → ~170） | ✅ 与实现逐条核对 |
 
 **本批验证汇总**：`npx tsc --noEmit` 0 错误；`CI=true npx react-scripts test --watchAll=false` **53 套件 463 用例全绿**（基线 449 + 14）；`npm run build` 成功；`SKIP_BUILD=1 bash scripts/run-e2e.sh` **171 项断言全过（0 FAIL）**。取舍说明：`?raw=1` 对非可预览类型（octet-stream 等）回退 attachment 而非强行 inline；过期分享的 Chip 显示「已过期」并用 warning 色；落地页不展示有效期信息（规格未要求，避免泄露多余元数据）。
+
+## 测试覆盖率体系与后端直测（第四轮 C 组，2026-09-05）
+
+| 批 | 内容 | 结果 |
+|----|------|------|
+| 测试基础设施 | 新增 `src/app/testUtils.ts`（jsonResponse/AsAuthFetchMock/clearStorage/PROPFIND XML fixture/MCP rpc 构造器，12 个测试文件去重改造）；package.json jest 配置 `collectCoverageFrom` 纳入 `functions/**`（`src/index.js`、testUtils、InMemoryBucket 排除）；新增 `functionsLoader.test.ts` 强制加载全部 functions 模块绕过 CRA jest roots 限制；coverageThreshold 按「实测-0.5」棘轮（src / functions / global 三组路径键，注意 jest 阈值 glob 键是逐文件校验、路径键才是分组聚合）；cli 加 `test:coverage`（v8 provider）与 vitest.config.ts | ✅ src 组阈值 91.6/84.5/85.9/93.5（stmts/branch/funcs/lines），functions 组 58.67/53.23/66.69/60.92 |
+| CI 工作流 | `.github/workflows/ci.yml`：push main + 全 PR，三 job——frontend（npm ci → typecheck → test:ci → build）、cli（npm ci → npm test，独立 lockfile 缓存）、e2e（`npm install --no-save wrangler@4` 钉版本后跑 `npm run test:e2e`，本地完整预演通过） | ✅ 本地预演 171 断言全过 |
+| cli 补测 | client.ts（>100MB 三段式真实临时文件分块、分块失败 abort 清理、Range 断点续传 206/200/等长跳过/偏大重下、ApiError 文本回退、createKeyWithSession/revokeKey）、config.ts（XDG 临时目录注入、0600 权限、环境变量覆盖/合并、损坏文件）、util.ts 全覆盖、index.ts（commander 分发 + 错误路径） | ✅ cli 6 文件 58 用例全绿；stmts 86.11% / branch 90.09%，client.ts lines 98.56%、config.ts 100% |
+| 后端直测 | 新增 `src/app/testInMemoryBucket.ts`：R2Bucket 内存模拟（get/put/delete/head 含 onlyIf 条件语义、list 忠实模拟 prefix/cursor/delimiter/include/UTF-8 字典序/truncated、multipart 全生命周期）；新增 5 个测试套件 185 用例：webdavProtocol（84：304/206/412/423/LOCK 互斥与刷新/Overwrite/内部前缀/鉴权 fail-closed）、trashApi（25：marker/虚拟目录/父级重建/惰性过期）、shareToken（32：落地页转义/download/raw 安全头/提取码 cookie/410/404）、uploadApi（20：413/乱序/缺块/abort 幂等）、middleware（24：SPA/404.html/穿越/Host 接管） | ✅ **functions/ 覆盖率 lines 18.75% → 61.42%、branches 53.73%**；protocol.ts 80.16%、trash 98.05%、shares 96.55%、share token 92.86%、upload 92.82%、middleware 97.62% |
+| 顺手修的两个后端健壮性 bug | ① protocol.ts handleGet 未捕获 R2 InvalidRange → 非法 Range 500（现回退全量 200，与 download.ts 同类处理一致）；② trash.ts handleRestore 对损坏元数据 JSON 无 try/catch → 整个还原 500（现返回结构化「回收站项目损坏」） | ✅ 各有用例固化 |
+| 前端洼地补测 | 新增 5 套件 104 用例：hooksExtra（30：快捷键全分支/多选 shift/拖拽遮罩/粘贴上传）、transferMultipart（28：分块/断点续传/AbortError 时序/缩略图副作用）、PreviewDialogExtra（13：缩放钳制/平移/旋转补偿/倍速/pager）、AppExtra（10：队列顶替/去重/主题三态）、MainExtra（23：加载更多/undo 闭环/拖拽入文件夹） | ✅ **src/ lines 84.94 → 94.01%、branches 75.88 → 85.04%**；useKeyboardShortcuts/useMultiSelect/useUploadInputs/useDragDropUpload/usePasteUpload 全部 100% lines |
+| 顺手修的两个前端交互 bug | ① useMultiSelect shift 范围选择失效（setState updater 延迟求值期间 selectionAnchor 已被覆写为点击目标，退化为「原选中+目标」→ updater 前捕获 anchor）；② App Snackbar 队列重开竞态（退场完成前 effect 重开，onExited 永不触发，消息每轮 autoHideDuration 重闪 → shownSnackKeyRef 挡住已展示消息的重开） | ✅ jsdom 复现→修复→回归，AppExtra 断言「12s 后消失且不再重闪」 |
+
+**本批验证汇总**：`npx tsc --noEmit` 0 错误；`CI=true npx react-scripts test --watchAll=false` **64 套件 754 用例全绿**（基线 53/463 → +11 套件/+291 用例）；`npm run build` 成功；`SKIP_BUILD=1 bash scripts/run-e2e.sh` **171 断言全过（0 FAIL）**；cli `npm test` 58 用例全绿。已知环境限制：upload.ts 的 multipart/form-data 分支在 whatwg-fetch 测试环境无法解析 multipart 请求体（e2e 兜底）；protocol.ts handlePutMultipart 对未知 uploadId 的 part PUT 未捕获（边缘，已记录）。

--- a/cli/.gitignore
+++ b/cli/.gitignore
@@ -1,0 +1,1 @@
+coverage/

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -16,12 +16,84 @@
       },
       "devDependencies": {
         "@types/node": "^20.14.0",
+        "@vitest/coverage-v8": "^2.1.0",
         "typescript": "^5.5.3",
         "vitest": "^2.1.0"
       },
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/@ampproject/remapping": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
+      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.8.tgz",
+      "integrity": "sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.8"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.8.tgz",
+      "integrity": "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
+      "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.21.5",
@@ -414,12 +486,72 @@
         "node": ">=12"
       }
     },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@istanbuljs/schema": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.6.tgz",
+      "integrity": "sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.6.0.tgz",
       "integrity": "sha512-T7jf+5zgsZHwNJ4lvQ7/aezbyk0nNX+zJVWpmHA7VYsEx7a7qr5Rg5IbtJFqkgze5Y2sruq1RUY8Q837Od7iFw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
     },
     "node_modules/@napi-rs/lzma-linux-x64-gnu": {
       "version": "1.5.1",
@@ -439,6 +571,17 @@
       ],
       "engines": {
         "node": "^22.20 || ^24.12 || >=25"
+      }
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
@@ -847,6 +990,39 @@
         "undici-types": "~6.21.0"
       }
     },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-2.1.9.tgz",
+      "integrity": "sha512-Z2cOr0ksM00MpEfyVE8KXIYPEcBFxdbLSs56L8PO0QQMxt/6bDj45uQfxoc96v05KW3clk7vvgP0qfDit9DmfQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ampproject/remapping": "^2.3.0",
+        "@bcoe/v8-coverage": "^0.2.3",
+        "debug": "^4.3.7",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-lib-source-maps": "^5.0.6",
+        "istanbul-reports": "^3.1.7",
+        "magic-string": "^0.30.12",
+        "magicast": "^0.3.5",
+        "std-env": "^3.8.0",
+        "test-exclude": "^7.0.1",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "2.1.9",
+        "vitest": "2.1.9"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@vitest/expect": {
       "version": "2.1.9",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
@@ -960,6 +1136,32 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/ansi-regex": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.3.0.tgz",
+      "integrity": "sha512-WpDfL7NO6j7tH88IDBNVdUJxDh9nmCteAVW9dsep846XdwF4naCBK+/tGLX3KJgcpgMRXCFlTM2hKGoK9FsdrQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -968,6 +1170,29 @@
       "license": "MIT",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/cac": {
@@ -1007,6 +1232,26 @@
         "node": ">= 16"
       }
     },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/commander": {
       "version": "12.1.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
@@ -1014,6 +1259,21 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/debug": {
@@ -1043,6 +1303,20 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/es-module-lexer": {
       "version": "1.7.0",
@@ -1110,6 +1384,23 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -1125,12 +1416,178 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz",
+      "integrity": "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.23",
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
     "node_modules/loupe": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
       "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/magic-string": {
       "version": "0.30.21",
@@ -1140,6 +1597,60 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.3.5.tgz",
+      "integrity": "sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.25.4",
+        "@babel/types": "^7.25.4",
+        "source-map-js": "^1.2.0"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "10.2.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.8"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
       }
     },
     "node_modules/ms": {
@@ -1166,6 +1677,40 @@
       },
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0"
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/pathe": {
@@ -1267,12 +1812,61 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/siginfo": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
       "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
     },
     "node_modules/source-map-js": {
       "version": "1.2.1",
@@ -1297,6 +1891,138 @@
       "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/string-width-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/test-exclude": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-7.0.2.tgz",
+      "integrity": "sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^10.4.1",
+        "minimatch": "^10.2.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/tinybench": {
       "version": "2.9.0",
@@ -1512,6 +2238,22 @@
         }
       }
     },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/why-is-node-running": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
@@ -1524,6 +2266,104 @@
       },
       "bin": {
         "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
       },
       "engines": {
         "node": ">=8"

--- a/cli/package.json
+++ b/cli/package.json
@@ -17,6 +17,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "test": "vitest run",
+    "test:coverage": "vitest run --coverage",
     "prepublishOnly": "npm run build && npm test"
   },
   "dependencies": {
@@ -24,6 +25,7 @@
   },
   "devDependencies": {
     "@types/node": "^20.14.0",
+    "@vitest/coverage-v8": "^2.1.0",
     "typescript": "^5.5.3",
     "vitest": "^2.1.0"
   }

--- a/cli/test/client.test.ts
+++ b/cli/test/client.test.ts
@@ -1,0 +1,405 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+
+import { ApiError, DavflareClient } from "../src/client.js";
+
+function jsonRes(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function textRes(text: string, status = 200): Response {
+  return new Response(text, { status });
+}
+
+const SERVER = "https://example.com";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("DavflareClient 元操作（URL/方法/鉴权）", () => {
+  it("listPage 带 path/limit/cursor 参数并解析 JSON", async () => {
+    const fetchMock = vi.fn(async () =>
+      jsonRes({ items: [{ key: "a.txt", name: "a.txt", isDir: false, size: 1, uploaded: "" }] })
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const client = new DavflareClient(SERVER, "k1");
+    const page = await client.listPage("docs/", "c1", 500);
+
+    const url = new URL(String(fetchMock.mock.calls[0][0]));
+    expect(url.pathname).toBe("/api/list");
+    expect(url.searchParams.get("path")).toBe("docs/");
+    expect(url.searchParams.get("limit")).toBe("500");
+    expect(url.searchParams.get("cursor")).toBe("c1");
+    const init = fetchMock.mock.calls[0][1];
+    expect(init.headers.Authorization).toBe("Bearer k1");
+    expect(page.items[0].key).toBe("a.txt");
+  });
+
+  it("mkdir/remove/move/backup/search 走对应端点", async () => {
+    const fetchMock = vi.fn(async () => jsonRes({}));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const client = new DavflareClient(SERVER, "k1");
+    await client.mkdir("docs/new");
+    await client.remove("a.txt");
+    await client.remove("gone.txt", true);
+    await client.move("a.txt", "b.txt", true);
+    await client.backup("folder/notes.txt");
+    await client.search("hello");
+
+    const calls = fetchMock.mock.calls.map(([input, init]) => {
+      const url = new URL(String(input));
+      return {
+        method: init.method as string,
+        pathname: url.pathname,
+        params: Object.fromEntries(url.searchParams.entries()),
+        body: init.body ? String(init.body) : undefined,
+      };
+    });
+
+    expect(calls[0]).toMatchObject({ method: "POST", pathname: "/api/mkdir" });
+    expect(JSON.parse(calls[0].body!)).toEqual({ path: "docs/new" });
+    expect(calls[1]).toMatchObject({ method: "DELETE", pathname: "/api/delete", params: { path: "a.txt", soft: "1" } });
+    expect(calls[2]).toMatchObject({ method: "DELETE", params: { path: "gone.txt", soft: "0" } });
+    expect(calls[3]).toMatchObject({ method: "POST", pathname: "/api/rename" });
+    expect(JSON.parse(calls[3].body!)).toEqual({ from: "a.txt", to: "b.txt", overwrite: true });
+    expect(calls[4]).toMatchObject({ method: "POST", pathname: "/api/backup", params: { path: "folder/notes.txt" } });
+    expect(calls[5]).toMatchObject({ method: "GET", pathname: "/api/search", params: { q: "hello", limit: "100" } });
+  });
+
+  it("stat 返回 JSON 对象", async () => {
+    const fetchMock = vi.fn(async () => jsonRes({ key: "a.txt", kind: "file", size: 3 }));
+    vi.stubGlobal("fetch", fetchMock);
+    const client = new DavflareClient(SERVER, "k1");
+    await expect(client.stat("a.txt")).resolves.toMatchObject({ kind: "file", size: 3 });
+  });
+});
+
+describe("ApiError（非 2xx）", () => {
+  it("非 2xx 且响应有文本时抛出响应文本", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => textRes("boom", 500)));
+    const client = new DavflareClient(SERVER, "k1");
+    const err = await client.listPage("").catch((e) => e);
+    expect(err).toBeInstanceOf(ApiError);
+    expect(err.status).toBe(500);
+    expect(err.message).toBe("boom");
+  });
+
+  it("非 2xx 且响应体为空时回退 HTTP <status>", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => textRes("  ", 503)));
+    const client = new DavflareClient(SERVER, "k1");
+    const err = await client.listPage("").catch((e) => e);
+    expect(err).toBeInstanceOf(ApiError);
+    expect(err.status).toBe(503);
+    expect(err.message).toBe("HTTP 503");
+  });
+});
+
+describe("uploadFile（单发小文件）", () => {
+  it("按 path=目录 + X-File-Name 上传原始体并上报进度", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "davflare-up-"));
+    const local = path.join(dir, "note.txt");
+    fs.writeFileSync(local, "hello");
+
+    const fetchMock = vi.fn(async () => jsonRes({ key: "docs/note.txt" }, 201));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const onProgress = vi.fn();
+    const client = new DavflareClient(SERVER, "k1");
+    await client.uploadFile(local, "docs/note.txt", onProgress);
+
+    const [input, init] = fetchMock.mock.calls[0];
+    const url = new URL(String(input));
+    expect(url.pathname).toBe("/api/upload");
+    expect(url.searchParams.get("path")).toBe("docs/");
+    expect(url.searchParams.get("overwrite")).toBe("1");
+    expect(init.method).toBe("POST");
+    expect(init.headers["X-File-Name"]).toBe("note.txt");
+    expect(init.headers["Content-Type"]).toBe("application/octet-stream");
+    expect(Buffer.from(init.body).toString()).toBe("hello");
+    expect(onProgress).toHaveBeenCalledWith(5, 5);
+
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("根目录文件 folder 为空串", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "davflare-up-"));
+    const local = path.join(dir, "top.txt");
+    fs.writeFileSync(local, "x");
+
+    const fetchMock = vi.fn(async () => jsonRes({}, 201));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const client = new DavflareClient(SERVER, "k1");
+    await client.uploadFile(local, "top.txt");
+
+    const url = new URL(String(fetchMock.mock.calls[0][0]));
+    expect(url.searchParams.get("path")).toBe("");
+    expect(fetchMock.mock.calls[0][1].headers["X-File-Name"]).toBe("top.txt");
+
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+});
+
+describe("uploadFile（>=100MB 三段式分块）", () => {
+  const TOTAL = 100 * 1000 * 1000; // 与 client 内 SINGLE_UPLOAD_LIMIT 一致
+  const PART = 8 * 1000 * 1000;
+  let bigFile: string;
+  let bigDir: string;
+
+  beforeAll(() => {
+    bigDir = fs.mkdtempSync(path.join(os.tmpdir(), "davflare-big-"));
+    bigFile = path.join(bigDir, "big.bin");
+    const buf = Buffer.alloc(TOTAL, 0x61);
+    buf[0] = 0;
+    fs.writeFileSync(bigFile, buf);
+  });
+
+  afterAll(() => {
+    fs.rmSync(bigDir, { recursive: true, force: true });
+  });
+
+  it("按 8MB 分块走 create → PUT parts → complete", async () => {
+    const parts: Array<{ partNumber: number; size: number }> = [];
+    let completeBody: { parts: Array<{ partNumber: number; etag: string }> } | undefined;
+    let deleteCalls = 0;
+    const fetchMock = vi.fn(async (input: any, init: any = {}) => {
+      const url = new URL(String(input));
+      if (url.pathname === "/api/upload" && url.searchParams.get("uploads") === "1") {
+        return jsonRes({ uploadId: "u-1" }, 201);
+      }
+      if (url.pathname === "/api/upload" && init.method === "PUT") {
+        const partNumber = Number(url.searchParams.get("partNumber"));
+        parts.push({ partNumber, size: (init.body as Uint8Array).byteLength });
+        return jsonRes({ partNumber, etag: `etag-${partNumber}` });
+      }
+      if (url.pathname === "/api/upload" && init.method === "POST") {
+        completeBody = JSON.parse(String(init.body));
+        return jsonRes({ key: "big.bin", size: TOTAL });
+      }
+      deleteCalls += 0;
+      throw new Error(`unexpected ${init.method} ${url.pathname}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const progress: Array<[number, number]> = [];
+    const client = new DavflareClient(SERVER, "k1");
+    await client.uploadFile(bigFile, "big.bin", (sent, total) => progress.push([sent, total]));
+
+    expect(parts.map((p) => p.partNumber)).toEqual(Array.from({ length: 13 }, (_, i) => i + 1));
+    expect(parts[0].size).toBe(PART);
+    expect(parts[12].size).toBe(TOTAL - PART * 12);
+    expect(completeBody?.parts).toHaveLength(13);
+    expect(completeBody?.parts[0]).toEqual({ partNumber: 1, etag: "etag-1" });
+    expect(completeBody?.parts[12]).toEqual({ partNumber: 13, etag: "etag-13" });
+    expect(progress.at(-1)).toEqual([TOTAL, TOTAL]);
+    expect(deleteCalls).toBe(0);
+  });
+
+  it("分块失败时 abort 清理并抛出原始错误", async () => {
+    const abortCalls: Array<{ path: string | null; uploadId: string | null }> = [];
+    const fetchMock = vi.fn(async (input: any, init: any = {}) => {
+      const url = new URL(String(input));
+      if (url.searchParams.get("uploads") === "1") {
+        return jsonRes({ uploadId: "u-2" }, 201);
+      }
+      if (init.method === "PUT") {
+        const partNumber = Number(url.searchParams.get("partNumber"));
+        if (partNumber === 2) return textRes("part boom", 500);
+        return jsonRes({ partNumber, etag: `etag-${partNumber}` });
+      }
+      if (init.method === "DELETE") {
+        abortCalls.push({
+          path: url.searchParams.get("path"),
+          uploadId: url.searchParams.get("uploadId"),
+        });
+        return new Response(null, { status: 204 });
+      }
+      throw new Error(`unexpected ${init.method}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const client = new DavflareClient(SERVER, "k1");
+    const err = await client.uploadFile(bigFile, "big.bin").catch((e) => e);
+    expect(err).toBeInstanceOf(ApiError);
+    expect(err.status).toBe(500);
+    expect(err.message).toBe("part boom");
+    expect(abortCalls).toEqual([{ path: "big.bin", uploadId: "u-2" }]);
+  });
+});
+
+describe("downloadFile（Range 断点续传）", () => {
+  const TOTAL = 11; // "hello world"
+  const statRes = () => jsonRes({ key: "a.txt", kind: "file", size: TOTAL });
+  let dir: string;
+  let local: string;
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), "davflare-dl-"));
+    local = path.join(dir, "a.txt");
+  });
+
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  function mockDownload(body: string, status = 200) {
+    const downloads: Array<{ range?: string }> = [];
+    const fetchMock = vi.fn(async (input: any, init: any = {}) => {
+      const url = new URL(String(input));
+      if (url.pathname === "/api/stat") return statRes();
+      if (url.pathname === "/api/download") {
+        downloads.push({ range: init.headers?.Range });
+        return textRes(body, status);
+      }
+      throw new Error(`unexpected ${url.pathname}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    return { fetchMock, downloads };
+  }
+
+  it("stat 非 file 抛 ApiError(400)", async () => {
+    const fetchMock = vi.fn(async () => jsonRes({ key: "a.txt", kind: "dir" }));
+    vi.stubGlobal("fetch", fetchMock);
+    const client = new DavflareClient(SERVER, "k1");
+    const err = await client.downloadFile("a.txt", local).catch((e) => e);
+    expect(err).toBeInstanceOf(ApiError);
+    expect(err.status).toBe(400);
+    expect(err.message).toContain("不是文件");
+  });
+
+  it("本地无文件时全量下载（无 Range 头）", async () => {
+    const { fetchMock, downloads } = mockDownload("hello world", 200);
+    const client = new DavflareClient(SERVER, "k1");
+    const onProgress = vi.fn();
+    const resumed = await client.downloadFile("a.txt", local, onProgress);
+
+    expect(resumed).toBe(false);
+    expect(downloads).toEqual([{ range: undefined }]);
+    expect(fs.readFileSync(local, "utf8")).toBe("hello world");
+    expect(fetchMock).toHaveBeenCalledTimes(2); // stat + download
+    expect(onProgress).toHaveBeenCalledWith(TOTAL, TOTAL);
+  });
+
+  it("本地有前缀时带 Range 续传并追加", async () => {
+    fs.writeFileSync(local, "hello ");
+    const { downloads } = mockDownload("world", 206);
+    const client = new DavflareClient(SERVER, "k1");
+    const resumed = await client.downloadFile("a.txt", local);
+
+    expect(resumed).toBe(true);
+    expect(downloads).toEqual([{ range: "bytes=6-" }]);
+    expect(fs.readFileSync(local, "utf8")).toBe("hello world");
+  });
+
+  it("服务器不支持 Range（返回 200）时回退全量覆盖", async () => {
+    fs.writeFileSync(local, "hello ");
+    const { downloads } = mockDownload("hello world", 200);
+    const client = new DavflareClient(SERVER, "k1");
+    const resumed = await client.downloadFile("a.txt", local);
+
+    expect(resumed).toBe(false);
+    expect(downloads).toEqual([{ range: "bytes=6-" }]);
+    expect(fs.readFileSync(local, "utf8")).toBe("hello world");
+  });
+
+  it("本地与远端等长时不发起下载", async () => {
+    fs.writeFileSync(local, "hello world");
+    const { fetchMock } = mockDownload("ignored");
+    const client = new DavflareClient(SERVER, "k1");
+    const resumed = await client.downloadFile("a.txt", local);
+
+    expect(resumed).toBe(false);
+    expect(fetchMock).toHaveBeenCalledTimes(1); // 仅 stat
+    expect(fs.readFileSync(local, "utf8")).toBe("hello world");
+  });
+
+  it("本地比远端大时视为损坏，全量重下", async () => {
+    fs.writeFileSync(local, "x".repeat(TOTAL + 9));
+    const { downloads } = mockDownload("hello world", 200);
+    const client = new DavflareClient(SERVER, "k1");
+    const resumed = await client.downloadFile("a.txt", local);
+
+    expect(resumed).toBe(false);
+    expect(downloads).toEqual([{ range: undefined }]);
+    expect(fs.readFileSync(local, "utf8")).toBe("hello world");
+  });
+
+  it("下载响应非 2xx 抛 ApiError", async () => {
+    const fetchMock = vi.fn(async (input: any) => {
+      const url = new URL(String(input));
+      if (url.pathname === "/api/stat") return statRes();
+      return textRes("denied", 403);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const client = new DavflareClient(SERVER, "k1");
+    const err = await client.downloadFile("a.txt", local).catch((e) => e);
+    expect(err).toBeInstanceOf(ApiError);
+    expect(err.status).toBe(403);
+    expect(err.message).toBe("denied");
+  });
+});
+
+describe("createKeyWithSession / revokeKey", () => {
+  it("createKeyWithSession 用 Basic 会话凭据创建密钥", async () => {
+    const fetchMock = vi.fn(async () => jsonRes({ key: "fd_new", id: "id9" }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const client = new DavflareClient(SERVER, "ignored");
+    const created = await client.createKeyWithSession("alice", "s3cret", "cli-host");
+
+    expect(created).toEqual({ key: "fd_new", id: "id9" });
+    const [input, init] = fetchMock.mock.calls[0];
+    expect(new URL(String(input)).pathname).toBe("/api/keys");
+    expect(init.method).toBe("POST");
+    expect(init.headers.Authorization).toBe(`Basic ${Buffer.from("alice:s3cret").toString("base64")}`);
+    expect(init.headers["Content-Type"]).toBe("application/json");
+    expect(JSON.parse(init.body)).toEqual({ name: "cli-host" });
+  });
+
+  it("createKeyWithSession 失败抛 ApiError", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => textRes("bad login", 401)));
+    const client = new DavflareClient(SERVER, "x");
+    const err = await client.createKeyWithSession("a", "b", "n").catch((e) => e);
+    expect(err).toBeInstanceOf(ApiError);
+    expect(err.status).toBe(401);
+    expect(err.message).toBe("bad login");
+  });
+
+  it("revokeKey DELETE /api/keys?id= 并消费响应体", async () => {
+    const fetchMock = vi.fn(async () => jsonRes({ revoked: true }));
+    vi.stubGlobal("fetch", fetchMock);
+    const client = new DavflareClient(SERVER, "k1");
+    await expect(client.revokeKey("id9")).resolves.toBeUndefined();
+    const [input, init] = fetchMock.mock.calls[0];
+    const url = new URL(String(input));
+    expect(url.pathname).toBe("/api/keys");
+    expect(url.searchParams.get("id")).toBe("id9");
+    expect(init.method).toBe("DELETE");
+    expect(init.headers.Authorization).toBe("Bearer k1");
+  });
+
+  it("revokeKey 失败抛 ApiError（调用方尽力而为）", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => textRes("", 403)));
+    const client = new DavflareClient(SERVER, "k1");
+    const err = await client.revokeKey("id9").catch((e) => e);
+    expect(err).toBeInstanceOf(ApiError);
+    expect(err.message).toBe("HTTP 403");
+  });
+});

--- a/cli/test/config.test.ts
+++ b/cli/test/config.test.ts
@@ -1,0 +1,104 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  ConfigError,
+  clearConfig,
+  loadConfig,
+  normalizeServer,
+  saveConfig,
+} from "../src/config.js";
+
+// 通过 XDG_CONFIG_HOME 把配置目录注入到临时目录，避免碰真实 ~/.config。
+let configRoot: string;
+
+beforeEach(() => {
+  configRoot = fs.mkdtempSync(path.join(os.tmpdir(), "davflare-config-"));
+  vi.stubEnv("XDG_CONFIG_HOME", configRoot);
+  vi.stubEnv("DAVFLARE_SERVER", "");
+  vi.stubEnv("DAVFLARE_KEY", "");
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  fs.rmSync(configRoot, { recursive: true, force: true });
+});
+
+function configFile(): string {
+  return path.join(configRoot, "davflare", "config.json");
+}
+
+describe("normalizeServer", () => {
+  it("裸域名补 https://，多余斜杠去除", () => {
+    expect(normalizeServer("drive.example.com")).toBe("https://drive.example.com");
+    expect(normalizeServer("https://x.io/")).toBe("https://x.io");
+    expect(normalizeServer("http://a.io///")).toBe("http://a.io");
+  });
+
+  it("trim 空白且保留已带协议的地址", () => {
+    expect(normalizeServer("  https://s.example.com/path/  ")).toBe(
+      "https://s.example.com/path"
+    );
+  });
+});
+
+describe("saveConfig / loadConfig", () => {
+  it("保存后可读回完整配置，文件权限 0600", () => {
+    saveConfig({ server: "https://d.example", key: "fd_k", keyId: "id1", keyName: "cli-x" });
+    expect(loadConfig()).toEqual({
+      server: "https://d.example",
+      key: "fd_k",
+      keyId: "id1",
+      keyName: "cli-x",
+    });
+    const mode = fs.statSync(configFile()).mode & 0o777;
+    expect(mode).toBe(0o600);
+  });
+
+  it("重复保存覆盖旧内容且保持 0600", () => {
+    saveConfig({ server: "https://a.example", key: "old" });
+    saveConfig({ server: "https://b.example", key: "new" });
+    expect(loadConfig()).toEqual({ server: "https://b.example", key: "new" });
+    expect((fs.statSync(configFile()).mode & 0o777) === 0o600).toBe(true);
+  });
+});
+
+describe("loadConfig 环境变量", () => {
+  it("DAVFLARE_SERVER + DAVFLARE_KEY 同时设置时优先于文件", () => {
+    saveConfig({ server: "https://file.example", key: "file-key" });
+    vi.stubEnv("DAVFLARE_SERVER", "env.example.com/");
+    vi.stubEnv("DAVFLARE_KEY", "env-key");
+    expect(loadConfig()).toEqual({ server: "https://env.example.com", key: "env-key" });
+  });
+
+  it("仅 DAVFLARE_KEY 时与文件配置合并（server 来自文件）", () => {
+    saveConfig({ server: "https://file.example", key: "file-key" });
+    vi.stubEnv("DAVFLARE_KEY", "env-key");
+    expect(loadConfig()).toEqual({ server: "https://file.example", key: "env-key" });
+  });
+
+  it("无文件无环境变量抛 ConfigError", () => {
+    expect(() => loadConfig()).toThrow(ConfigError);
+    expect(() => loadConfig()).toThrow(/davflare login/);
+  });
+
+  it("文件损坏视为未登录", () => {
+    fs.mkdirSync(path.join(configRoot, "davflare"), { recursive: true });
+    fs.writeFileSync(configFile(), "{not json");
+    expect(() => loadConfig()).toThrow(ConfigError);
+  });
+});
+
+describe("clearConfig", () => {
+  it("删除已存在的配置文件返回 true", () => {
+    saveConfig({ server: "https://d.example", key: "k" });
+    expect(clearConfig()).toBe(true);
+    expect(fs.existsSync(configFile())).toBe(false);
+  });
+
+  it("无配置文件返回 false", () => {
+    expect(clearConfig()).toBe(false);
+  });
+});

--- a/cli/test/index.test.ts
+++ b/cli/test/index.test.ts
@@ -1,0 +1,223 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ApiError } from "../src/client.js";
+
+// index.ts 在模块加载时立即 program.parseAsync(process.argv)，
+// 因此每个用例先改写 process.argv 再动态 import（配合 vi.resetModules 重复加载）。
+// client/config 模块整体 mock，命令分发只验证参数与输出。
+
+const mocks = vi.hoisted(() => {
+  const api = {
+    listPage: vi.fn(),
+    mkdir: vi.fn(),
+    remove: vi.fn(),
+    move: vi.fn(),
+    uploadFile: vi.fn(),
+    downloadFile: vi.fn(),
+    walk: vi.fn(),
+    backup: vi.fn(),
+    stat: vi.fn(),
+    search: vi.fn(),
+    createKeyWithSession: vi.fn(),
+    revokeKey: vi.fn(),
+  };
+  return {
+    api,
+    clientCtor: vi.fn(() => api),
+    loadConfig: vi.fn(),
+    saveConfig: vi.fn(),
+    clearConfig: vi.fn(),
+  };
+});
+
+vi.mock("../src/client.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../src/client.js")>();
+  return { ...actual, DavflareClient: mocks.clientCtor };
+});
+
+vi.mock("../src/config.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../src/config.js")>();
+  return {
+    ...actual,
+    loadConfig: mocks.loadConfig,
+    saveConfig: mocks.saveConfig,
+    clearConfig: mocks.clearConfig,
+  };
+});
+
+const SERVER = "https://example.com";
+let originalArgv: string[];
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  originalArgv = process.argv;
+  mocks.loadConfig.mockReturnValue({ server: SERVER, key: "fd_k", keyId: "kid1" });
+  vi.spyOn(console, "log").mockImplementation(() => {});
+  vi.spyOn(console, "error").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  process.argv = originalArgv;
+  vi.restoreAllMocks();
+});
+
+async function runCli(...args: string[]): Promise<void> {
+  process.argv = ["node", "davflare", ...args];
+  vi.resetModules();
+  await import("../src/index.js");
+}
+
+describe("index 命令分发", () => {
+  it("ls 默认逐行输出，目录带斜杠后缀", async () => {
+    mocks.api.listPage.mockResolvedValue({
+      items: [
+        { key: "docs/", name: "docs", isDir: true, size: 0, uploaded: "" },
+        { key: "a.txt", name: "a.txt", isDir: false, size: 12, uploaded: "" },
+      ],
+      nextCursor: undefined,
+    });
+
+    await runCli("ls", "docs");
+    await vi.waitFor(() => expect(mocks.api.listPage).toHaveBeenCalled());
+
+    expect(mocks.clientCtor).toHaveBeenCalledWith(SERVER, "fd_k");
+    expect(mocks.api.listPage).toHaveBeenCalledWith("docs/", undefined);
+    const log = vi.mocked(console.log);
+    expect(log.mock.calls.map((c) => c[0])).toEqual(["docs/", "a.txt"]);
+  });
+
+  it("ls --json 输出原始 JSON", async () => {
+    const items = [{ key: "a.txt", name: "a.txt", isDir: false, size: 1, uploaded: "" }];
+    mocks.api.listPage.mockResolvedValue({ items, nextCursor: undefined });
+
+    await runCli("ls", "--json");
+    await vi.waitFor(() => expect(console.log).toHaveBeenCalled());
+
+    const output = vi.mocked(console.log).mock.calls[0][0] as string;
+    expect(JSON.parse(output)).toEqual(items);
+  });
+
+  it("mkdir 去掉尾部斜杠后调用远端并提示", async () => {
+    mocks.api.mkdir.mockResolvedValue(undefined);
+
+    await runCli("mkdir", "docs/new/");
+    await vi.waitFor(() => expect(mocks.api.mkdir).toHaveBeenCalled());
+
+    expect(mocks.api.mkdir).toHaveBeenCalledWith("docs/new");
+    expect(console.error).toHaveBeenCalledWith("已创建 docs/new/");
+  });
+
+  it("rm 默认软删除，目录需要 -r", async () => {
+    mocks.api.remove.mockResolvedValue(undefined);
+
+    await runCli("rm", "a.txt", "b/");
+    await vi.waitFor(() => expect(mocks.api.remove).toHaveBeenCalled());
+
+    expect(mocks.api.remove).toHaveBeenCalledWith("a.txt", false);
+    expect(mocks.api.remove).toHaveBeenCalledTimes(1); // b/ 被跳过
+    expect(console.error).toHaveBeenCalledWith("跳过 b/（目录需要 -r）");
+  });
+
+  it("rm -r 允许目录、--hard 彻底删除", async () => {
+    mocks.api.remove.mockResolvedValue(undefined);
+
+    await runCli("rm", "-r", "--hard", "b/");
+    await vi.waitFor(() => expect(mocks.api.remove).toHaveBeenCalled());
+
+    expect(mocks.api.remove).toHaveBeenCalledWith("b/", true);
+  });
+
+  it("mv 传递 from/to 与 --overwrite", async () => {
+    mocks.api.move.mockResolvedValue(undefined);
+
+    await runCli("mv", "a.txt", "b.txt", "--overwrite");
+    await vi.waitFor(() => expect(mocks.api.move).toHaveBeenCalled());
+
+    expect(mocks.api.move).toHaveBeenCalledWith("a.txt", "b.txt", true);
+    expect(console.error).toHaveBeenCalledWith("已移动 a.txt → b.txt");
+  });
+
+  it("cp 源是本地文件时走上传", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "davflare-cli-"));
+    const local = path.join(dir, "local.txt");
+    fs.writeFileSync(local, "data");
+    mocks.api.uploadFile.mockResolvedValue(undefined);
+
+    await runCli("cp", local, "remote/name.txt");
+    await vi.waitFor(() => expect(mocks.api.uploadFile).toHaveBeenCalled());
+
+    expect(mocks.api.uploadFile).toHaveBeenCalledWith(local, "remote/name.txt", expect.any(Function));
+    expect(console.error).toHaveBeenCalledWith("已上传 → remote/name.txt");
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("cp 源不在本地时走下载（目录目标保留远端文件名）", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "davflare-cli-"));
+    mocks.api.downloadFile.mockResolvedValue(true);
+
+    await runCli("cp", "remote/a.txt", `${dir}/`);
+    await vi.waitFor(() => expect(mocks.api.downloadFile).toHaveBeenCalled());
+
+    expect(mocks.api.downloadFile).toHaveBeenCalledWith(
+      "remote/a.txt",
+      path.join(dir, "a.txt"),
+      expect.any(Function)
+    );
+    expect(console.error).toHaveBeenCalledWith(
+      `已下载 → ${path.join(dir, "a.txt")}（断点续传）`
+    );
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("sync --dry-run push 只输出计划不传输", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "davflare-sync-"));
+    fs.writeFileSync(path.join(dir, "file.txt"), "abc");
+    mocks.api.walk.mockImplementation(() =>
+      (async function* () {
+        yield {
+          key: "remote/other.txt",
+          name: "other.txt",
+          isDir: false,
+          size: 5,
+          uploaded: "2026-01-01T00:00:00.000Z",
+        };
+      })()
+    );
+
+    await runCli("sync", "--dry-run", "push", dir, "remote");
+    await vi.waitFor(() => expect(mocks.api.walk).toHaveBeenCalled());
+
+    expect(mocks.api.uploadFile).not.toHaveBeenCalled();
+    expect(mocks.api.downloadFile).not.toHaveBeenCalled();
+    const errText = vi.mocked(console.error).mock.calls.map((c) => String(c[0])).join("\n");
+    expect(errText).toContain("同步计划 (push)：传输 1");
+    expect(errText).toContain("传输  file.txt");
+    expect(errText).toContain("可清理(远端) other.txt");
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+});
+
+describe("index 错误处理", () => {
+  it("ApiError 打印「错误: <message>」并 exit(1)", async () => {
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
+    mocks.api.listPage.mockRejectedValue(new ApiError(500, "boom"));
+
+    await runCli("ls");
+    await vi.waitFor(() => expect(exitSpy).toHaveBeenCalled());
+
+    expect(console.error).toHaveBeenCalledWith("错误: boom");
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
+  it("sync 非法 direction 直接报错退出", async () => {
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
+
+    await runCli("sync", "sideways", os.tmpdir(), "remote");
+    await vi.waitFor(() => expect(exitSpy).toHaveBeenCalled());
+
+    expect(console.error).toHaveBeenCalledWith("错误: direction 必须是 push 或 pull");
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+});

--- a/cli/test/util.test.ts
+++ b/cli/test/util.test.ts
@@ -1,0 +1,137 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  ensureLocalDir,
+  humanSize,
+  makeProgressBar,
+  remoteKeyToLocal,
+  walkLocal,
+} from "../src/util.js";
+
+describe("humanSize", () => {
+  it("bytes 以下原样展示", () => {
+    expect(humanSize(0)).toBe("0 B");
+    expect(humanSize(512)).toBe("512 B");
+    expect(humanSize(1023)).toBe("1023 B");
+  });
+
+  it("KB/MB/GB/TB 保留一位小数", () => {
+    expect(humanSize(1024)).toBe("1.0 KB");
+    expect(humanSize(1536)).toBe("1.5 KB");
+    expect(humanSize(1024 * 1024)).toBe("1.0 MB");
+    expect(humanSize(3.5 * 1024 * 1024)).toBe("3.5 MB");
+    expect(humanSize(1024 ** 3)).toBe("1.0 GB");
+    expect(humanSize(1024 ** 4)).toBe("1.0 TB");
+  });
+
+  it("超过最大单位时停在 TB", () => {
+    expect(humanSize(1024 ** 5)).toBe("1024.0 TB");
+  });
+
+  it("非有限值返回 -", () => {
+    expect(humanSize(Number.NaN)).toBe("-");
+    expect(humanSize(Number.POSITIVE_INFINITY)).toBe("-");
+  });
+});
+
+describe("walkLocal", () => {
+  let root: string;
+
+  beforeEach(() => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), "davflare-walk-"));
+    fs.writeFileSync(path.join(root, "a.txt"), "aaa");
+    fs.mkdirSync(path.join(root, "sub", "deep"), { recursive: true });
+    fs.writeFileSync(path.join(root, "sub", "b.txt"), "bb");
+    fs.writeFileSync(path.join(root, "sub", "deep", "c.txt"), "c");
+    fs.writeFileSync(path.join(root, ".DS_Store"), "skip me");
+    fs.writeFileSync(path.join(root, ".davflare-sync"), "skip metadata");
+    fs.mkdirSync(path.join(root, "empty-dir"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  it("递归收集文件并按路径排序，分隔符统一为 /", () => {
+    const entries = walkLocal(root);
+    expect(entries.map((e) => e.path)).toEqual([
+      "a.txt",
+      "sub/b.txt",
+      "sub/deep/c.txt",
+    ]);
+    expect(entries[0].size).toBe(3);
+    expect(entries[0].mtimeMs).toBeGreaterThan(0);
+  });
+
+  it("skipNames 排除 .DS_Store 与 .davflare-sync，自定义时整体替换默认值", () => {
+    expect(walkLocal(root).some((e) => e.path.includes(".DS_Store"))).toBe(false);
+    const onlyDeep = walkLocal(root, ["sub", ".DS_Store", ".davflare-sync"]);
+    expect(onlyDeep.map((e) => e.path)).toEqual(["a.txt"]);
+  });
+
+  it("空目录产出空列表", () => {
+    const empty = fs.mkdtempSync(path.join(os.tmpdir(), "davflare-empty-"));
+    try {
+      expect(walkLocal(empty)).toEqual([]);
+    } finally {
+      fs.rmSync(empty, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("makeProgressBar", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("按百分比渲染进度并在完成时换行", () => {
+    const write = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    const progress = makeProgressBar("上传 a.txt");
+    progress(50, 100);
+    const first = String(write.mock.calls[0][0]);
+    expect(first).toContain("上传 a.txt");
+    expect(first).toContain("50%");
+    expect(first).toContain("50 B/100 B");
+    expect(first).toContain("/s");
+    expect(first.endsWith("\n")).toBe(false);
+
+    progress(100, 100);
+    const last = String(write.mock.calls.at(-1)?.[0]);
+    expect(last.endsWith("\n")).toBe(true);
+  });
+
+  it("total 为 0 时按 100% 处理", () => {
+    const write = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    const progress = makeProgressBar("下载");
+    progress(0, 0);
+    expect(String(write.mock.calls[0][0])).toContain("100%");
+  });
+});
+
+describe("remoteKeyToLocal", () => {
+  it("按 / 拆分远端键拼接到本地根", () => {
+    expect(remoteKeyToLocal("/tmp/root", "a/b/c.txt")).toBe(
+      path.join("/tmp/root", "a", "b", "c.txt")
+    );
+    expect(remoteKeyToLocal("/tmp/root", "top.txt")).toBe(
+      path.join("/tmp/root", "top.txt")
+    );
+  });
+});
+
+describe("ensureLocalDir", () => {
+  it("递归创建目标文件的父目录", () => {
+    const base = fs.mkdtempSync(path.join(os.tmpdir(), "davflare-mkdir-"));
+    try {
+      const target = path.join(base, "x", "y", "file.txt");
+      ensureLocalDir(target);
+      expect(fs.statSync(path.join(base, "x", "y")).isDirectory()).toBe(true);
+      expect(fs.existsSync(target)).toBe(false);
+    } finally {
+      fs.rmSync(base, { recursive: true, force: true });
+    }
+  });
+});

--- a/cli/vitest.config.ts
+++ b/cli/vitest.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    coverage: {
+      provider: "v8",
+      include: ["src/**"],
+      reporter: ["text", "html"],
+      // 阈值先不设，只出数字
+    },
+  },
+});

--- a/functions/api/trash.ts
+++ b/functions/api/trash.ts
@@ -298,11 +298,18 @@ async function handleRestore(request: Request, env: TrashEnv) {
       continue;
     }
 
-    const metadata = (await metadataObject.json()) as {
+    // 与 listTrashItems 一致：单个损坏的回收站元数据不应让整个请求 500。
+    let metadata: {
       originalKey?: string;
       virtualDir?: boolean;
       items?: Array<{ source: string; target: string }>;
     };
+    try {
+      metadata = (await metadataObject.json()) as typeof metadata;
+    } catch {
+      results.push({ trashKey, status: "error", message: "回收站项目损坏" });
+      continue;
+    }
     if (!metadata.originalKey || !metadata.items) {
       results.push({ trashKey, status: "error", message: "回收站项目损坏" });
       continue;

--- a/functions/webdav/protocol.ts
+++ b/functions/webdav/protocol.ts
@@ -1055,10 +1055,19 @@ async function handleGet({
     }
   }
 
-  const object = await bucket.get(path, {
-    onlyIf: getConditionalHeaders(request.headers, true),
-    range: request.headers,
-  });
+  // R2 对非法/不可满足的 Range 头会抛 InvalidRange（HTTP 416 同类错误）。
+  // 这里回退为全量读取，避免未捕获异常变成 500（与 /api/download 的处理一致）。
+  let object: R2ObjectBody | R2Object | null;
+  try {
+    object = await bucket.get(path, {
+      onlyIf: getConditionalHeaders(request.headers, true),
+      range: request.headers,
+    });
+  } catch {
+    object = await bucket.get(path, {
+      onlyIf: getConditionalHeaders(request.headers, true),
+    });
+  }
   if (object === null) {
     return new Response("Not Found", { status: 404 });
   }

--- a/package.json
+++ b/package.json
@@ -37,6 +37,37 @@
       "react-app/jest"
     ]
   },
+  "jest": {
+    "collectCoverageFrom": [
+      "src/**/*.{js,jsx,ts,tsx}",
+      "functions/**/*.ts",
+      "!src/index.js",
+      "!src/app/testUtils.ts",
+      "!src/app/testInMemoryBucket.ts",
+      "!**/__tests__/**",
+      "!**/*.d.ts"
+    ],
+    "coverageThreshold": {
+      "global": {
+        "statements": 50.22,
+        "branches": 42.67,
+        "functions": 60.87,
+        "lines": 50.97
+      },
+      "./src": {
+        "statements": 91.6,
+        "branches": 84.5,
+        "functions": 85.9,
+        "lines": 93.5
+      },
+      "./functions": {
+        "statements": 58.67,
+        "branches": 53.23,
+        "functions": 66.69,
+        "lines": 60.92
+      }
+    }
+  },
   "browserslist": {
     "production": [
       ">0.2%",

--- a/scripts/api-e2e.sh
+++ b/scripts/api-e2e.sh
@@ -206,7 +206,7 @@ try:
 except Exception:
     print('ZIP-BAD')
 ")" "ZIP-OK"
-DTHEAD=$(curl -s --noproxy '*' -o /dev/null -w "%{http_code}|%{content_type}" -I "$BASE/share/$DTOKEN")
+DTHEAD=$(curl -s --noproxy '*' -o /dev/null -w "%{http_code}|%{content_type}" -I "$BASE/share/$DTOKEN?download=1")
 assert_contains "dir share HEAD 200 zip" "$DTHEAD" "200|application/zip"
 assert_contains "dir landing folder badge" "$(curl -s --noproxy '*' "$BASE/share/$DTOKEN")" "Folder (zip download)"
 # 过期：expiresInHours 接受小数（0.00001h = 36ms），落地页与直链都应 410

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -99,6 +99,7 @@ function AppContent({
   });
   const searchInputRef = useRef<HTMLInputElement>(null);
   const notified = useRef(new Set<string>());
+  const shownSnackKeyRef = useRef<number | null>(null);
 
   const pushSnack = useCallback(
     (snack: Omit<SnackbarMessage, "key">) => {
@@ -109,9 +110,15 @@ function AppContent({
     []
   );
 
-  // 队列化展示：上一条退出动画结束后再弹下一条，连续消息不再互相覆盖
+  // 队列化展示：上一条退出动画结束后再弹下一条，连续消息不再互相覆盖。
+  // onExited 是队列消费点；退场期间队首仍是已展示过的消息，用 shownSnackKeyRef
+  // 挡住重开——否则 effect 会在退出动画完成前把 Snackbar 重新打开，onExited
+  // 永不触发，消息每轮 autoHideDuration 重闪一次。
   useEffect(() => {
     if (snackOpen || snackQueue.length === 0) return;
+    const head = snackQueue[0];
+    if (shownSnackKeyRef.current === head.key) return;
+    shownSnackKeyRef.current = head.key;
     setSnackOpen(true);
   }, [snackOpen, snackQueue]);
 

--- a/src/app/__tests__/AppExtra.test.tsx
+++ b/src/app/__tests__/AppExtra.test.tsx
@@ -1,0 +1,229 @@
+/**
+ * App.tsx 覆盖补充：Snackbar 队列消费（排队/error 时长/action 回调/上传完成失败
+ * 通知去重）、主题三态切换持久化、快捷键的输入保护分支。
+ */
+import React from "react";
+import { act, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+
+import App from "../../App";
+import { setLang, strings, translate } from "../strings";
+import type { TransferTask } from "../types";
+
+let mockNotify: ((message: string, severity?: any, options?: any) => void) | null = null;
+let mockQueueTasks: TransferTask[] = [];
+
+jest.mock("../transferQueue", () => {
+  return {
+    TransferQueueProvider: ({ children }: { children: JSX.Element }) => children,
+    useTransferQueue: () => mockQueueTasks,
+    useTransferQueueActions: () => ({}),
+    useTransferQueueGlobalPaused: () => false,
+    useUploadEnqueue: () => jest.fn(),
+  };
+});
+
+jest.mock("../../Main", () => ({
+  __esModule: true,
+  default: (props: { onNotify: (m: string, s?: any, o?: any) => void }) => {
+    mockNotify = props.onNotify;
+    return <div>main-stub</div>;
+  },
+}));
+
+jest.mock("../../CommandPalette", () => ({
+  __esModule: true,
+  default: ({ open }: { open: boolean }) =>
+    open ? <div>command-palette-stub</div> : null,
+}));
+
+jest.mock("../../LoginDialog", () => ({
+  __esModule: true,
+  default: () => <div>login-stub</div>,
+}));
+
+jest.mock("../../TransferManager", () => ({
+  __esModule: true,
+  default: ({ open }: { open: boolean }) =>
+    open ? <div>transfers-stub</div> : null,
+}));
+
+jest.mock("../../ApiKeysPanel", () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+const completedTask = (id: string, name: string): TransferTask =>
+  ({
+    id,
+    type: "upload",
+    status: "completed",
+    name,
+    basedir: "",
+    remoteKey: name,
+    loaded: 1,
+    total: 1,
+  }) as TransferTask;
+
+beforeEach(() => {
+  setLang("zh");
+  localStorage.clear();
+  mockQueueTasks = [];
+});
+
+describe("App Snackbar 队列", () => {
+  test("连续 success 消息：后发的顶到队首，前一条排队随后展示", async () => {
+    jest.useFakeTimers();
+    try {
+      render(<App />);
+      await act(async () => {});
+      expect(mockNotify).toBeTruthy();
+      act(() => mockNotify!("第一条", "success"));
+      act(() => mockNotify!("第二条", "success"));
+      // enqueueSnack 把后发的非 error 顶到队首
+      expect(screen.getByText("第二条")).toBeInTheDocument();
+      expect(screen.queryByText("第一条")).not.toBeInTheDocument();
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  test("error 消息展示，Alert 自带关闭按钮可触发 onClose", async () => {
+    render(<App />);
+    await act(async () => {});
+    act(() => mockNotify!("出错了", "error"));
+    expect(screen.getByText("出错了")).toBeInTheDocument();
+    const closeBtn = screen.getByRole("button", { name: "Close" });
+    fireEvent.click(closeBtn);
+    // App 的 onClose 会 setSnackOpen(false)
+    expect(closeBtn).toBeInTheDocument();
+  });
+
+  // 修复后行为：8s 自动隐藏 → 退场动画完成 → onExited 排空队列，消息消失不再重闪
+  test("error autoHideDuration 到点后自动隐藏且不再重闪", async () => {
+    jest.useFakeTimers();
+    try {
+      render(<App />);
+      await act(async () => {});
+      act(() => mockNotify!("出错了", "error"));
+      expect(screen.getByText("出错了")).toBeInTheDocument();
+      // 8s 自动隐藏；分两段推进：先到隐藏点，再等退场动画触发 onExited
+      act(() => jest.advanceTimersByTime(8200));
+      act(() => jest.advanceTimersByTime(3000));
+      expect(screen.queryByText("出错了")).not.toBeInTheDocument();
+      // 修复前消息会在每轮 autoHideDuration 到点后重新进场；这里确认持续消失
+      act(() => jest.advanceTimersByTime(12000));
+      expect(screen.queryByText("出错了")).not.toBeInTheDocument();
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  test("action 按钮触发回调", async () => {
+    render(<App />);
+    await act(async () => {});
+    const onClick = jest.fn();
+    act(() =>
+      mockNotify!("失败", "error", {
+        action: { label: strings.transfers, onClick },
+      })
+    );
+    const btn = await screen.findByText(strings.transfers);
+    fireEvent.click(btn);
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  test("上传失败通知带 action，点击打开任务面板", async () => {
+    mockQueueTasks = [
+      {
+        id: "t-fail",
+        type: "upload",
+        status: "failed",
+        name: "bad.txt",
+        basedir: "",
+        remoteKey: "bad.txt",
+        loaded: 0,
+        total: 1,
+      } as TransferTask,
+    ];
+    const { rerender } = render(<App />);
+    await act(async () => {
+      rerender(<App />);
+    });
+    await waitFor(() =>
+      expect(
+        screen.getByText(translate("uploadFailedToast", { name: "bad.txt" }))
+      ).toBeInTheDocument()
+    );
+    fireEvent.click(screen.getByText(strings.transfers));
+    expect(screen.getByText("transfers-stub")).toBeInTheDocument();
+  });
+
+  test("上传完成通知且同一任务只通知一次", async () => {
+    const { rerender } = render(<App />);
+    await act(async () => {});
+    mockQueueTasks = [completedTask("t1", "same.txt")];
+    await act(async () => {
+      rerender(<App />);
+    });
+    await waitFor(() =>
+      expect(
+        screen.getByText(translate("uploadedToast", { name: "same.txt" }))
+      ).toBeInTheDocument()
+    );
+    // 再次渲染同一队列：notified 去重，不产生第二条
+    await act(async () => {
+      rerender(<App />);
+    });
+    expect(
+      screen.getAllByText(translate("uploadedToast", { name: "same.txt" }))
+    ).toHaveLength(1);
+  });
+});
+
+describe("App 主题三态", () => {
+  test("外观菜单切换 light/dark/system 并持久化", async () => {
+    render(<App />);
+    await act(async () => {});
+    fireEvent.click(screen.getByLabelText(strings.theme));
+    const menu = await screen.findByRole("menu");
+    fireEvent.click(within(menu).getByText(strings.themeDark));
+    expect(localStorage.getItem("flaredrive.themeMode")).toBe('"dark"');
+
+    fireEvent.click(screen.getByLabelText(strings.theme));
+    const menu2 = await screen.findByRole("menu");
+    fireEvent.click(within(menu2).getByText(strings.themeLight));
+    expect(localStorage.getItem("flaredrive.themeMode")).toBe('"light"');
+
+    fireEvent.click(screen.getByLabelText(strings.theme));
+    const menu3 = await screen.findByRole("menu");
+    fireEvent.click(within(menu3).getByText(strings.themeSystem));
+    expect(localStorage.getItem("flaredrive.themeMode")).toBe('"system"');
+  });
+});
+
+describe("App 快捷键保护分支", () => {
+  test("isComposing / Process 键不触发命令面板", () => {
+    render(<App />);
+    fireEvent.keyDown(window, { key: "k", ctrlKey: true, isComposing: true });
+    expect(screen.queryByText("command-palette-stub")).not.toBeInTheDocument();
+    fireEvent.keyDown(window, { key: "Process" });
+    expect(screen.queryByText("command-palette-stub")).not.toBeInTheDocument();
+    fireEvent.keyDown(window, { key: "k", ctrlKey: true });
+    expect(screen.getByText("command-palette-stub")).toBeInTheDocument();
+  });
+
+  test("带修饰键的 / 不聚焦搜索", () => {
+    render(<App />);
+    fireEvent.keyDown(window, { key: "/", metaKey: true, target: document.body });
+    const input = screen.getByLabelText(strings.searchShortcutHint) as HTMLInputElement;
+    expect(document.activeElement).not.toBe(input);
+  });
+
+  test("输入框聚焦时 cmd/ctrl+K 仍打开面板", () => {
+    render(<App />);
+    const input = screen.getByLabelText(strings.searchShortcutHint);
+    fireEvent.focus(input);
+    fireEvent.keyDown(window, { key: "k", ctrlKey: true });
+    expect(screen.getByText("command-palette-stub")).toBeInTheDocument();
+  });
+});

--- a/src/app/__tests__/MainExtra.test.tsx
+++ b/src/app/__tests__/MainExtra.test.tsx
@@ -314,18 +314,16 @@ describe("Main 上下文菜单动作", () => {
 });
 
 describe("Main 删除-撤销/重试闭环", () => {
-  function openConfirmAndConfirm(onNotify: jest.Mock) {
+  async function openConfirmAndConfirm(onNotify: jest.Mock) {
     renderMain({ kind: "folder", path: "" }, { onNotify });
-    return waitFor(() => screen.getByText("a.txt")).then(() => {
-      fireEvent.click(screen.getByLabelText(translate("fileActionsLabel", { name: "a.txt" })));
-      fireEvent.click(screen.getByRole("menuitem", { name: strings.delete }));
-      // 菜单动作经 50ms setTimeout 打开确认框，用 waitFor 消化时序抖动
-      return waitFor(() =>
-        expect(screen.getByRole("button", { name: strings.confirmAction })).toBeInTheDocument()
-      ).then(() => {
-        fireEvent.click(screen.getByRole("button", { name: strings.confirmAction }));
-      });
-    });
+    await waitFor(() => expect(screen.getByText("a.txt")).toBeInTheDocument());
+    fireEvent.click(screen.getByLabelText(translate("fileActionsLabel", { name: "a.txt" })));
+    fireEvent.click(screen.getByRole("menuitem", { name: strings.delete }));
+    // FileActionSheet setTimeout(0) + Main 50ms；与上下文菜单用例一致，先等确认文案。
+    await waitFor(() =>
+      expect(screen.getByText(translate("confirmDeleteMsg", { count: 1 }))).toBeInTheDocument()
+    );
+    fireEvent.click(screen.getByRole("button", { name: strings.confirmAction }));
   }
 
   test("删除成功 → undo 恢复成功并再次刷新", async () => {

--- a/src/app/__tests__/MainExtra.test.tsx
+++ b/src/app/__tests__/MainExtra.test.tsx
@@ -1,0 +1,603 @@
+/**
+ * Main.tsx 集成分支补充：搜索「加载更多」（IO/滚动/防重复/错误）、面包屑 goUp、
+ * 上下文菜单动作、删除-撤销/重试闭环、多选工具栏、空目录上传入口、
+ * 最近文件入口、拖拽入文件夹（内部移动 / 外部文件）、上传完成刷新列表。
+ */
+import React from "react";
+import { act, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+
+import Main from "../../Main";
+import { ClipboardProvider } from "../clipboard";
+import { DEFAULT_FEATURE_FLAGS, useFeatures } from "../features";
+import { useAuth } from "../auth";
+import {
+  collectFilesFromDataTransfer,
+  copyPaste,
+  createFolder,
+  downloadArchive,
+  downloadFile,
+  fetchFolderCounts,
+  fetchPath,
+  openFile,
+  searchFiles,
+} from "../transfer";
+import { moveToTrash, restoreTrash } from "../trash";
+import { setLang, strings, translate } from "../strings";
+import type { TransferTask } from "../types";
+
+jest.mock("../auth", () => ({
+  useAuth: jest.fn(),
+  authFetch: jest.fn(),
+}));
+
+jest.mock("../features", () => {
+  const actual = jest.requireActual("../features");
+  return { ...actual, useFeatures: jest.fn() };
+});
+
+let mockQueueTasks: TransferTask[] = [];
+const mockEnqueue = jest.fn();
+jest.mock("../transferQueue", () => ({
+  useTransferQueue: () => mockQueueTasks,
+  useUploadEnqueue: () => mockEnqueue,
+}));
+
+jest.mock("../transfer", () => ({
+  collectFilesFromDataTransfer: jest.fn(),
+  copyPaste: jest.fn(),
+  createFolder: jest.fn(),
+  downloadArchive: jest.fn(),
+  downloadFile: jest.fn(),
+  fetchFolderCounts: jest.fn().mockResolvedValue({}),
+  fetchPath: jest.fn(),
+  openFile: jest.fn(),
+  searchFiles: jest.fn(),
+  selectDirectoryFiles: jest.fn(),
+}));
+
+jest.mock("../trash", () => ({
+  moveToTrash: jest.fn(),
+  restoreTrash: jest.fn(),
+}));
+
+jest.mock("../../PreviewDialog", () => ({ __esModule: true, default: () => null }));
+jest.mock("../../ShareDialog", () => ({ __esModule: true, default: () => null }));
+jest.mock("../../SitesView", () => ({ __esModule: true, default: () => <div>sites-stub</div> }));
+jest.mock("../../ImagesView", () => ({ __esModule: true, default: () => <div>images-stub</div> }));
+jest.mock("../../TrashView", () => ({ __esModule: true, default: () => <div>trash-stub</div> }));
+jest.mock("../../SharesView", () => ({ __esModule: true, default: () => <div>shares-stub</div> }));
+jest.mock("../../SettingsView", () => ({ __esModule: true, default: () => <div>settings-stub</div> }));
+jest.mock("../../WebDavPanel", () => ({ __esModule: true, default: () => null }));
+jest.mock("../../TextPadDrawer", () => ({ __esModule: true, default: () => null }));
+jest.mock("../../MoveDialog", () => ({ __esModule: true, default: ({ open }: { open: boolean }) => (open ? <div>move-stub</div> : null) }));
+jest.mock("../../AuthThumbnail", () => ({ __esModule: true, default: () => <span /> }));
+jest.mock("../../MimeIcon", () => ({ __esModule: true, default: () => <span /> }));
+
+const mockUseAuth = useAuth as unknown as jest.Mock;
+const mockUseFeatures = useFeatures as unknown as jest.Mock;
+const mockFetchPath = fetchPath as unknown as jest.Mock;
+const mockSearch = searchFiles as unknown as jest.Mock;
+const mockCopyPaste = copyPaste as unknown as jest.Mock;
+const mockCreateFolder = createFolder as unknown as jest.Mock;
+const mockMoveTrash = moveToTrash as unknown as jest.Mock;
+const mockRestore = restoreTrash as unknown as jest.Mock;
+const mockCollect = collectFilesFromDataTransfer as unknown as jest.Mock;
+const mockDownload = downloadFile as unknown as jest.Mock;
+const mockArchive = downloadArchive as unknown as jest.Mock;
+const mockOpen = openFile as unknown as jest.Mock;
+const mockCounts = fetchFolderCounts as unknown as jest.Mock;
+
+const file = {
+  key: "a.txt",
+  name: "a.txt",
+  isDir: false,
+  size: 1,
+  uploaded: "2026-01-01T00:00:00.000Z",
+  contentType: "text/plain",
+};
+const file2 = { ...file, key: "b.txt", name: "b.txt" };
+const folder = {
+  key: "docs",
+  name: "docs",
+  isDir: true,
+  size: 0,
+  uploaded: "2026-01-02T00:00:00.000Z",
+  contentType: "application/x-directory",
+};
+
+function renderMain(route: any = { kind: "folder", path: "" }, extra: Partial<React.ComponentProps<typeof Main>> = {}) {
+  const props = {
+    search: "",
+    onSearchChange: jest.fn(),
+    onNotify: jest.fn(),
+    view: "list" as const,
+    onViewChange: jest.fn(),
+    sort: { field: "name" as const, order: "asc" as const },
+    onSortChange: jest.fn(),
+    route,
+    navigate: jest.fn(),
+    onOpenApi: jest.fn(),
+    onContentScroll: jest.fn(),
+    ...extra,
+  };
+  const result = render(
+    <ClipboardProvider>
+      <Main {...props} />
+    </ClipboardProvider>
+  );
+  return { ...result, props };
+}
+
+beforeAll(() => {
+  (global as any).IntersectionObserver = class {
+    constructor(cb: (entries: Array<{ isIntersecting: boolean }>) => void) {
+      void cb;
+    }
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  };
+  Element.prototype.scrollIntoView = jest.fn();
+  Object.assign(navigator, {
+    clipboard: { writeText: jest.fn().mockResolvedValue(undefined) },
+  });
+});
+
+beforeEach(() => {
+  setLang("zh");
+  mockQueueTasks = [];
+  mockEnqueue.mockReset();
+  mockUseAuth.mockReturnValue({ username: "alice", login: jest.fn(), logout: jest.fn() });
+  mockUseFeatures.mockReturnValue({
+    flags: DEFAULT_FEATURE_FLAGS,
+    sitesHost: null,
+    updateFlags: jest.fn(),
+    refresh: jest.fn(),
+    config: { username: "alice", publicRead: false, sitesHost: null, flags: DEFAULT_FEATURE_FLAGS },
+  });
+  mockFetchPath.mockReset();
+  mockFetchPath.mockResolvedValue([file, folder]);
+  mockSearch.mockReset();
+  mockSearch.mockResolvedValue({ items: [file], hasMore: false });
+  mockCopyPaste.mockReset();
+  mockCopyPaste.mockResolvedValue(undefined);
+  mockCreateFolder.mockReset();
+  mockCreateFolder.mockResolvedValue(undefined);
+  mockMoveTrash.mockReset();
+  mockMoveTrash.mockResolvedValue({ results: [{ id: "t1" }] });
+  mockRestore.mockReset();
+  mockRestore.mockResolvedValue(undefined);
+  mockCollect.mockReset();
+  mockCollect.mockResolvedValue([]);
+  mockDownload.mockReset();
+  mockDownload.mockResolvedValue(undefined);
+  mockArchive.mockReset();
+  mockArchive.mockResolvedValue(undefined);
+  mockOpen.mockReset();
+  mockOpen.mockResolvedValue(undefined);
+  mockCounts.mockResolvedValue({});
+  sessionStorage.clear();
+  localStorage.clear();
+});
+
+function delay(ms = 80) {
+  return act(() => new Promise((resolve) => setTimeout(resolve, ms)));
+}
+
+describe("Main 全盘搜索加载更多", () => {
+  test("触底自动加载下一页并去重，加载完显示 allLoaded", async () => {
+    jest.useFakeTimers();
+    try {
+      mockSearch
+        .mockResolvedValueOnce({ items: [file], hasMore: true, nextCursor: "c1" })
+        .mockResolvedValueOnce({ items: [file2], hasMore: false });
+      renderMain({ kind: "folder", path: "" }, { search: "hello" });
+      await act(async () => {
+        jest.advanceTimersByTime(400);
+      });
+      await act(async () => {
+        jest.runOnlyPendingTimers();
+      });
+      expect(mockSearch).toHaveBeenCalledTimes(2);
+      // 第二页带 cursor
+      const secondCall = mockSearch.mock.calls[1];
+      expect(secondCall[1]).toBe("c1");
+      await waitFor(() => expect(screen.getByText("b.txt")).toBeInTheDocument());
+      expect(screen.getByText(strings.allLoaded)).toBeInTheDocument();
+      // 已加载完：滚动不再触发新的请求
+      await act(async () => {
+        window.dispatchEvent(new Event("scroll"));
+      });
+      await act(async () => {
+        window.dispatchEvent(new Event("scroll"));
+      });
+      expect(mockSearch).toHaveBeenCalledTimes(2);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  test("加载更多失败时错误提示", async () => {
+    jest.useFakeTimers();
+    try {
+      mockSearch
+        .mockResolvedValueOnce({ items: [file], hasMore: true, nextCursor: "c1" })
+        .mockRejectedValueOnce(new Error("page-2-fail"));
+      const onNotify = jest.fn();
+      renderMain({ kind: "folder", path: "" }, { search: "hello", onNotify });
+      await act(async () => {
+        jest.advanceTimersByTime(400);
+      });
+      await act(async () => {
+        jest.runOnlyPendingTimers();
+      });
+      await waitFor(() =>
+        expect(onNotify).toHaveBeenCalledWith("page-2-fail", "error")
+      );
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  test("列表加载失败的重试 action 可再次触发 loadListing", async () => {
+    mockFetchPath.mockRejectedValue(new Error("list-fail"));
+    const onNotify = jest.fn();
+    renderMain({ kind: "folder", path: "" }, { onNotify });
+    await waitFor(() => expect(onNotify).toHaveBeenCalled());
+    const retry = onNotify.mock.calls[0][2]?.action?.onClick;
+    expect(retry).toBeTruthy();
+    mockFetchPath.mockResolvedValue([file]);
+    await act(async () => {
+      retry();
+    });
+    await waitFor(() => expect(screen.getByText("a.txt")).toBeInTheDocument());
+  });
+});
+
+describe("Main 面包屑导航", () => {
+  test("goUp 返回上级；子目录场景", async () => {
+    const { props } = renderMain({ kind: "folder", path: "docs/sub/" });
+    await waitFor(() => expect(screen.getByText("a.txt")).toBeInTheDocument());
+    fireEvent.click(screen.getByLabelText(strings.goUp));
+    expect(props.navigate).toHaveBeenCalledWith({ kind: "folder", path: "docs/" });
+  });
+
+  test("中间面包屑点击导航到对应层", async () => {
+    const { props } = renderMain({ kind: "folder", path: "a/b/" });
+    await waitFor(() => expect(screen.getByText("a.txt")).toBeInTheDocument());
+    fireEvent.click(screen.getByRole("button", { name: "a" }));
+    expect(props.navigate).toHaveBeenCalledWith({ kind: "folder", path: "a/" });
+  });
+});
+
+describe("Main 上下文菜单动作", () => {
+  test("下载文件夹走压缩包、打开目录导航、details 打开侧栏", async () => {
+    const { props } = renderMain();
+    await waitFor(() => expect(screen.getByText("docs")).toBeInTheDocument());
+    // 下载目录 → archive
+    fireEvent.click(screen.getByLabelText(translate("fileActionsLabel", { name: "docs" })));
+    fireEvent.click(screen.getByRole("menuitem", { name: strings.download }));
+    await waitFor(() => expect(mockArchive).toHaveBeenCalledWith(["docs"]));
+    // open 目录 → navigate
+    fireEvent.click(screen.getByLabelText(translate("fileActionsLabel", { name: "docs" })));
+    fireEvent.click(screen.getByRole("menuitem", { name: strings.open }));
+    expect(props.navigate).toHaveBeenCalledWith({ kind: "folder", path: "docs/" });
+    // details
+    fireEvent.click(screen.getByLabelText(translate("fileActionsLabel", { name: "a.txt" })));
+    fireEvent.click(screen.getByRole("menuitem", { name: translate("detailsOpen") }));
+    await waitFor(() => expect(screen.getByLabelText(strings.close)).toBeInTheDocument());
+  });
+
+  test("菜单 rename/share/move/delete 经延时后打开对应对话框", async () => {
+    renderMain();
+    await waitFor(() => expect(screen.getByText("a.txt")).toBeInTheDocument());
+    fireEvent.click(screen.getByLabelText(translate("fileActionsLabel", { name: "a.txt" })));
+    fireEvent.click(screen.getByRole("menuitem", { name: strings.rename }));
+    await delay();
+    await waitFor(() => expect(screen.getByLabelText(strings.name)).toBeInTheDocument());
+    fireEvent.click(screen.getByText(strings.cancel));
+
+    fireEvent.click(screen.getByLabelText(translate("fileActionsLabel", { name: "a.txt" })));
+    fireEvent.click(screen.getByRole("menuitem", { name: strings.move }));
+    await delay();
+    await waitFor(() => expect(screen.getByText("move-stub")).toBeInTheDocument());
+
+    fireEvent.click(screen.getByLabelText(translate("fileActionsLabel", { name: "a.txt" })));
+    fireEvent.click(screen.getByRole("menuitem", { name: strings.share }));
+    fireEvent.click(screen.getByLabelText(translate("fileActionsLabel", { name: "a.txt" })));
+    fireEvent.click(screen.getByRole("menuitem", { name: strings.delete }));
+    await waitFor(() =>
+      expect(screen.getByText(translate("confirmDeleteMsg", { count: 1 }))).toBeInTheDocument()
+    );
+    fireEvent.click(screen.getByText(strings.cancel));
+  });
+});
+
+describe("Main 删除-撤销/重试闭环", () => {
+  function openConfirmAndConfirm(onNotify: jest.Mock) {
+    renderMain({ kind: "folder", path: "" }, { onNotify });
+    return waitFor(() => screen.getByText("a.txt")).then(() => {
+      fireEvent.click(screen.getByLabelText(translate("fileActionsLabel", { name: "a.txt" })));
+      fireEvent.click(screen.getByRole("menuitem", { name: strings.delete }));
+      // 菜单动作经 50ms setTimeout 打开确认框，用 waitFor 消化时序抖动
+      return waitFor(() =>
+        expect(screen.getByRole("button", { name: strings.confirmAction })).toBeInTheDocument()
+      ).then(() => {
+        fireEvent.click(screen.getByRole("button", { name: strings.confirmAction }));
+      });
+    });
+  }
+
+  test("删除成功 → undo 恢复成功并再次刷新", async () => {
+    const onNotify = jest.fn();
+    await openConfirmAndConfirm(onNotify);
+    await waitFor(() => expect(mockMoveTrash).toHaveBeenCalled());
+    await waitFor(() => expect(onNotify).toHaveBeenCalledTimes(1));
+    const undo = onNotify.mock.calls[0][2]?.action?.onClick;
+    expect(undo).toBeTruthy();
+    await act(async () => {
+      undo();
+    });
+    await waitFor(() => expect(mockRestore).toHaveBeenCalledWith(["t1"]));
+    await waitFor(() =>
+      expect(onNotify).toHaveBeenCalledWith(translate("undoDeleteDone"), "success")
+    );
+  });
+
+  test("删除成功 → undo 恢复失败 → 错误提示", async () => {
+    const onNotify = jest.fn();
+    mockRestore.mockRejectedValue(new Error("restore-fail"));
+    await openConfirmAndConfirm(onNotify);
+    await waitFor(() => expect(mockMoveTrash).toHaveBeenCalled());
+    await waitFor(() => expect(onNotify).toHaveBeenCalledTimes(1));
+    const undo = onNotify.mock.calls[0][2]?.action?.onClick;
+    expect(undo).toBeTruthy();
+    await act(async () => {
+      undo();
+    });
+    await waitFor(() => expect(mockRestore).toHaveBeenCalledWith(["t1"]));
+    await waitFor(() => expect(onNotify).toHaveBeenCalledWith("restore-fail", "error"));
+  });
+
+  test("删除失败 → retry 重试成功", async () => {
+    const onNotify = jest.fn();
+    mockMoveTrash.mockRejectedValueOnce(new Error("trash-fail"));
+    await openConfirmAndConfirm(onNotify);
+    await waitFor(() => expect(onNotify).toHaveBeenCalledWith("trash-fail", "error", expect.anything()));
+    const retry = onNotify.mock.calls.find((c) => c[0] === "trash-fail")[2].action.onClick;
+    await act(async () => {
+      retry();
+    });
+    await waitFor(() => expect(mockMoveTrash).toHaveBeenCalledTimes(2));
+  });
+});
+
+describe("Main 重命名失败重试", () => {
+  test("rename 失败 → 错误提示带 retry，重试后成功", async () => {
+    const onNotify = jest.fn();
+    mockCopyPaste.mockRejectedValueOnce(new Error("rename-fail"));
+    renderMain({ kind: "folder", path: "" }, { onNotify });
+    await waitFor(() => expect(screen.getByText("a.txt")).toBeInTheDocument());
+    fireEvent.click(screen.getByLabelText(translate("selectFileLabel", { name: "a.txt" })));
+    fireEvent.keyDown(window, { key: "F2" });
+    fireEvent.change(screen.getByLabelText(strings.name), { target: { value: "renamed.txt" } });
+    fireEvent.click(screen.getByText(strings.ok));
+    await waitFor(() => expect(onNotify).toHaveBeenCalledWith("rename-fail", "error", expect.anything()));
+    const retry = onNotify.mock.calls.find((c) => c[0] === "rename-fail")[2].action.onClick;
+    await act(async () => {
+      retry();
+    });
+    await waitFor(() => expect(mockCopyPaste).toHaveBeenCalledTimes(2));
+  });
+});
+
+describe("Main 多选工具栏", () => {
+  test("单选文件 → 下载走单文件；copy/cut/move/share 入口；rename 最后", async () => {
+    renderMain();
+    await waitFor(() => expect(screen.getByText("a.txt")).toBeInTheDocument());
+    const toolbarBtn = (name: string) => {
+      const toolbar = document.querySelector(".MuiToolbar-root")!;
+      return within(toolbar as HTMLElement).getByRole("button", { name });
+    };
+    fireEvent.click(screen.getByLabelText(translate("selectFileLabel", { name: "a.txt" })));
+    fireEvent.click(toolbarBtn(strings.download));
+    await waitFor(() => expect(mockDownload).toHaveBeenCalledWith("a.txt"));
+
+    fireEvent.click(toolbarBtn(strings.copy));
+    fireEvent.click(toolbarBtn(strings.cut));
+    fireEvent.click(toolbarBtn(strings.move));
+    await waitFor(() => expect(screen.getByText("move-stub")).toBeInTheDocument());
+    // move-stub（mock 组件）不关闭，但其中没有 Dialog aria-hidden，后续查询不受影响
+    fireEvent.click(toolbarBtn(strings.share));
+
+    // rename 放最后：对话框关闭动画期间 aria-hidden 会屏蔽其他元素
+    fireEvent.click(toolbarBtn(strings.rename));
+    await waitFor(() => expect(screen.getByLabelText(strings.name)).toBeInTheDocument());
+    fireEvent.click(screen.getByText(strings.cancel));
+  });
+
+  test("多选 → 下载走压缩包；关闭清空选择", async () => {
+    mockFetchPath.mockResolvedValue([file, file2, folder]);
+    renderMain();
+    await waitFor(() => expect(screen.getByText("b.txt")).toBeInTheDocument());
+    fireEvent.click(screen.getByLabelText(translate("selectFileLabel", { name: "a.txt" })));
+    fireEvent.click(screen.getByLabelText(translate("selectFileLabel", { name: "b.txt" })));
+    const toolbar = document.querySelector(".MuiToolbar-root")!;
+    fireEvent.click(within(toolbar as HTMLElement).getByRole("button", { name: strings.download }));
+    await waitFor(() => expect(mockArchive).toHaveBeenCalledWith(["a.txt", "b.txt"]));
+    fireEvent.click(within(toolbar as HTMLElement).getByRole("button", { name: strings.close }));
+  });
+
+  test("多选下载失败时错误提示", async () => {
+    const onNotify = jest.fn();
+    mockArchive.mockRejectedValue(new Error("zip-fail"));
+    mockFetchPath.mockResolvedValue([file, file2, folder]);
+    renderMain({ kind: "folder", path: "" }, { onNotify });
+    await waitFor(() => expect(screen.getByText("b.txt")).toBeInTheDocument());
+    fireEvent.click(screen.getByLabelText(translate("selectFileLabel", { name: "a.txt" })));
+    fireEvent.click(screen.getByLabelText(translate("selectFileLabel", { name: "b.txt" })));
+    const toolbar = document.querySelector(".MuiToolbar-root")!;
+    fireEvent.click(within(toolbar as HTMLElement).getByRole("button", { name: strings.download }));
+    await waitFor(() => expect(onNotify).toHaveBeenCalledWith("zip-fail", "error"));
+  });
+});
+
+describe("Main 空目录入口", () => {
+  test("空目录展示上传/新建入口，上传按钮触发文件选择并入队", async () => {
+    mockFetchPath.mockResolvedValue([]);
+    const orig = document.createElement.bind(document);
+    let picked: HTMLInputElement | null = null;
+    const spy = jest.spyOn(document, "createElement").mockImplementation((tag: string) => {
+      const el = orig(tag) as HTMLInputElement;
+      if (tag === "input") picked = el;
+      return el;
+    });
+    try {
+      renderMain();
+      // 空目录 EmptyState 的上传按钮（ExplorerBar 的按钮 aria-label 是「上传文件」）
+      const emptyBox = await waitFor(() => {
+        const hint = screen.getByText(strings.noFilesHint);
+        return hint.closest("div")!.parentElement as HTMLElement;
+      });
+      picked = null; // 只捕获点击后创建的文件 input（渲染期的 input 也会被拦截）
+      fireEvent.click(within(emptyBox).getByRole("button", { name: strings.upload }));
+      expect(picked).toBeTruthy();
+      const dropped = new File(["x"], "picked.txt");
+      Object.defineProperty(picked!, "files", { value: [dropped], configurable: true });
+      picked!.onchange?.(new Event("change") as any);
+      await waitFor(() =>
+        expect(mockEnqueue).toHaveBeenCalledWith({ file: dropped, basedir: "" })
+      );
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  test("搜索无结果时展示清除搜索按钮", async () => {
+    jest.useFakeTimers();
+    try {
+      mockSearch.mockResolvedValue({ items: [], hasMore: false });
+      const onSearchChange = jest.fn();
+      renderMain({ kind: "folder", path: "" }, { search: "nomatch", onSearchChange });
+      await act(async () => {
+        jest.advanceTimersByTime(400);
+      });
+      await waitFor(() => expect(screen.getByText(strings.clearSearch)).toBeInTheDocument());
+      fireEvent.click(screen.getByText(strings.clearSearch));
+      expect(onSearchChange).toHaveBeenCalledWith("");
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+});
+
+describe("Main 最近文件入口", () => {
+  test("打开最近的文件：导航到父目录并触发打开", async () => {
+    localStorage.setItem(
+      "flaredrive.recent",
+      JSON.stringify([{ key: "x.bin", name: "x.bin", isDir: false, at: 1 }])
+    );
+    mockFetchPath.mockResolvedValue([
+      file,
+      folder,
+      { key: "x.bin", name: "x.bin", isDir: false, size: 1, uploaded: "2026", contentType: "application/octet-stream" },
+    ]);
+    renderMain();
+    await waitFor(() => expect(screen.getByText(strings.recent)).toBeInTheDocument());
+    fireEvent.click(screen.getByText(strings.recent));
+    const items = await screen.findAllByRole("menuitem");
+    const target = items.find((i) => i.textContent === "x.bin");
+    expect(target).toBeTruthy();
+    fireEvent.click(target!);
+    await waitFor(() => expect(mockOpen).toHaveBeenCalledWith("x.bin"));
+  });
+
+  test("最近条目缺失时提示", async () => {
+    const onNotify = jest.fn();
+    localStorage.setItem(
+      "flaredrive.recent",
+      JSON.stringify([{ key: "gone.txt", name: "gone.txt", isDir: false, at: 1 }])
+    );
+    renderMain({ kind: "folder", path: "" }, { onNotify });
+    await waitFor(() => expect(screen.getByText(strings.recent)).toBeInTheDocument());
+    fireEvent.click(screen.getByText(strings.recent));
+    const item = await screen.findByText("gone.txt");
+    fireEvent.click(item);
+    await waitFor(() => expect(onNotify).toHaveBeenCalledWith(translate("recentMissing"), "error"));
+  });
+
+  test("最近的目录直接导航", async () => {
+    localStorage.setItem(
+      "flaredrive.recent",
+      JSON.stringify([{ key: "docs", name: "docs", isDir: true, at: 1 }])
+    );
+    const { props } = renderMain();
+    await waitFor(() => expect(screen.getByText(strings.recent)).toBeInTheDocument());
+    fireEvent.click(screen.getByText(strings.recent));
+    const items = await screen.findAllByRole("menuitem");
+    const target = items.find((i) => (i.textContent || "").startsWith("docs"));
+    expect(target).toBeTruthy();
+    fireEvent.click(target!);
+    expect(props.navigate).toHaveBeenCalledWith({ kind: "folder", path: "docs/" });
+  });
+});
+
+describe("Main 拖拽入文件夹", () => {
+  test("内部拖拽（JSON 数组格式）→ MOVE 到目标目录，过滤自身", async () => {
+    const { props } = renderMain();
+    await waitFor(() => expect(screen.getByText("docs")).toBeInTheDocument());
+    const dt = { getData: () => '["x/a.txt","docs","docs/inner"]' } as unknown as DataTransfer;
+    fireEvent.drop(screen.getByText("docs"), { dataTransfer: dt });
+    await waitFor(() => expect(mockCopyPaste).toHaveBeenCalled());
+    expect(props.navigate).not.toHaveBeenCalled();
+  });
+
+  test("外部文件拖入文件夹 → 查询目标目录占用并入队", async () => {
+    renderMain();
+    await waitFor(() => expect(screen.getByText("docs")).toBeInTheDocument());
+    const dropped = new File(["x"], "drop.txt");
+    mockCollect.mockResolvedValue([dropped]);
+    const dt = { getData: () => "" } as unknown as DataTransfer;
+    fireEvent.drop(screen.getByText("docs"), { dataTransfer: dt });
+    await waitFor(() =>
+      expect(mockEnqueue).toHaveBeenCalledWith({ file: dropped, basedir: "docs/" })
+    );
+  });
+
+  test("内部拖拽仅自身时不动作", async () => {
+    renderMain();
+    await waitFor(() => expect(screen.getByText("docs")).toBeInTheDocument());
+    const dt = { getData: () => '["docs"]' } as unknown as DataTransfer;
+    fireEvent.drop(screen.getByText("docs"), { dataTransfer: dt });
+    await delay();
+    expect(mockCopyPaste).not.toHaveBeenCalled();
+  });
+});
+
+describe("Main 上传完成刷新列表", () => {
+  test("活动上传数归零时重新拉取列表", async () => {
+    mockQueueTasks = [
+      {
+        id: "t1",
+        type: "upload",
+        status: "in-progress",
+        name: "x.txt",
+        basedir: "",
+        remoteKey: "x.txt",
+        loaded: 0,
+        total: 1,
+      } as TransferTask,
+    ];
+    const { props, rerender } = renderMain();
+    await waitFor(() => expect(mockFetchPath).toHaveBeenCalledTimes(1));
+    mockQueueTasks = [];
+    await act(async () => {
+      rerender(
+        <ClipboardProvider>
+          <Main {...props} />
+        </ClipboardProvider>
+      );
+    });
+    await waitFor(() => expect(mockFetchPath.mock.calls.length).toBeGreaterThanOrEqual(2));
+  });
+});

--- a/src/app/__tests__/PreviewDialogExtra.test.tsx
+++ b/src/app/__tests__/PreviewDialogExtra.test.tsx
@@ -1,0 +1,347 @@
+/**
+ * PreviewDialog 覆盖补充：图片缩放（滚轮/双击/复位）、指针平移、旋转补偿、
+ * 视频倍速、翻页 pager（按钮 + 键盘 + 输入框保护）、文本下载/复制失败、超限流式分支。
+ */
+import React from "react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+import PreviewDialog from "../../PreviewDialog";
+import { authFetch } from "../auth";
+import { setLang, strings } from "../strings";
+import { FileItem } from "../types";
+
+jest.mock("../auth", () => ({
+  authFetch: jest.fn(),
+}));
+
+jest.mock("../transfer", () => ({
+  downloadFile: jest.fn(),
+}));
+
+const mockAuthFetch = authFetch as unknown as jest.Mock;
+
+const img: FileItem = {
+  key: "a.png",
+  name: "a.png",
+  isDir: false,
+  size: 4,
+  uploaded: "",
+  contentType: "image/png",
+};
+
+const img2: FileItem = { ...img, key: "b.png", name: "b.png" };
+const img3: FileItem = { ...img, key: "c.png", name: "c.png" };
+
+function blobFetch(type: string) {
+  return {
+    ok: true,
+    headers: { get: () => null },
+    blob: async () => new Blob(["xx"], { type }),
+    body: null,
+  };
+}
+
+function textReaderResponse(text: string) {
+  const bytes = new TextEncoder().encode(text);
+  return {
+    ok: true,
+    headers: { get: () => String(bytes.length) },
+    body: {
+      getReader: () => {
+        let done = false;
+        return {
+          read: async () => {
+            if (done) return { done: true, value: undefined };
+            done = true;
+            return { done: false, value: bytes };
+          },
+          cancel: async () => {},
+        };
+      },
+    },
+  };
+}
+
+function renderPreview(file: FileItem, siblings: FileItem[] = [img], onSibling = jest.fn()) {
+  const onNotify = jest.fn();
+  const onClose = jest.fn();
+  const utils = render(
+    <PreviewDialog
+      file={file}
+      siblings={siblings}
+      onSibling={siblings.length > 1 ? onSibling : undefined}
+      onClose={onClose}
+      onNotify={onNotify}
+      onShare={jest.fn()}
+      onRename={jest.fn()}
+      onDelete={jest.fn()}
+    />
+  );
+  return { ...utils, onNotify, onClose, onSibling };
+}
+
+beforeEach(() => {
+  setLang("zh");
+  mockAuthFetch.mockReset();
+  (URL as any).createObjectURL = jest.fn(() => "blob:preview");
+  (URL as any).revokeObjectURL = jest.fn();
+  // jsdom 未实现 Pointer Capture，补最小桩
+  HTMLElement.prototype.setPointerCapture = jest.fn();
+  HTMLElement.prototype.releasePointerCapture = jest.fn();
+  (HTMLElement.prototype as any).hasPointerCapture = jest.fn(() => false);
+});
+
+// 旋转按钮是图标（无文本、无 aria-label），从 DialogActions 里挑出唯一的纯图标按钮
+function clickRotateButton() {
+  const actionsEl = document.querySelector(".MuiDialogActions-root")!;
+  const iconOnly = Array.from(actionsEl.querySelectorAll("button")).find(
+    (b) => b.querySelector("svg") && !(b.textContent || "").trim()
+  );
+  expect(iconOnly).toBeTruthy();
+  fireEvent.click(iconOnly!);
+}
+
+describe("PreviewDialog 图片缩放/平移/旋转", () => {
+  test("滚轮缩放放大/缩小并显示比例", async () => {
+    mockAuthFetch.mockResolvedValue(blobFetch("image/png"));
+    renderPreview(img);
+    await waitFor(() => expect(document.querySelector("img")).toBeTruthy());
+    const imgEl = document.querySelector("img")!;
+    // 放大 1.1^2 ≈ 121%
+    fireEvent.wheel(imgEl, { deltaY: -100 });
+    fireEvent.wheel(imgEl, { deltaY: -100 });
+    await waitFor(() => expect(screen.getByText("121%")).toBeInTheDocument());
+    // 缩小回 110% 附近
+    fireEvent.wheel(imgEl, { deltaY: 100 });
+    await waitFor(() => expect(screen.getByText("110%")).toBeInTheDocument());
+  });
+
+  test("滚轮缩放钳制到 [0.25, 4]", async () => {
+    mockAuthFetch.mockResolvedValue(blobFetch("image/png"));
+    renderPreview(img);
+    await waitFor(() => expect(document.querySelector("img")).toBeTruthy());
+    const imgEl = document.querySelector("img")!;
+    for (let i = 0; i < 40; i++) fireEvent.wheel(imgEl, { deltaY: -100 });
+    await waitFor(() => expect(screen.getByText("400%")).toBeInTheDocument());
+    for (let i = 0; i < 60; i++) fireEvent.wheel(imgEl, { deltaY: 100 });
+    await waitFor(() => expect(screen.getByText("25%")).toBeInTheDocument());
+  });
+
+  test("双击在 2.5x 与 1x 间切换并复位偏移", async () => {
+    mockAuthFetch.mockResolvedValue(blobFetch("image/png"));
+    renderPreview(img);
+    await waitFor(() => expect(document.querySelector("img")).toBeTruthy());
+    const imgEl = document.querySelector("img")!;
+    fireEvent.dblClick(imgEl);
+    await waitFor(() => expect(screen.getByText("250%")).toBeInTheDocument());
+    fireEvent.dblClick(imgEl);
+    await waitFor(() => expect(screen.getByText("100%")).toBeInTheDocument());
+  });
+
+  test("指针拖拽平移图片并更新 transform", async () => {
+    mockAuthFetch.mockResolvedValue(blobFetch("image/png"));
+    renderPreview(img);
+    await waitFor(() => expect(document.querySelector("img")).toBeTruthy());
+    const imgEl = document.querySelector("img") as HTMLImageElement;
+    // jsdom 无 PointerEvent 构造器，直接派发带坐标的 Event
+    const pointer = (type: string, clientX: number, clientY: number) => {
+      const event = new Event(type, { bubbles: true, cancelable: true });
+      Object.assign(event, { clientX, clientY, pointerId: 1 });
+      return event;
+    };
+    fireEvent(imgEl, pointer("pointerdown", 10, 10));
+    fireEvent(imgEl, pointer("pointermove", 40, 35));
+    await waitFor(() =>
+      expect(imgEl.style.transform).toContain("translate(30px, 25px)")
+    );
+    fireEvent(imgEl, pointer("pointerup", 40, 35));
+    // 松开后再次 move 不再平移
+    fireEvent(imgEl, pointer("pointermove", 100, 100));
+    expect(imgEl.style.transform).toContain("translate(30px, 25px)");
+  });
+
+  test("旋转 90° 后按容器重新收敛 rotFit，比例按钮点击复位缩放", async () => {
+    mockAuthFetch.mockResolvedValue(blobFetch("image/png"));
+    renderPreview(img);
+    await waitFor(() => expect(document.querySelector("img")).toBeTruthy());
+    const imgEl = document.querySelector("img") as HTMLImageElement;
+    const stage = imgEl.parentElement as HTMLElement;
+    Object.defineProperty(imgEl, "clientWidth", { value: 400, configurable: true });
+    Object.defineProperty(imgEl, "clientHeight", { value: 300, configurable: true });
+    jest
+      .spyOn(stage, "getBoundingClientRect")
+      .mockReturnValue({ width: 200, height: 100, top: 0, left: 0, bottom: 0, right: 0, x: 0, y: 0, toJSON: () => ({}) } as DOMRect);
+
+    // 放大到 2x 后旋转：rotFit = min(1, 200/300, 100/400) = 0.25 → 2 * 0.25 = 50%
+    fireEvent.wheel(imgEl, { deltaY: -100 });
+    fireEvent.wheel(imgEl, { deltaY: -100 });
+    await waitFor(() => expect(screen.getByText("121%")).toBeInTheDocument());
+    // 放大到 1.21x，旋转 90°：rotFit = min(1, 200/300, 100/400) = 0.25 → 1.21*0.25 ≈ 30%
+    clickRotateButton();
+    await waitFor(() => expect(screen.getByText("30%")).toBeInTheDocument());
+    // 点击比例按钮复位缩放（rotFit 仍 0.25 → 25%）
+    fireEvent.click(screen.getByText("30%"));
+    await waitFor(() => expect(screen.getByText("25%")).toBeInTheDocument());
+  });
+
+  test("旋转 180° 不再补偿（rotFit 回 1）", async () => {
+    mockAuthFetch.mockResolvedValue(blobFetch("image/png"));
+    renderPreview(img);
+    await waitFor(() => expect(document.querySelector("img")).toBeTruthy());
+    clickRotateButton();
+    clickRotateButton();
+    // rotation 180 → % 180 === 0 → rotFit 回 1
+    await waitFor(() => expect(screen.getByText("100%")).toBeInTheDocument());
+  });
+});
+
+describe("PreviewDialog 视频倍速", () => {
+  test("倍速按钮循环 1 → 1.5 → 2 → 0.5 → 1 并写入 playbackRate", async () => {
+    mockAuthFetch.mockResolvedValue(blobFetch("video/mp4"));
+    const video: FileItem = { ...img, key: "a.mp4", name: "a.mp4", contentType: "video/mp4" };
+    renderPreview(video);
+    await waitFor(() => expect(document.querySelector("video")).toBeTruthy());
+    const videoEl = document.querySelector("video") as HTMLVideoElement;
+    const rateBtn = screen.getByText("1x");
+    fireEvent.click(rateBtn);
+    expect(screen.getByText("1.5x")).toBeInTheDocument();
+    expect(videoEl.playbackRate).toBe(1.5);
+    fireEvent.click(screen.getByText("1.5x"));
+    expect(screen.getByText("2x")).toBeInTheDocument();
+    fireEvent.click(screen.getByText("2x"));
+    expect(screen.getByText("0.5x")).toBeInTheDocument();
+    expect(videoEl.playbackRate).toBe(0.5);
+    fireEvent.click(screen.getByText("0.5x"));
+    expect(screen.getByText("1x")).toBeInTheDocument();
+    expect(videoEl.playbackRate).toBe(1);
+  });
+});
+
+describe("PreviewDialog 翻页 pager", () => {
+  test("prev/next 按钮按边界启停并回调 onSibling", async () => {
+    mockAuthFetch.mockResolvedValue(blobFetch("image/png"));
+    const onSibling = jest.fn();
+    const utils = renderPreview(img, [img, img2, img3], onSibling);
+    const prevBtn = screen.getByLabelText(strings.prevFile);
+    expect(prevBtn).toBeDisabled();
+    const nextBtn = screen.getByLabelText(strings.nextFile);
+    expect(nextBtn).toBeEnabled();
+    fireEvent.click(nextBtn);
+    expect(onSibling).toHaveBeenCalledWith(img2);
+
+    // 切到中间文件：两端都可点
+    utils.rerender(
+      <PreviewDialog
+        file={img2}
+        siblings={[img, img2, img3]}
+        onSibling={onSibling}
+        onClose={jest.fn()}
+        onNotify={jest.fn()}
+        onShare={jest.fn()}
+        onRename={jest.fn()}
+        onDelete={jest.fn()}
+      />
+    );
+    await waitFor(() => expect(screen.getByText("b.png")).toBeInTheDocument());
+    expect(screen.getByLabelText(strings.prevFile)).toBeEnabled();
+    expect(screen.getByLabelText(strings.nextFile)).toBeEnabled();
+
+    // 最后一个文件：next 禁用
+    utils.rerender(
+      <PreviewDialog
+        file={img3}
+        siblings={[img, img2, img3]}
+        onSibling={onSibling}
+        onClose={jest.fn()}
+        onNotify={jest.fn()}
+        onShare={jest.fn()}
+        onRename={jest.fn()}
+        onDelete={jest.fn()}
+      />
+    );
+    await waitFor(() => expect(screen.getByText("c.png")).toBeInTheDocument());
+    expect(screen.getByLabelText(strings.nextFile)).toBeDisabled();
+  });
+
+  test("键盘左右翻页，输入框聚焦时不抢按键", async () => {
+    mockAuthFetch.mockResolvedValue(blobFetch("image/png"));
+    const onSibling = jest.fn();
+    renderPreview(img, [img, img2], onSibling);
+    await waitFor(() => expect(document.querySelector("img")).toBeTruthy());
+    fireEvent.keyDown(window, { key: "ArrowRight" });
+    expect(onSibling).toHaveBeenCalledWith(img2);
+
+    const input = document.createElement("input");
+    document.body.appendChild(input);
+    input.focus();
+    fireEvent.keyDown(input, { key: "ArrowLeft" });
+    expect(onSibling).toHaveBeenCalledTimes(1);
+    input.remove();
+
+    // 未命中 sibling 的文件不翻页
+    fireEvent.keyDown(window, { key: "ArrowLeft" });
+    expect(onSibling).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("PreviewDialog 文本路径补充分支", () => {
+  test("流式读取超限 → 超限提示（header content-length 超限）", async () => {
+    const file: FileItem = {
+      key: "big.log",
+      name: "big.log",
+      isDir: false,
+      size: 1024,
+      uploaded: "",
+      contentType: "text/plain",
+    };
+    let canceled = false;
+    mockAuthFetch.mockResolvedValue({
+      ok: true,
+      headers: { get: (n: string) => (n.toLowerCase() === "content-length" ? String(5 * 1024 * 1024) : null) },
+      body: { cancel: async () => { canceled = true; } },
+    });
+    renderPreview(file);
+    await waitFor(() =>
+      expect(screen.getByText(strings.previewTooLargeTitle)).toBeInTheDocument()
+    );
+    expect(canceled).toBe(true);
+  });
+
+  test("纯文本下载走 blob 锚点", async () => {
+    mockAuthFetch.mockResolvedValue(textReaderResponse("hello world"));
+    const click = jest.fn();
+    const orig = document.createElement.bind(document);
+    jest.spyOn(document, "createElement").mockImplementation((tag: string) => {
+      const el = orig(tag);
+      if (tag === "a") (el as HTMLAnchorElement).click = click;
+      return el;
+    });
+    renderPreview({ ...img, key: "a.txt", name: "a.txt", contentType: "text/plain" });
+    await waitFor(() => expect(screen.getByText("hello world")).toBeInTheDocument());
+    fireEvent.click(screen.getByText(strings.download));
+    await waitFor(() => expect(click).toHaveBeenCalled());
+    (document.createElement as jest.Mock).mockRestore();
+  });
+
+  test("copyAll 失败时错误提示", async () => {
+    mockAuthFetch.mockResolvedValue(textReaderResponse("hello"));
+    Object.assign(navigator, {
+      clipboard: { writeText: jest.fn().mockRejectedValue(new Error("denied")) },
+    });
+    const { onNotify } = renderPreview({ ...img, key: "a.txt", name: "a.txt", contentType: "text/plain" });
+    await waitFor(() => expect(screen.getByText("hello")).toBeInTheDocument());
+    fireEvent.click(screen.getByText(strings.copyAll));
+    await waitFor(() => expect(onNotify).toHaveBeenCalledWith(expect.any(String), "error"));
+  });
+
+  test("关闭按钮回调 onClose 并 blur 当前焦点", async () => {
+    mockAuthFetch.mockResolvedValue(textReaderResponse("hello"));
+    const { onClose } = renderPreview({ ...img, key: "a.txt", name: "a.txt", contentType: "text/plain" });
+    await waitFor(() => expect(screen.getByText("hello")).toBeInTheDocument());
+    const blurSpy = jest.spyOn(HTMLElement.prototype, "blur");
+    fireEvent.click(screen.getByText(strings.close));
+    expect(onClose).toHaveBeenCalled();
+    expect(blurSpy).toHaveBeenCalled();
+    blurSpy.mockRestore();
+  });
+});

--- a/src/app/__tests__/apikeys.test.ts
+++ b/src/app/__tests__/apikeys.test.ts
@@ -14,21 +14,13 @@ import {
 } from "../apikeys";
 import { authFetch } from "../auth";
 import { getLang, setLang } from "../strings";
+import { asAuthFetchMock } from "../testUtils";
 
 jest.mock("../auth", () => ({
   authFetch: jest.fn(),
 }));
 
-const mockAuthFetch = authFetch as unknown as jest.Mock;
-
-function jsonResponse(body: unknown, ok = true, status = 200) {
-  return {
-    ok,
-    status,
-    json: async () => body,
-    text: async () => JSON.stringify(body),
-  } as unknown as Response;
-}
+const mockAuthFetch = asAuthFetchMock(authFetch);
 
 beforeEach(() => {
   mockAuthFetch.mockReset();
@@ -37,13 +29,13 @@ beforeEach(() => {
 describe("apikeys / listApiKeys", () => {
   test("成功返回 JSON", async () => {
     const keys = [{ id: "1", name: "k", prefix: "fd_", createdAt: "", expiresAt: null }];
-    mockAuthFetch.mockResolvedValue(jsonResponse(keys));
+    mockAuthFetch.mockOk(keys);
     await expect(listApiKeys()).resolves.toEqual(keys);
     expect(mockAuthFetch).toHaveBeenCalledWith("/api/keys");
   });
 
   test("失败抛出响应文本", async () => {
-    mockAuthFetch.mockResolvedValue({ ok: false, status: 500, text: async () => "boom" } as unknown as Response);
+    mockAuthFetch.mockError(500, "boom");
     await expect(listApiKeys()).rejects.toThrow("boom");
   });
 });
@@ -51,7 +43,7 @@ describe("apikeys / listApiKeys", () => {
 describe("apikeys / createApiKey", () => {
   test("携带可选参数与自定义 key", async () => {
     const created = { id: "1", name: "k", prefix: "fd_", createdAt: "", expiresAt: null, key: "fd_xxx" };
-    mockAuthFetch.mockResolvedValue(jsonResponse(created));
+    mockAuthFetch.mockOk(created);
     await createApiKey({ name: "k", expiresInHours: 24, key: "  custom  " });
     const [, init] = mockAuthFetch.mock.calls[0];
     expect(init.method).toBe("POST");
@@ -59,27 +51,27 @@ describe("apikeys / createApiKey", () => {
   });
 
   test("空可选参数不进 body", async () => {
-    mockAuthFetch.mockResolvedValue(jsonResponse({}));
+    mockAuthFetch.mockOk({});
     await createApiKey({ name: "k", expiresInHours: 0, key: "   " });
     const [, init] = mockAuthFetch.mock.calls[0];
     expect(JSON.parse(init.body)).toEqual({ name: "k" });
   });
 
   test("失败抛出响应文本", async () => {
-    mockAuthFetch.mockResolvedValue({ ok: false, status: 400, text: async () => "bad key" } as unknown as Response);
+    mockAuthFetch.mockError(400, "bad key");
     await expect(createApiKey({ name: "k" })).rejects.toThrow("bad key");
   });
 });
 
 describe("apikeys / revokeApiKey", () => {
   test("成功 DELETE", async () => {
-    mockAuthFetch.mockResolvedValue({ ok: true, status: 200 } as unknown as Response);
+    mockAuthFetch.mockOk({});
     await revokeApiKey("abc");
     expect(mockAuthFetch).toHaveBeenCalledWith("/api/keys?id=abc", { method: "DELETE" });
   });
 
   test("失败抛出响应文本", async () => {
-    mockAuthFetch.mockResolvedValue({ ok: false, status: 500, text: async () => "no" } as unknown as Response);
+    mockAuthFetch.mockError(500, "no");
     await expect(revokeApiKey("abc")).rejects.toThrow("no");
   });
 });

--- a/src/app/__tests__/features.test.ts
+++ b/src/app/__tests__/features.test.ts
@@ -5,21 +5,13 @@ import {
   parseAppConfig,
   patchFeatureFlags,
 } from "../features";
+import { asAuthFetchMock } from "../testUtils";
 
 jest.mock("../auth", () => ({
   authFetch: jest.fn(),
 }));
 
-const mockAuthFetch = authFetch as unknown as jest.Mock;
-
-function jsonResponse(body: unknown, ok = true, status = 200) {
-  return {
-    ok,
-    status,
-    json: async () => body,
-    text: async () => (ok ? JSON.stringify(body) : ""),
-  } as unknown as Response;
-}
+const mockAuthFetch = asAuthFetchMock(authFetch);
 
 beforeEach(() => {
   mockAuthFetch.mockReset();
@@ -68,33 +60,24 @@ describe("parseAppConfig", () => {
 
 describe("config client", () => {
   test("fetchAppConfig GETs /api/config", async () => {
-    mockAuthFetch.mockResolvedValue(
-      jsonResponse({ username: "a", publicRead: false, webdav: true })
-    );
+    mockAuthFetch.mockOk({ username: "a", publicRead: false, webdav: true });
     const config = await fetchAppConfig();
     expect(mockAuthFetch).toHaveBeenCalledWith("/api/config");
     expect(config.flags.webdav).toBe(true);
   });
 
   test("fetchAppConfig throws on empty error body", async () => {
-    mockAuthFetch.mockResolvedValue(jsonResponse({}, false, 500));
+    mockAuthFetch.mockError(500);
     await expect(fetchAppConfig()).rejects.toThrow();
   });
 
   test("fetchAppConfig uses response text when present", async () => {
-    mockAuthFetch.mockResolvedValue({
-      ok: false,
-      status: 500,
-      json: async () => ({}),
-      text: async () => "config-down",
-    } as unknown as Response);
+    mockAuthFetch.mockError(500, "config-down");
     await expect(fetchAppConfig()).rejects.toThrow("config-down");
   });
 
   test("patchFeatureFlags PATCHes flags", async () => {
-    mockAuthFetch.mockResolvedValue(
-      jsonResponse({ username: "a", publicRead: false, webdav: false })
-    );
+    mockAuthFetch.mockOk({ username: "a", publicRead: false, webdav: false });
     await patchFeatureFlags({ webdav: false });
     const [url, init] = mockAuthFetch.mock.calls[0];
     expect(url).toBe("/api/config");
@@ -103,12 +86,7 @@ describe("config client", () => {
   });
 
   test("patchFeatureFlags throws on failure", async () => {
-    mockAuthFetch.mockResolvedValue({
-      ok: false,
-      status: 400,
-      json: async () => ({}),
-      text: async () => "save-fail",
-    } as unknown as Response);
+    mockAuthFetch.mockError(400, "save-fail");
     await expect(patchFeatureFlags({ mcp: false })).rejects.toThrow("save-fail");
   });
 });

--- a/src/app/__tests__/featuresProvider.test.tsx
+++ b/src/app/__tests__/featuresProvider.test.tsx
@@ -3,13 +3,14 @@ import { act, render, screen, waitFor } from "@testing-library/react";
 
 import { authFetch, useAuth } from "../auth";
 import { FeaturesProvider, useFeatures } from "../features";
+import { asAuthFetchMock } from "../testUtils";
 
 jest.mock("../auth", () => ({
   authFetch: jest.fn(),
   useAuth: jest.fn(),
 }));
 
-const mockAuthFetch = authFetch as unknown as jest.Mock;
+const mockAuthFetch = asAuthFetchMock(authFetch);
 const mockUseAuth = useAuth as unknown as jest.Mock;
 
 function Probe() {
@@ -32,15 +33,6 @@ function Probe() {
   );
 }
 
-function jsonResponse(body: unknown, ok = true) {
-  return {
-    ok,
-    status: ok ? 200 : 500,
-    json: async () => body,
-    text: async () => (ok ? JSON.stringify(body) : "fail"),
-  } as unknown as Response;
-}
-
 beforeEach(() => {
   mockAuthFetch.mockReset();
   mockUseAuth.mockReset();
@@ -61,23 +53,19 @@ describe("FeaturesProvider", () => {
   test("loads config, swallows refresh errors, and patches flags", async () => {
     mockUseAuth.mockReturnValue({ username: "alice" });
     mockAuthFetch
-      .mockResolvedValueOnce(
-        jsonResponse({
-          username: "alice",
-          publicRead: true,
-          sitesHost: "sites.example.com",
-          webdav: true,
-        })
-      )
-      .mockResolvedValueOnce(jsonResponse({}, false))
-      .mockResolvedValueOnce(
-        jsonResponse({
-          username: "alice",
-          publicRead: false,
-          sitesHost: "",
-          webdav: false,
-        })
-      );
+      .mockOkOnce({
+        username: "alice",
+        publicRead: true,
+        sitesHost: "sites.example.com",
+        webdav: true,
+      })
+      .mockErrorOnce(500)
+      .mockOkOnce({
+        username: "alice",
+        publicRead: false,
+        sitesHost: "",
+        webdav: false,
+      });
 
     render(
       <FeaturesProvider>

--- a/src/app/__tests__/functionsLoader.test.ts
+++ b/src/app/__tests__/functionsLoader.test.ts
@@ -1,0 +1,71 @@
+/**
+ * functions 覆盖率收集专用套件。
+ *
+ * CRA 的 jest roots 固定为 src/，collectCoverageFrom 里匹配到的 functions/
+ * 文件如果从未被任何测试 import，就不会进入 istanbul 覆盖率统计（hasteFS
+ * 不索引 src 以外的路径，无法通过 package.json 的 jest 字段扩展 roots）。
+ * 这里把 functions/ 下全部模块显式加载一遍（只触发模块初始化，不执行
+ * handler），让后续的「后端 functions 直测」从真实基线开始棘轮。
+ */
+
+import * as shareRoute from "../../../functions/share/[[token]]";
+import * as webdavRoute from "../../../functions/webdav/[[path]]";
+import * as mcpRoute from "../../../functions/mcp";
+
+// 通用 helper / 常量模块
+import "../../../functions/_flags";
+import "../../../functions/_images";
+import "../../../functions/_mcp";
+import "../../../functions/_middleware";
+import "../../../functions/_sites";
+import "../../../functions/api/_apikey";
+import "../../../functions/api/_zip";
+import "../../../functions/webdav/protocol";
+
+// Pages Functions 入口（api/*）
+import "../../../functions/api/archive";
+import "../../../functions/api/backup";
+import "../../../functions/api/config";
+import "../../../functions/api/copy";
+import "../../../functions/api/counts";
+import "../../../functions/api/delete";
+import "../../../functions/api/download";
+import "../../../functions/api/images";
+import "../../../functions/api/keys";
+import "../../../functions/api/list";
+import "../../../functions/api/mkdir";
+import "../../../functions/api/rename";
+import "../../../functions/api/search";
+import "../../../functions/api/shares";
+import "../../../functions/api/sites";
+import "../../../functions/api/stat";
+import "../../../functions/api/trash";
+import "../../../functions/api/upload";
+
+function isHandler(value: unknown): boolean {
+  return typeof value === "function";
+}
+
+describe("functions modules load", () => {
+  test("route entrypoints export PagesFunction handlers", () => {
+    const handlers = [
+      [mcpRoute, "mcp.ts"],
+      [shareRoute, "share/[[token]].ts"],
+      [webdavRoute, "webdav/[[path]].ts"],
+    ] as Array<[Record<string, unknown>, string]>;
+
+    for (const [mod, name] of handlers) {
+      const hasHandler = Object.keys(mod).some(
+        (key) => key.startsWith("onRequest") && isHandler(mod[key])
+      );
+      expect({ name, hasHandler }).toEqual({ name, hasHandler: true });
+    }
+  });
+
+  test("webdav protocol re-exports a single onRequest entry", () => {
+    // functions/webdav/[[path]].ts 转发到 ./protocol
+    expect(typeof (webdavRoute as unknown as Record<string, unknown>).onRequest).toBe(
+      "function"
+    );
+  });
+});

--- a/src/app/__tests__/hooksExtra.test.tsx
+++ b/src/app/__tests__/hooksExtra.test.tsx
@@ -1,0 +1,584 @@
+/**
+ * hooks 覆盖补充：useKeyboardShortcuts / useMultiSelect / useDragDropUpload /
+ * usePasteUpload / useUploadInputs(transferKeys) 的分支缺口。
+ */
+import React from "react";
+import { act, fireEvent, render, renderHook, screen } from "@testing-library/react";
+
+import { useKeyboardShortcuts, KeyboardShortcutsParams } from "../useKeyboardShortcuts";
+import { useMultiSelect } from "../useMultiSelect";
+import { useDragDropUpload } from "../useDragDropUpload";
+import { usePasteUpload } from "../usePasteUpload";
+import { transferKeys, useUploadInputs } from "../useUploadInputs";
+import { useTransferQueue, useUploadEnqueue } from "../transferQueue";
+import { copyPaste, fetchPath } from "../transfer";
+import { FileItem } from "../types";
+
+jest.mock("../transferQueue", () => ({
+  useTransferQueue: jest.fn(() => []),
+  useUploadEnqueue: jest.fn(),
+}));
+
+jest.mock("../transfer", () => ({
+  collectFilesFromDataTransfer: jest.fn(),
+  copyPaste: jest.fn(),
+  fetchPath: jest.fn(),
+}));
+
+const mockCollect = require("../transfer").collectFilesFromDataTransfer as jest.Mock;
+const mockFetchPath = fetchPath as unknown as jest.Mock;
+const mockCopyPaste = copyPaste as unknown as jest.Mock;
+const mockUploadEnqueueFn = jest.fn();
+const mockUseUploadEnqueue = useUploadEnqueue as unknown as jest.Mock;
+const mockUseTransferQueue = useTransferQueue as unknown as jest.Mock;
+
+function makeFile(key: string, isDir = false): FileItem {
+  return {
+    key,
+    name: key.split("/").pop() || key,
+    isDir,
+    size: 1,
+    uploaded: "2026-01-01T00:00:00.000Z",
+    contentType: isDir ? "application/x-directory" : "text/plain",
+  };
+}
+
+const files = [
+  makeFile("a.txt"),
+  makeFile("b.txt"),
+  makeFile("c.md"),
+  makeFile("docs", true),
+];
+
+function setupShortcuts(overrides: Partial<KeyboardShortcutsParams> = {}) {
+  const params: KeyboardShortcutsParams = {
+    route: { kind: "folder", path: "docs/" },
+    visibleFiles: files,
+    selectedKeys: [],
+    focusedKey: null,
+    setSelectedKeys: jest.fn(),
+    setFocusedKey: jest.fn(),
+    moveFocused: jest.fn(),
+    jumpFocused: jest.fn(),
+    toggleSelect: jest.fn(),
+    selectAll: jest.fn(),
+    navigateFolder: jest.fn(),
+    onOpen: jest.fn(),
+    onRename: jest.fn(),
+    onDetails: jest.fn(),
+    onDelete: jest.fn(),
+    ...overrides,
+  };
+  const utils = renderHook(() => useKeyboardShortcuts(params));
+  // 同一测试内多次改参数时复用同一实例（旧实例若不卸载会残留 window 监听）
+  const update = (patch: Partial<KeyboardShortcutsParams>) => {
+    Object.assign(params, patch);
+    utils.rerender();
+  };
+  return { ...utils, params, update };
+}
+
+function withOverlay(body: () => void) {
+  const node = document.createElement("div");
+  node.className = "MuiModal-root";
+  document.body.appendChild(node);
+  try {
+    body();
+  } finally {
+    node.remove();
+  }
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockCollect.mockResolvedValue([]);
+  Element.prototype.scrollIntoView = jest.fn();
+  mockUseUploadEnqueue.mockReturnValue(mockUploadEnqueueFn);
+  mockUseTransferQueue.mockReturnValue([]);
+});
+
+describe("useKeyboardShortcuts", () => {
+  test("方向键/Home/End/Space/Ctrl+A 基础派发", () => {
+    const moveFocused = jest.fn();
+    const jumpFocused = jest.fn();
+    const toggleSelect = jest.fn();
+    const selectAll = jest.fn();
+    const { update } = setupShortcuts({ moveFocused, jumpFocused, toggleSelect, selectAll });
+
+    fireEvent.keyDown(window, { key: "ArrowDown", shiftKey: true });
+    fireEvent.keyDown(window, { key: "ArrowUp" });
+    fireEvent.keyDown(window, { key: "ArrowRight" });
+    fireEvent.keyDown(window, { key: "ArrowLeft", shiftKey: true });
+    expect(moveFocused).toHaveBeenNthCalledWith(1, 1, true);
+    expect(moveFocused).toHaveBeenNthCalledWith(2, -1, false);
+    expect(moveFocused).toHaveBeenNthCalledWith(3, 1, false);
+    expect(moveFocused).toHaveBeenNthCalledWith(4, -1, true);
+
+    fireEvent.keyDown(window, { key: "Home", shiftKey: true });
+    fireEvent.keyDown(window, { key: "End" });
+    expect(jumpFocused).toHaveBeenNthCalledWith(1, 0, true);
+    expect(jumpFocused).toHaveBeenNthCalledWith(2, files.length - 1, false);
+
+    update({ focusedKey: "a.txt" });
+    fireEvent.keyDown(window, { key: " " });
+    expect(toggleSelect).toHaveBeenCalledWith("a.txt");
+
+    fireEvent.keyDown(window, { key: "a", metaKey: true });
+    expect(selectAll).toHaveBeenCalled();
+  });
+
+  test("F2：焦点优先，其次唯一选中；无目标/文件缺失不动作", () => {
+    const onRename = jest.fn();
+    const { update } = setupShortcuts({ onRename });
+    fireEvent.keyDown(window, { key: "F2" });
+    expect(onRename).not.toHaveBeenCalled();
+
+    update({ focusedKey: "missing.txt" });
+    fireEvent.keyDown(window, { key: "F2" });
+    expect(onRename).not.toHaveBeenCalled();
+
+    update({ focusedKey: null, selectedKeys: ["b.txt"] });
+    fireEvent.keyDown(window, { key: "F2" });
+    expect(onRename).toHaveBeenCalledWith(files[1]);
+
+    update({ focusedKey: "c.md" });
+    fireEvent.keyDown(window, { key: "F2" });
+    expect(onRename).toHaveBeenCalledWith(files[2]);
+  });
+
+  test("I 键打开详情（与 F2 同型分支）", () => {
+    const onDetails = jest.fn();
+    setupShortcuts({ onDetails, selectedKeys: ["c.md"] });
+    fireEvent.keyDown(window, { key: "I" });
+    expect(onDetails).toHaveBeenCalledWith(files[2]);
+  });
+
+  test("Delete：选中组优先，其次焦点，无目标不动作", () => {
+    const onDelete = jest.fn();
+    const { update } = setupShortcuts({ onDelete });
+    fireEvent.keyDown(window, { key: "Delete" });
+    expect(onDelete).not.toHaveBeenCalled();
+
+    update({ focusedKey: "a.txt" });
+    fireEvent.keyDown(window, { key: "Delete" });
+    expect(onDelete).toHaveBeenCalledWith(["a.txt"]);
+
+    update({ selectedKeys: ["a.txt", "b.txt"], focusedKey: "c.md" });
+    fireEvent.keyDown(window, { key: "Delete" });
+    expect(onDelete).toHaveBeenCalledWith(["a.txt", "b.txt"]);
+  });
+
+  test("Enter：目录导航、文件打开、未命中不动作", () => {
+    const onOpen = jest.fn();
+    const navigateFolder = jest.fn();
+    const { update } = setupShortcuts({ onOpen, navigateFolder, selectedKeys: ["docs"] });
+    fireEvent.keyDown(window, { key: "Enter" });
+    expect(navigateFolder).toHaveBeenCalledWith("docs");
+    expect(onOpen).not.toHaveBeenCalled();
+
+    update({ selectedKeys: ["a.txt"] });
+    fireEvent.keyDown(window, { key: "Enter" });
+    expect(onOpen).toHaveBeenCalledWith("a.txt");
+
+    update({ selectedKeys: ["ghost.txt"] });
+    fireEvent.keyDown(window, { key: "Enter" });
+    expect(onOpen).toHaveBeenCalledTimes(1);
+  });
+
+  test("Backspace 仅在文件夹路由返回上级", () => {
+    const navigateFolder = jest.fn();
+    const { update } = setupShortcuts({ navigateFolder, route: { kind: "shares" } });
+    fireEvent.keyDown(window, { key: "Backspace" });
+    expect(navigateFolder).not.toHaveBeenCalled();
+
+    update({ route: { kind: "folder", path: "docs/sub/" } });
+    fireEvent.keyDown(window, { key: "Backspace" });
+    expect(navigateFolder).toHaveBeenCalledWith("docs/");
+  });
+
+  test("Escape 清空选择与焦点；无选中时不动作", () => {
+    const setSelectedKeys = jest.fn();
+    const setFocusedKey = jest.fn();
+    const { update } = setupShortcuts({
+      setSelectedKeys,
+      setFocusedKey,
+      selectedKeys: ["a.txt"],
+    });
+    fireEvent.keyDown(window, { key: "Escape" });
+    expect(setSelectedKeys).toHaveBeenCalledWith([]);
+    expect(setFocusedKey).toHaveBeenCalledWith(null);
+
+    update({ selectedKeys: [], focusedKey: null });
+    fireEvent.keyDown(window, { key: "Escape" });
+    expect(setSelectedKeys).toHaveBeenCalledTimes(1);
+  });
+
+  test("输入框聚焦与输入法组合时忽略所有快捷键", () => {
+    const moveFocused = jest.fn();
+    setupShortcuts({ moveFocused });
+    const input = document.createElement("input");
+    document.body.appendChild(input);
+    input.focus();
+    fireEvent.keyDown(window, { key: "ArrowDown" });
+    expect(moveFocused).not.toHaveBeenCalled();
+    fireEvent.keyDown(window, { key: "Escape", isComposing: true });
+    fireEvent.keyDown(window, { key: "Process" });
+    expect(moveFocused).not.toHaveBeenCalled();
+    input.blur();
+    input.remove();
+  });
+
+  test("存在打开的浮层时忽略快捷键", () => {
+    const moveFocused = jest.fn();
+    const setSelectedKeys = jest.fn();
+    setupShortcuts({ moveFocused, setSelectedKeys, selectedKeys: ["a.txt"] });
+    withOverlay(() => {
+      fireEvent.keyDown(window, { key: "ArrowDown" });
+      fireEvent.keyDown(window, { key: "Escape" });
+      fireEvent.keyDown(window, { key: "Delete" });
+    });
+    expect(moveFocused).not.toHaveBeenCalled();
+    expect(setSelectedKeys).not.toHaveBeenCalled();
+  });
+});
+
+describe("useMultiSelect", () => {
+  function SelectionProbe() {
+    const s = useMultiSelect(files);
+    return (
+      <div>
+        {files.map((file) => (
+          <button
+            key={file.key}
+            data-file-key={file.key}
+            data-selected={s.selectedKeys.includes(file.key) ? "1" : "0"}
+            data-focused={s.focusedKey === file.key ? "1" : "0"}
+            onClick={(event) => s.toggleSelect(file.key, event)}
+          >
+            {file.key}
+          </button>
+        ))}
+        <button onClick={() => s.jumpFocused(99, true)}>jump-end</button>
+        <button onClick={() => s.moveFocused(-5, false)}>move-before</button>
+        <button onClick={() => s.moveFocused(1, true)}>move-next-extend</button>
+        <button onClick={() => s.selectAll()}>select-all</button>
+      </div>
+    );
+  }
+
+  const selectedOf = (container: HTMLElement) =>
+    Array.from(container.querySelectorAll("[data-selected='1']")).map(
+      (n) => n.getAttribute("data-file-key")
+    );
+
+  test("toggle 增减与 shift 点击", () => {
+    const utils = render(<SelectionProbe />);
+    fireEvent.click(screen.getByText("a.txt"));
+    expect(selectedOf(utils.container)).toEqual(["a.txt"]);
+    // 再点一次取消
+    fireEvent.click(screen.getByText("a.txt"));
+    expect(selectedOf(utils.container)).toEqual([]);
+
+    // shift 范围选择：anchor 与点击目标之间的所有项都并入选中
+    fireEvent.click(screen.getByText("a.txt"));
+    fireEvent.click(screen.getByText("c.md"), { shiftKey: true });
+    expect(selectedOf(utils.container)).toEqual(["a.txt", "b.txt", "c.md"]);
+  });
+
+  test("shift 反向点击同样覆盖 anchor 到目标的范围", () => {
+    const utils = render(<SelectionProbe />);
+    fireEvent.click(screen.getByText("c.md"));
+    fireEvent.click(screen.getByText("a.txt"), { shiftKey: true });
+    expect(selectedOf(utils.container)).toEqual(["a.txt", "b.txt", "c.md"]);
+  });
+
+  test("shift 但 anchor 已失效时退化为普通 toggle", () => {
+    const utils = render(<SelectionProbe />);
+    // anchor 是 a.txt，但点一个不在 visibleFiles 的 key 没有入口；
+    // 用未选过 anchor 的 shift 点击（selectionAnchor 为 null）
+    fireEvent.click(screen.getByText("b.txt"), { shiftKey: true });
+    expect(selectedOf(utils.container)).toEqual(["b.txt"]);
+  });
+
+  test("moveFocused / jumpFocused 越界收敛并滚动定位", () => {
+    const focusSpy = jest.spyOn(HTMLElement.prototype, "focus");
+    render(<SelectionProbe />);
+    fireEvent.click(screen.getByText("move-before"));
+    // 焦点收敛到第一项
+    expect(document.querySelector("[data-focused='1']")?.getAttribute("data-file-key")).toBe("a.txt");
+    fireEvent.click(screen.getByText("move-next-extend"));
+    expect(selectedOf(document.body)).toEqual(["b.txt"]);
+    fireEvent.click(screen.getByText("jump-end"));
+    // index 越界收敛到最后一项（files 含目录 docs）
+    expect(
+      document.querySelector("[data-focused='1']")?.getAttribute("data-file-key")
+    ).toBe("docs");
+    expect(focusSpy).toHaveBeenCalled();
+    focusSpy.mockRestore();
+  });
+
+  test("空列表时移动/跳转不崩", () => {
+    function Empty() {
+      const s = useMultiSelect([]);
+      return <button onClick={() => s.moveFocused(1, false)}>mv</button>;
+    }
+    render(<Empty />);
+    expect(() => fireEvent.click(screen.getByText("mv"))).not.toThrow();
+  });
+
+  test("selectAll 全选/再按清空", () => {
+    const utils = render(<SelectionProbe />);
+    fireEvent.click(screen.getByText("select-all"));
+    expect(selectedOf(utils.container)).toHaveLength(4);
+    fireEvent.click(screen.getByText("select-all"));
+    expect(selectedOf(utils.container)).toHaveLength(0);
+  });
+});
+
+describe("useDragDropUpload", () => {
+  type DropProps = { active: boolean; enqueueToCwd: (files: File[]) => void };
+  function setup(active = true, enqueue = jest.fn()) {
+    const utils = renderHook(
+      (props: DropProps) => useDragDropUpload(props),
+      { initialProps: { active, enqueueToCwd: enqueue } }
+    );
+    return { ...utils, enqueue };
+  }
+
+  function dragEvent(
+    type: "dragenter" | "dragleave" | "dragover" | "drop",
+    types?: string[],
+    filesArr?: File[]
+  ) {
+    const event = new Event(type, { bubbles: true, cancelable: true }) as DragEvent;
+    Object.defineProperty(event, "dataTransfer", {
+      value: { types: types ?? ["Files"], files: filesArr ?? [] },
+    });
+    return event;
+  }
+
+  test("dragenter 显示遮罩，dragover 阻止默认，dragleave 计数归零隐藏", () => {
+    const utils = setup();
+    act(() => window.dispatchEvent(dragEvent("dragenter")));
+    expect(utils.result.current).toBe(true);
+    const over = dragEvent("dragover");
+    expect(() => act(() => window.dispatchEvent(over))).not.toThrow();
+    expect(over.defaultPrevented).toBe(true);
+    act(() => window.dispatchEvent(dragEvent("dragleave")));
+    expect(utils.result.current).toBe(false);
+  });
+
+  test("非文件拖拽不触发遮罩也不 preventDefault", () => {
+    const utils = setup();
+    act(() => window.dispatchEvent(dragEvent("dragenter", ["text/plain"])));
+    expect(utils.result.current).toBe(false);
+    const over = dragEvent("dragover", ["text/plain"]);
+    act(() => window.dispatchEvent(over));
+    expect(over.defaultPrevented).toBe(false);
+  });
+
+  test("drop 收集文件并入队", async () => {
+    const enqueue = jest.fn();
+    mockCollect.mockResolvedValueOnce([new File(["x"], "drop.txt")]);
+    const utils = setup(true, enqueue);
+    act(() => window.dispatchEvent(dragEvent("dragenter")));
+    await act(async () => {
+      window.dispatchEvent(dragEvent("drop", ["Files"]));
+    });
+    expect(utils.result.current).toBe(false);
+    expect(enqueue).toHaveBeenCalledTimes(1);
+    expect(enqueue.mock.calls[0][0][0].name).toBe("drop.txt");
+  });
+
+  test("drop 无文件不入队", async () => {
+    const enqueue = jest.fn();
+    setup(true, enqueue);
+    await act(async () => {
+      window.dispatchEvent(dragEvent("drop"));
+    });
+    expect(enqueue).not.toHaveBeenCalled();
+  });
+
+  test("active 关闭时重置遮罩与深度", () => {
+    const utils = setup(true);
+    act(() => window.dispatchEvent(dragEvent("dragenter")));
+    expect(utils.result.current).toBe(true);
+    act(() => utils.rerender({ active: false, enqueueToCwd: jest.fn() }));
+    expect(utils.result.current).toBe(false);
+    // 重新激活后计数从 0 开始
+    act(() => utils.rerender({ active: true, enqueueToCwd: jest.fn() }));
+    act(() => window.dispatchEvent(dragEvent("dragenter")));
+    act(() => window.dispatchEvent(dragEvent("dragleave")));
+    expect(utils.result.current).toBe(false);
+  });
+
+  test("多余 dragleave 不会把计数打成负数", () => {
+    const utils = setup();
+    act(() => window.dispatchEvent(dragEvent("dragleave")));
+    expect(utils.result.current).toBe(false);
+    act(() => window.dispatchEvent(dragEvent("dragenter")));
+    act(() => window.dispatchEvent(dragEvent("dragleave")));
+    expect(utils.result.current).toBe(false);
+  });
+});
+
+describe("usePasteUpload", () => {
+  function setup(enqueue = jest.fn(), onNotify = jest.fn()) {
+    renderHook(() =>
+      usePasteUpload({ active: true, enqueueToCwd: enqueue, onNotify })
+    );
+    return { enqueue, onNotify };
+  }
+
+  function pasteEvent(items: unknown[], target?: EventTarget) {
+    const event = new Event("paste", { bubbles: true, cancelable: true }) as ClipboardEvent;
+    Object.defineProperty(event, "clipboardData", { value: { items } });
+    Object.defineProperty(event, "target", { value: target ?? document.body });
+    return event;
+  }
+
+  test("剪贴板文件入队；普通命名保留、无名图片盖时间戳", () => {
+    const { enqueue, onNotify } = setup();
+    const named = new File(["a"], "photo.jpg", { type: "image/jpeg" });
+    const generic = new File(["b"], "image.png", { type: "image/png" });
+    const items = [
+      { kind: "string" },
+      { kind: "file", getAsFile: () => null },
+      { kind: "file", getAsFile: () => named },
+      { kind: "file", getAsFile: () => generic },
+    ];
+    act(() => {
+      window.dispatchEvent(pasteEvent(items));
+    });
+    expect(enqueue).toHaveBeenCalledTimes(1);
+    const queued = enqueue.mock.calls[0][0] as File[];
+    expect(queued[0].name).toBe("photo.jpg");
+    expect(queued[1].name).not.toBe("image.png");
+    expect(queued[1].type).toBe("image/png");
+    expect(onNotify).toHaveBeenCalled();
+  });
+
+  test("无剪贴板数据 / 无文件 / 输入框聚焦时不动作", () => {
+    const { enqueue } = setup();
+    const noData = new Event("paste") as ClipboardEvent;
+    act(() => window.dispatchEvent(noData));
+    expect(enqueue).not.toHaveBeenCalled();
+
+    act(() => window.dispatchEvent(pasteEvent([])));
+    expect(enqueue).not.toHaveBeenCalled();
+
+    const input = document.createElement("input");
+    document.body.appendChild(input);
+    input.focus();
+    const file = new File(["a"], "a.png", { type: "image/png" });
+    act(() => {
+      window.dispatchEvent(
+        pasteEvent([{ kind: "file", getAsFile: () => file }], input)
+      );
+    });
+    expect(enqueue).not.toHaveBeenCalled();
+    input.remove();
+  });
+});
+
+describe("useUploadInputs / transferKeys", () => {
+  test("cut 模式跳过同目录子项", async () => {
+    mockFetchPath.mockResolvedValue([]);
+    mockCopyPaste.mockResolvedValue(undefined);
+    // "docs/x" 的 parent 是 "docs/"，与目标相同 → 跳过
+    await transferKeys(["docs/x", "docs/y"], "docs/", "cut");
+    expect(mockCopyPaste).not.toHaveBeenCalled();
+
+    // 不同父目录则正常 MOVE
+    await transferKeys(["other/a.txt"], "docs/", "cut");
+    expect(mockCopyPaste).toHaveBeenCalledWith("other/a.txt", "docs/a.txt", true);
+  });
+
+  test("目标目录同名自动追加序号", async () => {
+    mockFetchPath.mockResolvedValue([makeFile("a.txt")]);
+    mockCopyPaste.mockResolvedValue(undefined);
+    await transferKeys(["src/a.txt"], "", "copy");
+    // 产品 uniqueName 首个重名编号跳过 (1) 直接用 (2)（见汇报观察）
+    expect(mockCopyPaste).toHaveBeenCalledWith("src/a.txt", "a (2).txt", false);
+  });
+
+  test("fetchPath 失败按空目录处理", async () => {
+    mockFetchPath.mockRejectedValue(new Error("boom"));
+    mockCopyPaste.mockResolvedValue(undefined);
+    await transferKeys(["a.txt"], "", "copy");
+    expect(mockCopyPaste).toHaveBeenCalledWith("a.txt", "a.txt", false);
+  });
+});
+
+describe("useUploadInputs takenForCwd", () => {
+  function Probe({ cwd, list }: { cwd: string; list: FileItem[] }) {
+    const { takenForCwd, enqueueToDir } = useUploadInputs({ cwd, files: list });
+    return (
+      <button onClick={() => enqueueToDir([new File(["x"], "dup.txt")], cwd, takenForCwd)}>
+        enq
+      </button>
+    );
+  }
+
+  test("进行中任务占位名参与重名规避（renamed 入队）", () => {
+    mockUploadEnqueueFn.mockReset();
+    const task = {
+      id: "t1",
+      type: "upload",
+      status: "in-progress",
+      name: "dup.txt",
+      basedir: "docs/",
+      remoteKey: "docs/dup.txt",
+      loaded: 0,
+      total: 1,
+    };
+    mockUseTransferQueue.mockReturnValue([task]);
+    render(<Probe cwd="docs/" list={[]} />);
+    fireEvent.click(screen.getByText("enq"));
+    const queued = mockUploadEnqueueFn.mock.calls[0] as Array<{
+      file: File;
+      basedir: string;
+    }>;
+    expect(queued[0].file.name).toBe("dup (2).txt");
+    expect(queued[0].basedir).toBe("docs/");
+  });
+
+  test("canceled/completed 与非本目录任务不占名，非 upload 任务跳过", () => {
+    mockUploadEnqueueFn.mockReset();
+    mockUseTransferQueue.mockReturnValue([
+      { id: "1", type: "download", status: "in-progress", name: "x", basedir: "docs/", remoteKey: "docs/x" },
+      { id: "2", type: "upload", status: "canceled", name: "dup.txt", basedir: "docs/", remoteKey: "docs/dup.txt" },
+      { id: "3", type: "upload", status: "completed", name: "dup.txt", basedir: "docs/", remoteKey: "docs/dup.txt" },
+      { id: "4", type: "upload", status: "in-progress", name: "dup.txt", basedir: "other/", remoteKey: "other/dup.txt" },
+    ]);
+    render(<Probe cwd="docs/" list={[]} />);
+    fireEvent.click(screen.getByText("enq"));
+    const queued = mockUploadEnqueueFn.mock.calls[0] as Array<{
+      file: File;
+    }>;
+    expect(queued[0].file.name).toBe("dup.txt");
+  });
+
+  test("remoteKey 不以 cwd 开头时回退 task.name 占位", () => {
+    mockUploadEnqueueFn.mockReset();
+    mockUseTransferQueue.mockReturnValue([
+      { id: "5", type: "upload", status: "in-progress", name: "dup.txt", basedir: "docs/", remoteKey: "elsewhere/dup.txt" },
+    ]);
+    render(<Probe cwd="docs/" list={[]} />);
+    fireEvent.click(screen.getByText("enq"));
+    const queued = mockUploadEnqueueFn.mock.calls[0] as Array<{ file: File }>;
+    expect(queued[0].file.name).toBe("dup (2).txt");
+  });
+
+  test("空入队列表不触发 uploadEnqueue", () => {
+    mockUploadEnqueueFn.mockReset();
+    mockUseTransferQueue.mockReturnValue([]);
+    function EmptyProbe() {
+      const { enqueueToDir } = useUploadInputs({ cwd: "", files: [] });
+      return <button onClick={() => enqueueToDir([], "", [])}>empty</button>;
+    }
+    render(<EmptyProbe />);
+    fireEvent.click(screen.getByText("empty"));
+    expect(mockUploadEnqueueFn).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/__tests__/imagesClient.test.ts
+++ b/src/app/__tests__/imagesClient.test.ts
@@ -1,20 +1,12 @@
 import { authFetch } from "../auth";
 import { deleteImage, listImages, uploadImage } from "../images";
+import { asAuthFetchMock } from "../testUtils";
 
 jest.mock("../auth", () => ({
   authFetch: jest.fn(),
 }));
 
-const mockAuthFetch = authFetch as unknown as jest.Mock;
-
-function jsonResponse(body: unknown, ok = true, status = 200) {
-  return {
-    ok,
-    status,
-    json: async () => body,
-    text: async () => JSON.stringify(body),
-  } as unknown as Response;
-}
+const mockAuthFetch = asAuthFetchMock(authFetch);
 
 beforeEach(() => {
   mockAuthFetch.mockReset();
@@ -22,13 +14,13 @@ beforeEach(() => {
 
 describe("images client", () => {
   test("listImages GETs /api/images", async () => {
-    mockAuthFetch.mockResolvedValue(jsonResponse({ sitesHost: null, images: [] }));
+    mockAuthFetch.mockOk({ sitesHost: null, images: [] });
     await listImages();
     expect(mockAuthFetch).toHaveBeenCalledWith("/api/images");
   });
 
   test("uploadImage POSTs the file with original name header", async () => {
-    mockAuthFetch.mockResolvedValue(jsonResponse({ id: "x", name: "a.png" }, true, 201));
+    mockAuthFetch.mockOk({ id: "x", name: "a.png" }, 201);
     const file = new File([new Uint8Array([1, 2, 3])], "a.png", { type: "image/png" });
     await uploadImage(file);
     const [url, init] = mockAuthFetch.mock.calls[0];
@@ -39,7 +31,7 @@ describe("images client", () => {
   });
 
   test("deleteImage DELETEs by id", async () => {
-    mockAuthFetch.mockResolvedValue(jsonResponse({ deleted: true }));
+    mockAuthFetch.mockOk({ deleted: true });
     await deleteImage("ab".repeat(16));
     const [url, init] = mockAuthFetch.mock.calls[0];
     expect(url).toBe(`/api/images?id=${"ab".repeat(16)}`);

--- a/src/app/__tests__/mcp.test.ts
+++ b/src/app/__tests__/mcp.test.ts
@@ -18,57 +18,39 @@ import {
   dispatchMcpRequest,
   mcpJsonHasRawSecrets,
   parseJsonRpcBody,
-  type JsonRpcRequest,
   type ToolCallApis,
 } from "../../../functions/_mcp";
-
-function rpc(partial: Partial<JsonRpcRequest> & { method: string }): JsonRpcRequest {
-  const hasId = partial.hasId !== undefined ? partial.hasId : true;
-  return {
-    jsonrpc: "2.0",
-    id: hasId ? (partial.id ?? 1) : undefined,
-    method: partial.method,
-    params: partial.params,
-    hasId,
-  };
-}
-
-function jsonResponse(body: unknown, status = 200) {
-  return new Response(JSON.stringify(body), {
-    status,
-    headers: { "Content-Type": "application/json; charset=utf-8" },
-  });
-}
+import { httpJsonResponse, rpc } from "../testUtils";
 
 function mockApis(overrides: Partial<ToolCallApis> = {}): ToolCallApis {
   return {
-    list: async () => jsonResponse({ items: [] }),
-    upload: async () => jsonResponse({ key: "notes.txt", overwritten: false }, 201),
+    list: async () => httpJsonResponse({ items: [] }),
+    upload: async () => httpJsonResponse({ key: "notes.txt", overwritten: false }, 201),
     download: async () => new Response("hello", { status: 200, headers: { "Content-Type": "text/plain" } }),
-    mkdir: async () => jsonResponse({ key: "folder/", created: true }, 201),
-    delete: async () => jsonResponse({ key: "notes.txt", deleted: true, soft: true }),
-    search: async () => jsonResponse({ matches: [], nextCursor: null }),
-    move: async () => jsonResponse({ from: "a", to: "b", kind: "file" }),
-    copy: async () => jsonResponse({ from: "a", to: "b", copied: true }),
-    stat: async () => jsonResponse({ key: "a.txt", kind: "file", size: 5 }),
+    mkdir: async () => httpJsonResponse({ key: "folder/", created: true }, 201),
+    delete: async () => httpJsonResponse({ key: "notes.txt", deleted: true, soft: true }),
+    search: async () => httpJsonResponse({ matches: [], nextCursor: null }),
+    move: async () => httpJsonResponse({ from: "a", to: "b", kind: "file" }),
+    copy: async () => httpJsonResponse({ from: "a", to: "b", copied: true }),
+    stat: async () => httpJsonResponse({ key: "a.txt", kind: "file", size: 5 }),
     downloadRange: async () => new Response("hello", {
       status: 206,
       headers: { "Content-Type": "application/octet-stream" },
     }),
-    uploadStart: async () => jsonResponse({ key: "big.bin", uploadId: "uid-1" }, 201),
-    uploadPart: async () => jsonResponse({ partNumber: 1, etag: "etag-1" }),
-    uploadComplete: async () => jsonResponse({ key: "big.bin", size: 10 }),
+    uploadStart: async () => httpJsonResponse({ key: "big.bin", uploadId: "uid-1" }, 201),
+    uploadPart: async () => httpJsonResponse({ partNumber: 1, etag: "etag-1" }),
+    uploadComplete: async () => httpJsonResponse({ key: "big.bin", size: 10 }),
     uploadAbort: async () => new Response(null, { status: 204 }),
-    shareCreate: async () => jsonResponse({ token: "tok-1", url: "http://x/share/tok-1" }, 201),
-    shareList: async () => jsonResponse([]),
+    shareCreate: async () => httpJsonResponse({ token: "tok-1", url: "http://x/share/tok-1" }, 201),
+    shareList: async () => httpJsonResponse([]),
     shareRevoke: async () => new Response(null, { status: 204 }),
-    sitesList: async () => jsonResponse({ sitesHost: "sites.example.com", sites: [] }),
-    sitesConfig: async () => jsonResponse({ slug: "demo", spa: true }),
-    sitesDelete: async () => jsonResponse({ slug: "demo", deleted: 2 }),
+    sitesList: async () => httpJsonResponse({ sitesHost: "sites.example.com", sites: [] }),
+    sitesConfig: async () => httpJsonResponse({ slug: "demo", spa: true }),
+    sitesDelete: async () => httpJsonResponse({ slug: "demo", deleted: 2 }),
     sitesEnabled: async () => true,
-    imageList: async () => jsonResponse({ sitesHost: "sites.example.com", images: [] }),
+    imageList: async () => httpJsonResponse({ sitesHost: "sites.example.com", images: [] }),
     imageUpload: async () =>
-      jsonResponse(
+      httpJsonResponse(
         {
           id: "a".repeat(32),
           name: "shot.png",
@@ -80,7 +62,7 @@ function mockApis(overrides: Partial<ToolCallApis> = {}): ToolCallApis {
         },
         201
       ),
-    imageDelete: async () => jsonResponse({ id: "a".repeat(32), deleted: true }),
+    imageDelete: async () => httpJsonResponse({ id: "a".repeat(32), deleted: true }),
     imageHostEnabled: async () => true,
     ...overrides,
   };
@@ -192,15 +174,15 @@ describe("mcp protocol", () => {
         upload: async () => {
           throw new Error("inline upload should not be used for >1MiB");
         },
-        uploadStart: async ({ key }) => jsonResponse({ key, uploadId: "uid-42" }, 201),
+        uploadStart: async ({ key }) => httpJsonResponse({ key, uploadId: "uid-42" }, 201),
         uploadPart: async ({ partNumber, body }) => {
           parts.push({ partNumber, body });
-          return jsonResponse({ partNumber, etag: `etag-${partNumber}` });
+          return httpJsonResponse({ partNumber, etag: `etag-${partNumber}` });
         },
         uploadComplete: async ({ uploadId, parts: completed }) => {
           expect(uploadId).toBe("uid-42");
           expect(completed).toHaveLength(2);
-          return jsonResponse({ key: "docs/big.bin", size: content.length });
+          return httpJsonResponse({ key: "docs/big.bin", size: content.length });
         },
         uploadAbort: async () => {
           throw new Error("abort should not fire on the happy path");
@@ -261,7 +243,7 @@ describe("mcp protocol", () => {
         { path: "big.bin", part: 1, partSize: 100 },
         {
           stat: async () =>
-            jsonResponse({ key: "big.bin", kind: "file", size: big.length }),
+            httpJsonResponse({ key: "big.bin", kind: "file", size: big.length }),
           downloadRange,
         }
       );
@@ -285,7 +267,7 @@ describe("mcp protocol", () => {
 
   test("list tool wraps API json", async () => {
     const result = await callTool("list", { path: "" }, {
-      list: async () => jsonResponse({ items: [{ key: "a.txt", isDir: false }] }),
+      list: async () => httpJsonResponse({ items: [{ key: "a.txt", isDir: false }] }),
     });
     const body = toolPayload(result);
     expect(body.isError).toBeFalsy();
@@ -293,26 +275,26 @@ describe("mcp protocol", () => {
   });
 
   test("search/move/copy/stat forward arguments", async () => {
-    const search = jest.fn(async () => jsonResponse({ matches: [{ key: "a.txt" }] }));
+    const search = jest.fn(async () => httpJsonResponse({ matches: [{ key: "a.txt" }] }));
     const searchResult = await callTool("search", { query: "a.txt", limit: 10 }, { search });
     expect(search).toHaveBeenCalledWith({ query: "a.txt", limit: 10, cursor: undefined });
     expect(JSON.parse(toolPayload(searchResult).content[0].text).matches).toHaveLength(1);
 
-    const move = jest.fn(async () => jsonResponse({ from: "a", to: "b" }));
+    const move = jest.fn(async () => httpJsonResponse({ from: "a", to: "b" }));
     await callTool("move", { from: "a", to: "b", overwrite: true }, { move });
     expect(move).toHaveBeenCalledWith({ from: "a", to: "b", overwrite: true });
 
-    const copy = jest.fn(async () => jsonResponse({ copied: true }));
+    const copy = jest.fn(async () => httpJsonResponse({ copied: true }));
     await callTool("copy", { from: "a", to: "b" }, { copy });
     expect(copy).toHaveBeenCalledWith({ from: "a", to: "b", overwrite: undefined });
 
-    const stat = jest.fn(async () => jsonResponse({ kind: "file", size: 3 }));
+    const stat = jest.fn(async () => httpJsonResponse({ kind: "file", size: 3 }));
     await callTool("stat", { path: "a.txt" }, { stat });
     expect(stat).toHaveBeenCalledWith({ path: "a.txt" });
   });
 
   test("share tools create, list, revoke", async () => {
-    const shareCreate = jest.fn(async () => jsonResponse({ token: "tok-1" }, 201));
+    const shareCreate = jest.fn(async () => httpJsonResponse({ token: "tok-1" }, 201));
     const created = await callTool(
       "share_create",
       { path: "docs/report.pdf", extractCode: "abcd", expiresInHours: 24 },
@@ -325,7 +307,7 @@ describe("mcp protocol", () => {
     });
     expect(JSON.parse(toolPayload(created).content[0].text).token).toBe("tok-1");
 
-    const shareList = jest.fn(async () => jsonResponse([{ token: "tok-1" }]));
+    const shareList = jest.fn(async () => httpJsonResponse([{ token: "tok-1" }]));
     const listed = await callTool("share_list", {}, { shareList });
     expect(shareList).toHaveBeenCalledTimes(1);
     expect(JSON.parse(toolPayload(listed).content[0].text)).toHaveLength(1);
@@ -336,7 +318,7 @@ describe("mcp protocol", () => {
   });
 
   test("share_create rejects missing path and short codes are left to the API", async () => {
-    const shareCreate = jest.fn(async () => jsonResponse({ token: "t" }, 201));
+    const shareCreate = jest.fn(async () => httpJsonResponse({ token: "t" }, 201));
     const missing = await callTool("share_create", {}, { shareCreate });
     expect(toolPayload(missing).isError).toBe(true);
     expect(shareCreate).not.toHaveBeenCalled();
@@ -344,23 +326,23 @@ describe("mcp protocol", () => {
 
   test("sites tools list/config/delete", async () => {
     const sitesList = jest.fn(async () =>
-      jsonResponse({ sitesHost: "sites.example.com", sites: [{ slug: "demo", spa: false }] })
+      httpJsonResponse({ sitesHost: "sites.example.com", sites: [{ slug: "demo", spa: false }] })
     );
     const listed = await callTool("sites_list", {}, { sitesList });
     expect(sitesList).toHaveBeenCalledWith({ withStats: true });
     expect(JSON.parse(toolPayload(listed).content[0].text).sites[0].slug).toBe("demo");
 
-    const sitesConfig = jest.fn(async () => jsonResponse({ slug: "demo", spa: true }));
+    const sitesConfig = jest.fn(async () => httpJsonResponse({ slug: "demo", spa: true }));
     await callTool("sites_config", { slug: "demo", spa: true }, { sitesConfig });
     expect(sitesConfig).toHaveBeenCalledWith({ slug: "demo", spa: true });
 
-    const sitesDelete = jest.fn(async () => jsonResponse({ slug: "demo", deleted: 3 }));
+    const sitesDelete = jest.fn(async () => httpJsonResponse({ slug: "demo", deleted: 3 }));
     await callTool("sites_delete", { slug: "demo", purge: true }, { sitesDelete });
     expect(sitesDelete).toHaveBeenCalledWith({ slug: "demo", purge: true });
   });
 
   test("sites_config requires slug and spa", async () => {
-    const sitesConfig = jest.fn(async () => jsonResponse({ slug: "demo", spa: true }));
+    const sitesConfig = jest.fn(async () => httpJsonResponse({ slug: "demo", spa: true }));
     const missing = await callTool("sites_config", { slug: "demo" }, { sitesConfig });
     expect(toolPayload(missing).isError).toBe(true);
     expect(sitesConfig).not.toHaveBeenCalled();
@@ -395,7 +377,7 @@ describe("mcp protocol", () => {
       const folder = path.replace(/\/+$/, "");
       const items = trees[folder];
       if (!items) return new Response("目录不存在", { status: 404 });
-      return jsonResponse({ items });
+      return httpJsonResponse({ items });
     });
     const download = jest.fn(async ({ path }: { path: string }) => {
       const text = contents[path];
@@ -456,7 +438,7 @@ describe("mcp protocol", () => {
   });
 
   test("push rejects raw keys in mcp.json", async () => {
-    const upload = jest.fn(async () => jsonResponse({ key: "agents/cursor/mcp/mcp.json" }, 201));
+    const upload = jest.fn(async () => httpJsonResponse({ key: "agents/cursor/mcp/mcp.json" }, 201));
     const rejected = await callTool(
       "push",
       {
@@ -523,9 +505,9 @@ describe("mcp protocol", () => {
     const list = jest.fn(async ({ path }: { path: string }) => {
       const items = trees[path.replace(/\/+$/, "")];
       if (!items) return new Response("目录不存在", { status: 404 });
-      return jsonResponse({ items });
+      return httpJsonResponse({ items });
     });
-    const copy = jest.fn(async () => jsonResponse({ copied: true }));
+    const copy = jest.fn(async () => httpJsonResponse({ copied: true }));
     const copied = await callTool(
       "publish_site",
       { slug: "hello", source: "draft/hello" },
@@ -562,7 +544,7 @@ describe("mcp protocol", () => {
     const imageUpload = jest.fn(async (query: { name: string; body: Uint8Array }) => {
       expect(query.name).toBe("dot.png");
       expect(query.body.byteLength).toBeGreaterThan(0);
-      return jsonResponse(
+      return httpJsonResponse(
         {
           id,
           name: query.name,
@@ -584,7 +566,7 @@ describe("mcp protocol", () => {
     expect(imageUpload).toHaveBeenCalled();
 
     const listed = await callTool("image_list", {}, {
-      imageList: async () => jsonResponse({ images: [{ id, url: payload.url, markdown: payload.markdown }] }),
+      imageList: async () => httpJsonResponse({ images: [{ id, url: payload.url, markdown: payload.markdown }] }),
       imageHostEnabled: async () => true,
     });
     expect(toolPayload(listed).content[0].text).toContain(id);
@@ -592,7 +574,7 @@ describe("mcp protocol", () => {
     const deleted = await callTool("image_delete", { id }, {
       imageDelete: async (query) => {
         expect(query.id).toBe(id);
-        return jsonResponse({ id, deleted: true });
+        return httpJsonResponse({ id, deleted: true });
       },
       imageHostEnabled: async () => true,
     });

--- a/src/app/__tests__/middleware.test.ts
+++ b/src/app/__tests__/middleware.test.ts
@@ -1,0 +1,391 @@
+/**
+ * functions/_middleware.ts + functions/_sites.ts 分支级直测：
+ * SITES_HOST 接管（静态命中 / index 回退 / spa / 404.html / 纯 404）、
+ * 路径穿越与内部前缀保护、图片宿主 /i/{id}、产品路由开关门禁。
+ */
+import { onRequest } from "../../../functions/_middleware";
+import {
+  isValidSlug,
+  mimeForKey,
+  parseSitesPath,
+  siteConfigKey,
+} from "../../../functions/_sites";
+import { InMemoryBucket, makeContext } from "../testInMemoryBucket";
+
+const HOST = "http://sites.example.com";
+const IMAGE_ID = "0123456789abcdef0123456789abcdef";
+
+interface MiddlewareEnv {
+  BUCKET: R2Bucket;
+  SITES_HOST?: string;
+}
+
+function makeEnv(bucket: InMemoryBucket, extra: Record<string, unknown> = {}): MiddlewareEnv {
+  return { BUCKET: bucket.asBucket(), ...extra };
+}
+
+function siteRequest(
+  path: string,
+  env: MiddlewareEnv,
+  options: { method?: string; host?: string; headers?: Record<string, string>; next?: () => Promise<Response> } = {}
+) {
+  const request = new Request(`${HOST}${path}`, {
+    method: options.method ?? "GET",
+    headers: { Host: options.host ?? "sites.example.com", ...(options.headers ?? {}) },
+  });
+  return onRequest(makeContext(request, env, {}, options.next));
+}
+
+function defaultEnv(bucket: InMemoryBucket) {
+  return makeEnv(bucket, { SITES_HOST: "sites.example.com" });
+}
+
+describe("sites path parsing (parseSitesPath / helpers)", () => {
+  test("valid slugs and keys", () => {
+    expect(parseSitesPath("/blog/index.html")).toEqual({
+      ok: true,
+      slug: "blog",
+      key: "sites/blog/index.html",
+      tryIndex: false,
+    });
+    expect(parseSitesPath("/blog")).toEqual({
+      ok: true,
+      slug: "blog",
+      key: "sites/blog/index.html",
+      tryIndex: false,
+    });
+    expect(parseSitesPath("/Blog/style.CSS")).toEqual({
+      ok: true,
+      slug: "blog",
+      key: "sites/blog/style.CSS",
+      tryIndex: false,
+    });
+    expect(parseSitesPath("/blog/sub/page")).toEqual({
+      ok: true,
+      slug: "blog",
+      key: "sites/blog/sub/page",
+      tryIndex: true,
+    });
+  });
+
+  test("rejects traversal, encoded traversal, internal prefixes and bad slugs", () => {
+    expect(parseSitesPath("/blog/../secret").ok).toBe(false);
+    expect(parseSitesPath("/blog/%2e%2e/secret").ok).toBe(false);
+    expect(parseSitesPath("/blog/%2e%2e%2fsecret").ok).toBe(false);
+    expect(parseSitesPath("/blog/_$flaredrive$/apikeys/x").ok).toBe(false);
+    expect(parseSitesPath("/_$flaredrive$/config.json").ok).toBe(false);
+    expect(parseSitesPath("/").ok).toBe(false);
+    expect(parseSitesPath("/Bad_Slug/x").ok).toBe(false);
+    // 文件名内部的合法 "a..b" 不受影响
+    expect(parseSitesPath("/blog/a..b.html").ok).toBe(true);
+  });
+
+  test("slug regex and mime table", () => {
+    expect(isValidSlug("blog")).toBe(true);
+    expect(isValidSlug("-blog")).toBe(false);
+    expect(isValidSlug("Blog")).toBe(false);
+    expect(mimeForKey("sites/x/index.html")).toBe("text/html; charset=utf-8");
+    expect(mimeForKey("sites/x/app.js")).toBe("text/javascript; charset=utf-8");
+    expect(mimeForKey("sites/x/data.weird")).toBe("application/octet-stream");
+    expect(siteConfigKey("blog")).toBe("_$flaredrive$/sites/blog.json");
+  });
+});
+
+describe("sites host: static serving", () => {
+  function seedSite(bucket: InMemoryBucket, slug = "blog") {
+    bucket.seed([
+      { key: `sites/${slug}/index.html`, body: "<h1>home</h1>", contentType: "text/html" },
+      { key: `sites/${slug}/app.js`, body: "console.log(1)", contentType: "text/javascript" },
+      { key: `sites/${slug}/data.bin`, body: "\x00\x01", contentType: "application/octet-stream" },
+    ]);
+  }
+
+  test("exact object hit returns 200 with mime/nosniff/cache headers", async () => {
+    const bucket = new InMemoryBucket();
+    seedSite(bucket);
+    const response = await siteRequest("/blog/app.js", defaultEnv(bucket));
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Content-Type")).toBe("text/javascript; charset=utf-8");
+    expect(response.headers.get("X-Content-Type-Options")).toBe("nosniff");
+    expect(response.headers.get("Cache-Control")).toBe("public, max-age=60");
+    expect(response.headers.get("X-Robots-Tag")).toBe("noindex");
+    expect(response.headers.get("ETag")).toMatch(/^"/);
+    expect(await response.text()).toBe("console.log(1)");
+  });
+
+  test("extensionless directory path falls back to its own index.html", async () => {
+    const bucket = new InMemoryBucket();
+    seedSite(bucket);
+    bucket.seed([
+      { key: "sites/blog/about/index.html", body: "<h1>about</h1>", contentType: "text/html" },
+    ]);
+    const response = await siteRequest("/blog/about", defaultEnv(bucket));
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Content-Type")).toBe("text/html; charset=utf-8");
+    expect(await response.text()).toBe("<h1>about</h1>");
+  });
+
+  test("root path serves index.html directly", async () => {
+    const bucket = new InMemoryBucket();
+    seedSite(bucket);
+    const response = await siteRequest("/blog/", defaultEnv(bucket));
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe("<h1>home</h1>");
+  });
+
+  test("unknown extension falls back to octet-stream", async () => {
+    const bucket = new InMemoryBucket();
+    seedSite(bucket);
+    const response = await siteRequest("/blog/data.bin", defaultEnv(bucket));
+    expect(response.headers.get("Content-Type")).toBe("application/octet-stream");
+  });
+
+  test("HEAD returns headers without body", async () => {
+    const bucket = new InMemoryBucket();
+    seedSite(bucket);
+    const response = await siteRequest("/blog/app.js", defaultEnv(bucket), { method: "HEAD" });
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe("");
+  });
+
+  test("plain miss without spa/404 page is a bare 404", async () => {
+    const bucket = new InMemoryBucket();
+    seedSite(bucket);
+    const response = await siteRequest("/blog/missing.png", defaultEnv(bucket));
+    expect(response.status).toBe(404);
+    expect(response.headers.get("Content-Type")).toContain("text/plain");
+    expect(response.headers.get("X-Content-Type-Options")).toBe("nosniff");
+    expect(response.headers.get("Cache-Control")).toBe("no-store");
+    expect(await response.text()).toBe("Not Found");
+  });
+
+  test("spa=true falls back to the site index.html on miss", async () => {
+    const bucket = new InMemoryBucket();
+    seedSite(bucket);
+    bucket.seed([
+      {
+        key: siteConfigKey("blog"),
+        body: JSON.stringify({ slug: "blog", spa: true }),
+        contentType: "application/json",
+      },
+    ]);
+    const response = await siteRequest("/blog/missing.png", defaultEnv(bucket));
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Content-Type")).toBe("text/html; charset=utf-8");
+    expect(await response.text()).toBe("<h1>home</h1>");
+  });
+
+  test("custom 404.html is served with 404 status and no-store", async () => {
+    const bucket = new InMemoryBucket();
+    seedSite(bucket);
+    bucket.seed([
+      { key: "sites/blog/404.html", body: "<h1>custom 404</h1>", contentType: "text/html" },
+    ]);
+    const response = await siteRequest("/blog/missing.png", defaultEnv(bucket));
+    expect(response.status).toBe(404);
+    expect(response.headers.get("Content-Type")).toBe("text/html; charset=utf-8");
+    expect(response.headers.get("Cache-Control")).toBe("no-store");
+    expect(await response.text()).toBe("<h1>custom 404</h1>");
+  });
+
+  test("non-GET/HEAD methods on the sites host are 405", async () => {
+    const bucket = new InMemoryBucket();
+    seedSite(bucket);
+    const response = await siteRequest("/blog/app.js", defaultEnv(bucket), { method: "DELETE" });
+    expect(response.status).toBe(405);
+    expect(response.headers.get("Allow")).toBe("GET, HEAD");
+  });
+
+  test("malformed paths (traversal / internal prefix / root) are plain 404", async () => {
+    const bucket = new InMemoryBucket();
+    seedSite(bucket);
+    for (const path of [
+      "/blog/%2e%2e/secret",
+      "/blog/%2e%2e%2fsecret",
+      "/blog/_$flaredrive$/apikeys/x.json",
+      "/_$flaredrive$/config.json",
+      "/",
+      "/Bad_Slug/x",
+    ]) {
+      const response = await siteRequest(path, defaultEnv(bucket));
+      expect(response.status).toBe(404);
+    }
+  });
+
+  test("sites flag off 404s slug routes but keeps images host working", async () => {
+    const bucket = new InMemoryBucket();
+    seedSite(bucket);
+    bucket.seed([
+      {
+        key: "_$flaredrive$/config.json",
+        body: JSON.stringify({ sites: false }),
+        contentType: "application/json",
+      },
+      {
+        key: "_$flaredrive$/img/" + IMAGE_ID,
+        body: "png",
+        customMetadata: { contentType: "image/png" },
+      },
+    ]);
+    const env = makeEnv(bucket, { SITES_HOST: "sites.example.com" });
+    const slug = await siteRequest("/blog/app.js", env);
+    expect(slug.status).toBe(404);
+    const image = await siteRequest(`/i/${IMAGE_ID}`, env);
+    expect(image.status).toBe(200);
+  });
+});
+
+describe("sites host: image routes (/i/{id})", () => {
+  function seedImage(bucket: InMemoryBucket, contentType = "image/png", name?: string) {
+    bucket.seed([
+      {
+        key: "_$flaredrive$/img/" + IMAGE_ID,
+        body: "image-bytes",
+        customMetadata: {
+          contentType,
+          ...(name ? { name } : {}),
+        },
+      },
+    ]);
+  }
+
+  test("serves the image with inline disposition and long cache", async () => {
+    const bucket = new InMemoryBucket();
+    seedImage(bucket, "image/png", "shot.png");
+    const response = await siteRequest(`/i/${IMAGE_ID}`, defaultEnv(bucket));
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Content-Type")).toBe("image/png");
+    expect(response.headers.get("Content-Disposition")).toBe("inline");
+    expect(response.headers.get("X-Content-Type-Options")).toBe("nosniff");
+    expect(response.headers.get("Cache-Control")).toBe("public, max-age=31536000, immutable");
+    expect(await response.text()).toBe("image-bytes");
+  });
+
+  test("svg content is forced to attachment", async () => {
+    const bucket = new InMemoryBucket();
+    seedImage(bucket, "image/svg+xml", "logo.svg");
+    const response = await siteRequest(`/i/${IMAGE_ID}`, defaultEnv(bucket));
+    expect(response.headers.get("Content-Disposition")).toMatch(/^attachment;/);
+  });
+
+  test("missing image is 404; bad id is 404", async () => {
+    const bucket = new InMemoryBucket();
+    expect((await siteRequest(`/i/${IMAGE_ID}`, defaultEnv(bucket))).status).toBe(404);
+    expect((await siteRequest("/i/nothex", defaultEnv(bucket))).status).toBe(404);
+  });
+
+  test("imageHost flag off 404s image routes even when sites is on", async () => {
+    const bucket = new InMemoryBucket();
+    seedImage(bucket);
+    bucket.seed([
+      {
+        key: "_$flaredrive$/config.json",
+        body: JSON.stringify({ imageHost: false }),
+        contentType: "application/json",
+      },
+    ]);
+    const response = await siteRequest(`/i/${IMAGE_ID}`, defaultEnv(bucket));
+    expect(response.status).toBe(404);
+  });
+});
+
+describe("sites host host-matching", () => {
+  test("non-matching Host falls through to product routing (next)", async () => {
+    const bucket = new InMemoryBucket();
+    const next = jest.fn(async () => new Response("next-ok", { status: 200 }));
+    const response = await siteRequest("/blog/app.js", defaultEnv(bucket), {
+      host: "drive.example.com",
+      next,
+    });
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe("next-ok");
+  });
+
+  test("SITES_HOST comparison ignores case, port and trailing dot", async () => {
+    const bucket = new InMemoryBucket();
+    bucket.seed([
+      { key: "sites/blog/index.html", body: "hi", contentType: "text/html" },
+    ]);
+    const env = makeEnv(bucket, { SITES_HOST: "Sites.Example.com." });
+    const response = await siteRequest("/blog/", env, { host: "sites.example.com:8443" });
+    expect(response.status).toBe(200);
+  });
+
+  test("missing SITES_HOST config never takes over", async () => {
+    const bucket = new InMemoryBucket();
+    const next = jest.fn(async () => new Response("next-ok", { status: 200 }));
+    const response = await siteRequest("/blog/", makeEnv(bucket), { next });
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(await response.text()).toBe("next-ok");
+  });
+});
+
+describe("drive product route gates (webdav/mcp)", () => {
+  test("webdav disabled returns 404 unless the UI client header is present", async () => {
+    const bucket = new InMemoryBucket();
+    bucket.seed([
+      {
+        key: "_$flaredrive$/config.json",
+        body: JSON.stringify({ webdav: false }),
+        contentType: "application/json",
+      },
+    ]);
+    const blocked = await siteRequest("/webdav/", makeEnv(bucket), {
+      host: "drive.example.com",
+    });
+    expect(blocked.status).toBe(404);
+    expect(blocked.headers.get("X-Content-Type-Options")).toBe("nosniff");
+
+    const next = jest.fn(async () => new Response("next-ok", { status: 200 }));
+    const allowed = await siteRequest("/webdav/", makeEnv(bucket), {
+      host: "drive.example.com",
+      headers: { "X-Davflare-UI": "1" },
+      next,
+    });
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(allowed.status).toBe(200);
+  });
+
+  test("mcp requires both mcp and apiKey flags", async () => {
+    const bucket = new InMemoryBucket();
+    bucket.seed([
+      {
+        key: "_$flaredrive$/config.json",
+        body: JSON.stringify({ mcp: false, apiKey: true }),
+        contentType: "application/json",
+      },
+    ]);
+    const blocked = await siteRequest("/mcp", makeEnv(bucket), {
+      host: "drive.example.com",
+    });
+    expect(blocked.status).toBe(404);
+
+    const bucket2 = new InMemoryBucket();
+    bucket2.seed([
+      {
+        key: "_$flaredrive$/config.json",
+        body: JSON.stringify({ mcp: true, apiKey: false }),
+        contentType: "application/json",
+      },
+    ]);
+    const blocked2 = await siteRequest("/mcp", makeEnv(bucket2), {
+      host: "drive.example.com",
+    });
+    expect(blocked2.status).toBe(404);
+  });
+
+  test("enabled product routes and /api/* paths pass through to next", async () => {
+    const bucket = new InMemoryBucket();
+    const next = jest.fn(async () => new Response("next-ok", { status: 200 }));
+    for (const path of ["/webdav/", "/mcp", "/api/upload", "/share/tok"]) {
+      next.mockClear();
+      const response = await siteRequest(path, makeEnv(bucket), {
+        host: "drive.example.com",
+        next,
+      });
+      expect(next).toHaveBeenCalledTimes(1);
+      expect(await response.text()).toBe("next-ok");
+    }
+  });
+});

--- a/src/app/__tests__/recent.test.ts
+++ b/src/app/__tests__/recent.test.ts
@@ -1,9 +1,10 @@
 import { act, renderHook } from "@testing-library/react";
 
 import { loadRecent, pushRecent, useRecent } from "../recent";
+import { clearStorage } from "../testUtils";
 
 beforeEach(() => {
-  localStorage.clear();
+  clearStorage();
 });
 
 describe("recent / loadRecent", () => {

--- a/src/app/__tests__/share.test.ts
+++ b/src/app/__tests__/share.test.ts
@@ -1,21 +1,13 @@
 import { createShare, formatShareClipboard, formatShareCountdown, listShares, revokeShare, shareExpiryView } from "../share";
 import { authFetch } from "../auth";
 import { setLang } from "../strings";
+import { asAuthFetchMock } from "../testUtils";
 
 jest.mock("../auth", () => ({
   authFetch: jest.fn(),
 }));
 
-const mockAuthFetch = authFetch as unknown as jest.Mock;
-
-function jsonResponse(body: unknown, ok = true, status = 200) {
-  return {
-    ok,
-    status,
-    json: async () => body,
-    text: async () => JSON.stringify(body),
-  } as unknown as Response;
-}
+const mockAuthFetch = asAuthFetchMock(authFetch);
 
 beforeEach(() => {
   mockAuthFetch.mockReset();
@@ -23,7 +15,7 @@ beforeEach(() => {
 
 describe("share / createShare", () => {
   test("默认 body 只含 key", async () => {
-    mockAuthFetch.mockResolvedValue(jsonResponse({ token: "t" }));
+    mockAuthFetch.mockOk({ token: "t" });
     await createShare("a/b.txt");
     const [, init] = mockAuthFetch.mock.calls[0];
     expect(init.method).toBe("POST");
@@ -31,14 +23,14 @@ describe("share / createShare", () => {
   });
 
   test("携带过期时间与提取码（trim）", async () => {
-    mockAuthFetch.mockResolvedValue(jsonResponse({ token: "t" }));
+    mockAuthFetch.mockOk({ token: "t" });
     await createShare("a.txt", 12, " 1234 ");
     const [, init] = mockAuthFetch.mock.calls[0];
     expect(JSON.parse(init.body)).toEqual({ key: "a.txt", expiresInHours: 12, extractCode: "1234" });
   });
 
   test("失败抛出响应文本", async () => {
-    mockAuthFetch.mockResolvedValue({ ok: false, status: 400, text: async () => "bad" } as unknown as Response);
+    mockAuthFetch.mockError(400, "bad");
     await expect(createShare("a.txt")).rejects.toThrow("bad");
   });
 });
@@ -46,19 +38,19 @@ describe("share / createShare", () => {
 describe("share / listShares & revokeShare", () => {
   test("listShares 成功返回 JSON", async () => {
     const shares = [{ token: "t", key: "a", name: "a", expiresAt: null, createdAt: "", url: "" }];
-    mockAuthFetch.mockResolvedValue(jsonResponse(shares));
+    mockAuthFetch.mockOk(shares);
     await expect(listShares()).resolves.toEqual(shares);
     expect(mockAuthFetch).toHaveBeenCalledWith("/api/shares");
   });
 
   test("revokeShare DELETE 并编码 token", async () => {
-    mockAuthFetch.mockResolvedValue({ ok: true, status: 200 } as unknown as Response);
+    mockAuthFetch.mockOk({});
     await revokeShare("a b&c");
     expect(mockAuthFetch).toHaveBeenCalledWith("/api/shares?token=a%20b%26c", { method: "DELETE" });
   });
 
   test("失败抛出默认文案", async () => {
-    mockAuthFetch.mockResolvedValue({ ok: false, status: 500, text: async () => "" } as unknown as Response);
+    mockAuthFetch.mockError(500);
     setLang("zh");
     await expect(listShares()).rejects.toThrow("获取分享失败");
     await expect(revokeShare("t")).rejects.toThrow("撤销分享失败");

--- a/src/app/__tests__/shareToken.test.ts
+++ b/src/app/__tests__/shareToken.test.ts
@@ -1,0 +1,640 @@
+/**
+ * functions/share/[[token]].ts + functions/api/shares.ts 分支级直测：
+ * 创建/列表/撤销、落地页与 HTML 转义、?download=1 / ?raw=1、安全响应头、
+ * 提取码（?code=、表单 POST、cookie）、410 过期、404 撤销、目录分享 zip。
+ */
+import { ReadableStream } from "stream/web";
+// buildZipStream 用到 ReadableStream，jsdom 测试环境没有该全局，补上
+(globalThis as any).ReadableStream = (globalThis as any).ReadableStream ?? ReadableStream;
+
+import {
+  onRequestGet as shareGet,
+  onRequestHead as shareHead,
+  onRequestPost as sharePost,
+} from "../../../functions/share/[[token]]";
+import {
+  onRequestDelete as sharesDelete,
+  onRequestGet as sharesList,
+  onRequestPost as sharesCreate,
+} from "../../../functions/api/shares";
+import { InMemoryBucket, basicAuthHeader, makeContext } from "../testInMemoryBucket";
+
+const AUTH = basicAuthHeader("user", "pass");
+const SHARES_PREFIX = "_$flaredrive$/shares/";
+const HOST = "http://drive.example.com";
+
+function makeEnv(bucket: InMemoryBucket, extra: Record<string, unknown> = {}) {
+  return { BUCKET: bucket.asBucket(), ...extra };
+}
+
+function sharesEnv(bucket: InMemoryBucket) {
+  return {
+    BUCKET: bucket.asBucket(),
+    WEBDAV_USERNAME: "user",
+    WEBDAV_PASSWORD: "pass",
+  };
+}
+
+async function sha256Hex(value: string): Promise<string> {
+  const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(value));
+  return Array.from(new Uint8Array(digest))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+function seedShare(
+  bucket: InMemoryBucket,
+  token: string,
+  meta: Record<string, unknown>
+) {
+  bucket.seed([
+    {
+      key: `${SHARES_PREFIX}${token}.json`,
+      body: JSON.stringify(meta),
+      contentType: "application/json",
+    },
+  ]);
+}
+
+function seedFileShare(bucket: InMemoryBucket, token = "tok1", key = "docs/report.txt") {
+  bucket.seed([{ key, body: "Hello World", contentType: "text/plain" }]);
+  seedShare(bucket, token, {
+    key,
+    name: key.split("/").pop(),
+    isDir: false,
+    expiresAt: null,
+    createdAt: "2026-01-01T00:00:00.000Z",
+  });
+}
+
+function shareRequest(
+  token: string | null,
+  method = "GET",
+  query = "",
+  extra: Record<string, string> = {},
+  body?: BodyInit
+): Request {
+  const path = token === null ? "/share/" : `/share/${token}`;
+  return new Request(`${HOST}${path}${query}`, {
+    method,
+    headers: extra,
+    body,
+  });
+}
+
+async function callShareGet(
+  bucket: InMemoryBucket,
+  token: string | null,
+  query = "",
+  extra: Record<string, string> = {}
+) {
+  return shareGet(makeContext(shareRequest(token, "GET", query, extra), makeEnv(bucket), {
+    token: token ?? "",
+  }));
+}
+
+function jsonRequest(
+  path: string,
+  method: string,
+  body?: unknown,
+  headers: Record<string, string> = {},
+  authorized = true
+) {
+  return new Request(`${HOST}${path}`, {
+    method,
+    headers: {
+      "Content-Type": "application/json",
+      ...(authorized ? { Authorization: AUTH } : {}),
+      ...headers,
+    },
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+}
+
+describe("shares API (POST/GET/DELETE /api/shares)", () => {
+  test("requires Basic or API key auth", async () => {
+    const bucket = new InMemoryBucket();
+    const anonymous = new Request(`${HOST}/api/shares`, { method: "GET" });
+    expect((await sharesList(makeContext(anonymous, sharesEnv(bucket)))).status).toBe(401);
+    const wrongBasic = new Request(`${HOST}/api/shares`, {
+      headers: { Authorization: basicAuthHeader("user", "nope") },
+    });
+    expect((await sharesList(makeContext(wrongBasic, sharesEnv(bucket)))).status).toBe(401);
+    const anonPost = jsonRequest("/api/shares", "POST", { key: "a.txt" }, {}, false);
+    expect((await sharesCreate(makeContext(anonPost, sharesEnv(bucket)))).status).toBe(401);
+  });
+
+  test("API key (X-Api-Key) is accepted as an alternative to Basic", async () => {
+    const bucket = new InMemoryBucket();
+    bucket.seed([{ key: "a.txt", body: "A" }]);
+    bucket.seed([
+      {
+        key: "_$flaredrive$/apikeys/record.json",
+        body: JSON.stringify({
+          id: "rec",
+          name: "rec",
+          prefix: "fd_",
+          keyHash: await sha256Hex("fd_secret_key"),
+          createdAt: "2026-01-01T00:00:00.000Z",
+          expiresAt: null,
+        }),
+        contentType: "application/json",
+      },
+    ]);
+    const created = await sharesCreate(
+      makeContext(
+        jsonRequest("/api/shares", "POST", { key: "a.txt" }, { "X-Api-Key": "fd_secret_key" }),
+        sharesEnv(bucket)
+      )
+    );
+    expect(created.status).toBe(200);
+    const body = (await created.json()) as { token: string };
+    expect(typeof body.token).toBe("string");
+
+    const invalid = await sharesCreate(
+      makeContext(
+        jsonRequest("/api/shares", "POST", { key: "a.txt" }, { "X-Api-Key": "fd_wrong" }, false),
+        sharesEnv(bucket)
+      )
+    );
+    expect(invalid.status).toBe(401);
+  });
+
+  test("creates a share for a file without extract code", async () => {
+    const bucket = new InMemoryBucket();
+    bucket.seed([{ key: "docs/report.txt", body: "R", contentType: "text/plain" }]);
+    const response = await sharesCreate(
+      makeContext(jsonRequest("/api/shares", "POST", { key: "docs/report.txt" }), sharesEnv(bucket))
+    );
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as Record<string, unknown>;
+    expect(body.key).toBe("docs/report.txt");
+    expect(body.name).toBe("report.txt");
+    expect(body.isDir).toBe(false);
+    expect(body.expiresAt).toBeNull();
+    expect(body.hasExtractCode).toBe(false);
+    expect(body.extractCode).toBeNull();
+    expect(typeof body.token).toBe("string");
+    expect(body.url).toBe(`${HOST}/share/${body.token}`);
+    // 元数据写入内部前缀
+    const meta = bucket.rawJson(`${SHARES_PREFIX}${body.token}.json`);
+    expect(meta).toMatchObject({ key: "docs/report.txt", isDir: false });
+  });
+
+  test("expiresInHours sets expiresAt; extract code echoed when >= 4 chars", async () => {
+    const bucket = new InMemoryBucket();
+    bucket.seed([{ key: "a.txt", body: "A" }]);
+    const before = Date.now();
+    const response = await sharesCreate(
+      makeContext(
+        jsonRequest("/api/shares", "POST", {
+          key: "a.txt",
+          expiresInHours: 24,
+          extractCode: "abcd",
+        }),
+        sharesEnv(bucket)
+      )
+    );
+    const body = (await response.json()) as { expiresAt: string; hasExtractCode: boolean; extractCode: string };
+    const ts = Date.parse(body.expiresAt);
+    expect(ts).toBeGreaterThan(before + 23 * 60 * 60 * 1000);
+    expect(body.hasExtractCode).toBe(true);
+    expect(body.extractCode).toBe("abcd");
+  });
+
+  test("extract code shorter than 4 chars is rejected", async () => {
+    const bucket = new InMemoryBucket();
+    bucket.seed([{ key: "a.txt", body: "A" }]);
+    const response = await sharesCreate(
+      makeContext(
+        jsonRequest("/api/shares", "POST", { key: "a.txt", extractCode: "abc" }),
+        sharesEnv(bucket)
+      )
+    );
+    expect(response.status).toBe(400);
+  });
+
+  test("missing key / internal key / invalid JSON are 400", async () => {
+    const bucket = new InMemoryBucket();
+    const noKey = await sharesCreate(
+      makeContext(jsonRequest("/api/shares", "POST", {}), sharesEnv(bucket))
+    );
+    expect(noKey.status).toBe(400);
+    const internal = await sharesCreate(
+      makeContext(
+        jsonRequest("/api/shares", "POST", { key: "_$flaredrive$/apikeys/x.json" }),
+        sharesEnv(bucket)
+      )
+    );
+    expect(internal.status).toBe(400);
+    const badJson = new Request(`${HOST}/api/shares`, {
+      method: "POST",
+      headers: { Authorization: AUTH, "Content-Type": "application/json" },
+      body: "{nope",
+    });
+    expect((await sharesCreate(makeContext(badJson, sharesEnv(bucket)))).status).toBe(400);
+  });
+
+  test("unknown key without children is 404", async () => {
+    const bucket = new InMemoryBucket();
+    const response = await sharesCreate(
+      makeContext(jsonRequest("/api/shares", "POST", { key: "ghost.txt" }), sharesEnv(bucket))
+    );
+    expect(response.status).toBe(404);
+  });
+
+  test("directory marker or children-only prefix yields isDir share", async () => {
+    const bucket = new InMemoryBucket();
+    bucket.seedDir("docs");
+    bucket.seed([{ key: "vdir/inner.txt", body: "I" }]);
+    const marked = (await (
+      await sharesCreate(
+        makeContext(jsonRequest("/api/shares", "POST", { key: "docs" }), sharesEnv(bucket))
+      )
+    ).json()) as { isDir: boolean };
+    expect(marked.isDir).toBe(true);
+    const virtual = (await (
+      await sharesCreate(
+        makeContext(jsonRequest("/api/shares", "POST", { key: "vdir" }), sharesEnv(bucket))
+      )
+    ).json()) as { isDir: boolean };
+    expect(virtual.isDir).toBe(true);
+  });
+
+  test("lists shares with url/extractCode/isDir; corrupt entries skipped", async () => {
+    const bucket = new InMemoryBucket();
+    bucket.seed([{ key: "a.txt", body: "A" }]);
+    seedShare(bucket, "tok-a", {
+      key: "a.txt",
+      name: "a.txt",
+      isDir: false,
+      expiresAt: null,
+      createdAt: "2026-01-01T00:00:00.000Z",
+      extractCode: "abcd",
+    });
+    bucket.seed([{ key: `${SHARES_PREFIX}broken.json`, body: "{oops" }]);
+    const response = await sharesList(
+      makeContext(new Request(`${HOST}/api/shares`, { headers: { Authorization: AUTH } }), sharesEnv(bucket))
+    );
+    expect(response.status).toBe(200);
+    const items = (await response.json()) as Array<Record<string, unknown>>;
+    expect(items).toHaveLength(1);
+    expect(items[0]).toMatchObject({ token: "tok-a", key: "a.txt", hasExtractCode: true });
+    expect(items[0].extractCode).toBe("abcd");
+    expect(items[0].url).toBe(`${HOST}/share/tok-a`);
+  });
+
+  test("DELETE removes share metadata; missing token is 400", async () => {
+    const bucket = new InMemoryBucket();
+    seedShare(bucket, "tok-del", { key: "a.txt" });
+    const ok = await sharesDelete(
+      makeContext(
+        new Request(`${HOST}/api/shares?token=tok-del`, { method: "DELETE", headers: { Authorization: AUTH } }),
+        sharesEnv(bucket)
+      )
+    );
+    expect(ok.status).toBe(204);
+    expect(bucket.has(`${SHARES_PREFIX}tok-del.json`)).toBe(false);
+    const noToken = await sharesDelete(
+      makeContext(
+        new Request(`${HOST}/api/shares`, { method: "DELETE", headers: { Authorization: AUTH } }),
+        sharesEnv(bucket)
+      )
+    );
+    expect(noToken.status).toBe(400);
+  });
+});
+
+describe("share landing page (GET default)", () => {
+  test("renders meta, preview link and download link", async () => {
+    const bucket = new InMemoryBucket();
+    seedFileShare(bucket);
+    const response = await callShareGet(bucket, "tok1");
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Content-Type")).toContain("text/html");
+    expect(response.headers.get("Cache-Control")).toBe("no-store");
+    const html = await response.text();
+    expect(html).toContain("<h1>report.txt</h1>");
+    expect(html).toContain("11 B");
+    expect(html).toContain("2026-01-01 00:00 UTC");
+    expect(html).toContain(`href="/share/tok1?download=1"`);
+    // text/plain 属于可预览类型：iframe 内嵌 raw 链接
+    expect(html).toContain(`src="/share/tok1?raw=1"`);
+    expect(html).toContain("<iframe");
+  });
+
+  test("escapes hostile filenames in the landing page", async () => {
+    const bucket = new InMemoryBucket();
+    const evilKey = 'evil/<img src=x onerror=alert(1)> & "quote".txt';
+    bucket.seed([{ key: evilKey, body: "X" }]);
+    seedShare(bucket, "evil", { key: evilKey, name: evilKey.split("/").pop(), isDir: false });
+    const response = await callShareGet(bucket, "evil");
+    const html = await response.text();
+    expect(html).toContain("&lt;img src=x onerror=alert(1)&gt;");
+    expect(html).not.toContain("<img src=x");
+    expect(html).toContain("&amp;");
+    expect(html).toContain("&quot;quote&quot;");
+  });
+
+  test("landing page localizes to zh with Accept-Language", async () => {
+    const bucket = new InMemoryBucket();
+    seedFileShare(bucket);
+    const response = await callShareGet(bucket, "tok1", "", { "Accept-Language": "zh-CN,zh;q=0.9" });
+    const html = await response.text();
+    expect(html).toContain("下载");
+    expect(html).toContain("文件分享");
+  });
+});
+
+describe("share raw / download responses", () => {
+  test("?download=1 is attachment with hardening headers", async () => {
+    const bucket = new InMemoryBucket();
+    seedFileShare(bucket);
+    const response = await callShareGet(bucket, "tok1", "?download=1");
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Content-Type")).toBe("text/plain");
+    expect(response.headers.get("Content-Security-Policy")).toBe("sandbox");
+    expect(response.headers.get("X-Content-Type-Options")).toBe("nosniff");
+    expect(response.headers.get("Cache-Control")).toBe("no-store");
+    expect(response.headers.get("Content-Disposition")).toContain("attachment");
+    expect(response.headers.get("Content-Disposition")).toContain("report.txt");
+    expect(await response.text()).toBe("Hello World");
+  });
+
+  test("?raw=1 inline for preview-safe type, attachment fallback for binary", async () => {
+    const bucket = new InMemoryBucket();
+    seedFileShare(bucket, "tok1");
+    const inline = await callShareGet(bucket, "tok1", "?raw=1");
+    expect(inline.headers.get("Content-Disposition")).toContain("inline");
+    expect(inline.headers.get("Content-Security-Policy")).toBe("sandbox");
+
+    const bucket2 = new InMemoryBucket();
+    bucket2.seed([{ key: "blob.bin", body: "\x00\x01", contentType: "application/octet-stream" }]);
+    seedShare(bucket2, "tok2", {
+      key: "blob.bin",
+      name: "blob.bin",
+      isDir: false,
+      expiresAt: null,
+      createdAt: null,
+    });
+    const binary = await callShareGet(bucket2, "tok2", "?raw=1");
+    expect(binary.headers.get("Content-Disposition")).toContain("attachment");
+  });
+
+  test("?raw=1 supports Range with 206 + Content-Range", async () => {
+    const bucket = new InMemoryBucket();
+    seedFileShare(bucket);
+    const response = await callShareGet(bucket, "tok1", "?raw=1", { Range: "bytes=0-4" });
+    expect(response.status).toBe(206);
+    expect(response.headers.get("Content-Range")).toBe("bytes 0-4/11");
+    expect(response.headers.get("Content-Length")).toBe("5");
+    expect(await response.text()).toBe("Hello");
+  });
+
+  test("missing backing object is 404 for landing and raw", async () => {
+    const bucket = new InMemoryBucket();
+    seedShare(bucket, "tok1", { key: "gone.txt", name: "gone.txt", isDir: false });
+    const landing = await callShareGet(bucket, "tok1");
+    expect(landing.status).toBe(404);
+    const raw = await callShareGet(bucket, "tok1", "?raw=1");
+    expect(raw.status).toBe(404);
+  });
+});
+
+describe("share extract code gate", () => {
+  function seedGatedShare(bucket: InMemoryBucket, token = "gate", code = "abcd") {
+    bucket.seed([{ key: "secret.txt", body: "SECRET", contentType: "text/plain" }]);
+    seedShare(bucket, token, {
+      key: "secret.txt",
+      name: "secret.txt",
+      isDir: false,
+      expiresAt: null,
+      createdAt: null,
+      extractCode: code,
+    });
+  }
+
+  test("no code shows the extract form without an error message", async () => {
+    const bucket = new InMemoryBucket();
+    seedGatedShare(bucket);
+    const response = await callShareGet(bucket, "gate");
+    expect(response.status).toBe(200);
+    const html = await response.text();
+    expect(html).toContain("Extract file");
+    expect(html).toContain('name="code"');
+    expect(html).not.toContain("Incorrect");
+  });
+
+  test("wrong ?code= is 403 with error; correct ?code= grants content", async () => {
+    const bucket = new InMemoryBucket();
+    seedGatedShare(bucket);
+    const wrong = await callShareGet(bucket, "gate", "?code=zzzz");
+    expect(wrong.status).toBe(403);
+    expect(await wrong.text()).toContain("Incorrect extract code");
+    const right = await callShareGet(bucket, "gate", "?code=abcd");
+    expect(right.status).toBe(200);
+    expect(await right.text()).toContain("secret.txt");
+    const raw = await callShareGet(bucket, "gate", "?code=abcd&raw=1");
+    expect(await raw.text()).toBe("SECRET");
+  });
+
+  test("cookie with the code hash grants access", async () => {
+    const bucket = new InMemoryBucket();
+    seedGatedShare(bucket);
+    const cookie = `fd_share_code=${await sha256Hex("abcd")}`;
+    const response = await callShareGet(bucket, "gate", "", { Cookie: cookie });
+    expect(response.status).toBe(200);
+    expect(await response.text()).toContain("secret.txt");
+    const raw = await callShareGet(bucket, "gate", "?raw=1", { Cookie: cookie });
+    expect(await raw.text()).toBe("SECRET");
+  });
+
+  test("POST correct code seeds cookie and 303s to clean URL", async () => {
+    const bucket = new InMemoryBucket();
+    seedGatedShare(bucket);
+    const response = await sharePost(
+      makeContext(
+        shareRequest("gate", "POST", "", {
+          "Content-Type": "application/x-www-form-urlencoded",
+        }, "code=abcd"),
+        makeEnv(bucket),
+        { token: "gate" }
+      )
+    );
+    expect(response.status).toBe(303);
+    expect(response.headers.get("Location")).toBe("/share/gate");
+    const setCookie = response.headers.get("Set-Cookie") ?? "";
+    expect(setCookie).toContain(`fd_share_code=${await sha256Hex("abcd")}`);
+    expect(setCookie).toContain("HttpOnly");
+    expect(setCookie).toContain("SameSite=Lax");
+    expect(setCookie).toContain("Path=/share/gate");
+  });
+
+  test("POST without code shows form; wrong code is 403", async () => {
+    const bucket = new InMemoryBucket();
+    seedGatedShare(bucket);
+    const empty = await sharePost(
+      makeContext(
+        shareRequest("gate", "POST", "", {
+          "Content-Type": "application/x-www-form-urlencoded",
+        }, "code="),
+        makeEnv(bucket),
+        { token: "gate" }
+      )
+    );
+    expect(empty.status).toBe(200);
+    const wrong = await sharePost(
+      makeContext(
+        shareRequest("gate", "POST", "", {
+          "Content-Type": "application/x-www-form-urlencoded",
+        }, "code=zzzz"),
+        makeEnv(bucket),
+        { token: "gate" }
+      )
+    );
+    expect(wrong.status).toBe(403);
+    expect(await wrong.text()).toContain("Incorrect extract code");
+  });
+
+  test("share without extract code POST just 303s to the landing page", async () => {
+    const bucket = new InMemoryBucket();
+    seedFileShare(bucket, "open");
+    const response = await sharePost(
+      makeContext(shareRequest("open", "POST"), makeEnv(bucket), { token: "open" })
+    );
+    expect(response.status).toBe(303);
+    expect(response.headers.get("Location")).toBe("/share/open");
+    expect(response.headers.get("Set-Cookie")).toBeNull();
+  });
+
+  test("HEAD gated without code is 403; with code mirrors GET", async () => {
+    const bucket = new InMemoryBucket();
+    seedGatedShare(bucket);
+    const gated = await shareHead(
+      makeContext(shareRequest("gate", "HEAD"), makeEnv(bucket), { token: "gate" })
+    );
+    expect(gated.status).toBe(403);
+    const granted = await shareHead(
+      makeContext(
+        shareRequest("gate", "HEAD", "?download=1", { Cookie: `fd_share_code=${await sha256Hex("abcd")}` }),
+        makeEnv(bucket),
+        { token: "gate" }
+      )
+    );
+    expect(granted.status).toBe(200);
+    expect(granted.headers.get("Content-Type")).toBe("text/plain");
+    const landing = await shareHead(
+      makeContext(
+        shareRequest("gate", "HEAD", "", { Cookie: `fd_share_code=${await sha256Hex("abcd")}` }),
+        makeEnv(bucket),
+        { token: "gate" }
+      )
+    );
+    expect(landing.status).toBe(200);
+    expect(landing.headers.get("Content-Type")).toContain("text/html");
+    expect(await landing.text()).toBe("");
+  });
+});
+
+describe("share expiry / revocation / guards", () => {
+  test("expired share is 410 on GET and HEAD", async () => {
+    const bucket = new InMemoryBucket();
+    seedFileShare(bucket, "expired");
+    seedShare(bucket, "expired", {
+      key: "docs/report.txt",
+      expiresAt: "2020-01-01T00:00:00.000Z",
+    });
+    const get = await callShareGet(bucket, "expired");
+    expect(get.status).toBe(410);
+    const head = await shareHead(
+      makeContext(shareRequest("expired", "HEAD"), makeEnv(bucket), { token: "expired" })
+    );
+    expect(head.status).toBe(410);
+  });
+
+  test("revoked (missing) share is 404", async () => {
+    const bucket = new InMemoryBucket();
+    const response = await callShareGet(bucket, "ghost");
+    expect(response.status).toBe(404);
+    expect(await response.text()).toContain("不存在");
+  });
+
+  test("metadata pointing at internal keys is rejected defensively", async () => {
+    const bucket = new InMemoryBucket();
+    seedShare(bucket, "internal", { key: "_$flaredrive$/apikeys/x.json" });
+    const response = await callShareGet(bucket, "internal");
+    expect(response.status).toBe(404);
+  });
+
+  test("metadata without a key is 404; missing token param is 404", async () => {
+    const bucket = new InMemoryBucket();
+    seedShare(bucket, "nokey", { name: "x" });
+    expect((await callShareGet(bucket, "nokey")).status).toBe(404);
+    expect((await callShareGet(bucket, null)).status).toBe(404);
+    expect(
+      (
+        await sharePost(makeContext(shareRequest(null, "POST"), makeEnv(bucket), { token: "" }))
+      ).status
+    ).toBe(404);
+  });
+
+  test("future expiry stays shareable", async () => {
+    const bucket = new InMemoryBucket();
+    seedFileShare(bucket, "future");
+    seedShare(bucket, "future", {
+      key: "docs/report.txt",
+      expiresAt: "2099-01-01T00:00:00.000Z",
+      createdAt: null,
+    });
+    expect((await callShareGet(bucket, "future")).status).toBe(200);
+  });
+});
+
+describe("share directory (zip download)", () => {
+  function seedDirShare(bucket: InMemoryBucket, token = "dir") {
+    bucket.seedDir("docs");
+    bucket.seed([{ key: "docs/a.txt", body: "A" }, { key: "docs/sub/b.txt", body: "B" }]);
+    seedShare(bucket, token, {
+      key: "docs",
+      name: "docs",
+      isDir: true,
+      expiresAt: null,
+      createdAt: "2026-01-01T00:00:00.000Z",
+    });
+  }
+
+  test("default GET is the landing page with folder badge", async () => {
+    const bucket = new InMemoryBucket();
+    seedDirShare(bucket);
+    const response = await callShareGet(bucket, "dir");
+    expect(response.status).toBe(200);
+    const html = await response.text();
+    expect(html).toContain("Folder (zip download)");
+    expect(html).not.toContain("<iframe");
+  });
+
+  test("?download=1 streams a zip with attachment + hardening headers", async () => {
+    const bucket = new InMemoryBucket();
+    seedDirShare(bucket);
+    const response = await callShareGet(bucket, "dir", "?download=1");
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Content-Type")).toBe("application/zip");
+    expect(response.headers.get("Content-Security-Policy")).toBe("sandbox");
+    expect(response.headers.get("X-Content-Type-Options")).toBe("nosniff");
+    expect(response.headers.get("Cache-Control")).toBe("no-store");
+    expect(response.headers.get("Content-Disposition")).toContain("attachment");
+    expect(response.headers.get("Content-Disposition")).toContain(".zip");
+  });
+
+  test("?raw=1 on a directory also zips; HEAD reports zip type", async () => {
+    const bucket = new InMemoryBucket();
+    seedDirShare(bucket);
+    const raw = await callShareGet(bucket, "dir", "?raw=1");
+    expect(raw.headers.get("Content-Type")).toBe("application/zip");
+    const head = await shareHead(
+      makeContext(shareRequest("dir", "HEAD", "?download=1"), makeEnv(bucket), { token: "dir" })
+    );
+    expect(head.status).toBe(200);
+    expect(head.headers.get("Content-Type")).toBe("application/zip");
+  });
+});

--- a/src/app/__tests__/sitesClient.test.ts
+++ b/src/app/__tests__/sitesClient.test.ts
@@ -1,21 +1,13 @@
 import { deleteSite, listSites, siteUrl, updateSiteConfig } from "../sites";
 import { authFetch } from "../auth";
 import { setLang } from "../strings";
+import { asAuthFetchMock } from "../testUtils";
 
 jest.mock("../auth", () => ({
   authFetch: jest.fn(),
 }));
 
-const mockAuthFetch = authFetch as unknown as jest.Mock;
-
-function jsonResponse(body: unknown, ok = true, status = 200) {
-  return {
-    ok,
-    status,
-    json: async () => body,
-    text: async () => JSON.stringify(body),
-  } as unknown as Response;
-}
+const mockAuthFetch = asAuthFetchMock(authFetch);
 
 beforeEach(() => {
   mockAuthFetch.mockReset();
@@ -23,19 +15,19 @@ beforeEach(() => {
 
 describe("sites / listSites", () => {
   test("不带 stats 时路径无查询参数", async () => {
-    mockAuthFetch.mockResolvedValue(jsonResponse({ sitesHost: null, sites: [] }));
+    mockAuthFetch.mockOk({ sitesHost: null, sites: [] });
     await listSites();
     expect(mockAuthFetch).toHaveBeenCalledWith("/api/sites");
   });
 
   test("withStats=true 带 ?stats=1", async () => {
-    mockAuthFetch.mockResolvedValue(jsonResponse({ sitesHost: "s.example.com", sites: [] }));
+    mockAuthFetch.mockOk({ sitesHost: "s.example.com", sites: [] });
     await listSites(true);
     expect(mockAuthFetch).toHaveBeenCalledWith("/api/sites?stats=1");
   });
 
   test("失败抛出默认文案", async () => {
-    mockAuthFetch.mockResolvedValue({ ok: false, status: 500, text: async () => "" } as unknown as Response);
+    mockAuthFetch.mockError(500);
     setLang("zh");
     await expect(listSites()).rejects.toThrow("获取站点列表失败");
   });
@@ -43,7 +35,7 @@ describe("sites / listSites", () => {
 
 describe("sites / updateSiteConfig", () => {
   test("POST slug 与 spa", async () => {
-    mockAuthFetch.mockResolvedValue({ ok: true, status: 200 } as unknown as Response);
+    mockAuthFetch.mockOk({});
     await updateSiteConfig("blog", true);
     const [url, init] = mockAuthFetch.mock.calls[0];
     expect(url).toBe("/api/sites");
@@ -52,14 +44,14 @@ describe("sites / updateSiteConfig", () => {
   });
 
   test("失败抛出响应文本", async () => {
-    mockAuthFetch.mockResolvedValue({ ok: false, status: 400, text: async () => "bad spa" } as unknown as Response);
+    mockAuthFetch.mockError(400, "bad spa");
     await expect(updateSiteConfig("blog", true)).rejects.toThrow("bad spa");
   });
 });
 
 describe("sites / deleteSite", () => {
   test("默认不带 purge", async () => {
-    mockAuthFetch.mockResolvedValue(jsonResponse({ deleted: 3 }));
+    mockAuthFetch.mockOk({ deleted: 3 });
     await expect(deleteSite("blog")).resolves.toBe(3);
     const [url, init] = mockAuthFetch.mock.calls[0];
     expect(url).toBe("/api/sites?slug=blog");
@@ -67,7 +59,7 @@ describe("sites / deleteSite", () => {
   });
 
   test("purge=true 带 purge=1 且 deleted 缺省返回 0", async () => {
-    mockAuthFetch.mockResolvedValue(jsonResponse({}));
+    mockAuthFetch.mockOk({});
     await expect(deleteSite("blog", { purge: true })).resolves.toBe(0);
     expect(mockAuthFetch.mock.calls[0][0]).toBe("/api/sites?slug=blog&purge=1");
   });

--- a/src/app/__tests__/transfer.test.ts
+++ b/src/app/__tests__/transfer.test.ts
@@ -11,6 +11,12 @@ import {
 } from "../transfer";
 import { authFetch } from "../auth";
 import { setLang } from "../strings";
+import {
+  asAuthFetchMock,
+  jsonResponse,
+  propfindResponse,
+  type PropfindEntry,
+} from "../testUtils";
 
 jest.mock("p-limit", () => ({
   __esModule: true,
@@ -22,50 +28,18 @@ jest.mock("../auth", () => ({
   basicAuthHeader: jest.fn(),
 }));
 
-const mockAuthFetch = authFetch as unknown as jest.Mock;
+const mockAuthFetch = asAuthFetchMock(authFetch);
 
-function jsonResponse(body: unknown, ok = true, status = 200) {
-  return {
-    ok,
-    status,
-    headers: { get: () => null },
-    json: async () => body,
-    text: async () => JSON.stringify(body),
-  } as unknown as Response;
-}
-
-function xmlResponse(body: string, ok = true) {
-  return {
-    ok,
-    status: ok ? 207 : 500,
-    headers: { get: (n: string) => (n.toLowerCase() === "content-type" ? "application/xml; charset=utf-8" : null) },
-    text: async () => body,
-  } as unknown as Response;
-}
-
-const XML_ONE_FILE = `<?xml version="1.0" encoding="utf-8"?>
-<multistatus>
-  <response>
-    <href>/webdav/</href>
-    <propstat>
-      <prop>
-        <resourcetype><collection/></resourcetype>
-        <getcontenttype>application/x-directory</getcontenttype>
-      </prop>
-    </propstat>
-  </response>
-  <response>
-    <href>/webdav/a.txt</href>
-    <propstat>
-      <prop>
-        <resourcetype/>
-        <getcontenttype>text/plain</getcontenttype>
-        <getcontentlength>12</getcontentlength>
-        <getlastmodified>Mon, 01 Jan 2026 00:00:00 GMT</getlastmodified>
-      </prop>
-    </propstat>
-  </response>
-</multistatus>`;
+// 根目录 + 单文件（等价于原手写 XML_ONE_FILE）
+const PROPFIND_ROOT_ONE_FILE: PropfindEntry[] = [
+  { href: "/webdav/", isDir: true, contentType: "application/x-directory" },
+  {
+    href: "/webdav/a.txt",
+    contentType: "text/plain",
+    size: 12,
+    lastModified: "Mon, 01 Jan 2026 00:00:00 GMT",
+  },
+];
 
 beforeEach(() => {
   mockAuthFetch.mockReset();
@@ -92,7 +66,7 @@ describe("transfer / davHrefToKey", () => {
 
 describe("transfer / fetchPath", () => {
   test("解析 PROPFIND XML 并过滤当前目录", async () => {
-    mockAuthFetch.mockResolvedValue(xmlResponse(XML_ONE_FILE));
+    mockAuthFetch.mockResolvedValue(propfindResponse(PROPFIND_ROOT_ONE_FILE));
     const items = await fetchPath("");
     expect(mockAuthFetch).toHaveBeenCalledWith("/webdav/", {
       method: "PROPFIND",
@@ -110,21 +84,21 @@ describe("transfer / fetchPath", () => {
   });
 
   test("非 XML 响应抛错", async () => {
-    mockAuthFetch.mockResolvedValue(jsonResponse({}, true));
+    mockAuthFetch.mockResolvedValue(jsonResponse({}));
     await expect(fetchPath("")).rejects.toThrow("Invalid response");
   });
 });
 
 describe("transfer / searchFiles", () => {
   test("映射搜索结果字段", async () => {
-    mockAuthFetch.mockResolvedValue(jsonResponse({
+    mockAuthFetch.mockOk({
       items: [
         { key: "docs/a.txt", size: 3, uploaded: "2026-01-01", contentType: "text/plain", thumbnail: null },
         { key: "docs/", size: 0, uploaded: null, contentType: "application/x-directory" },
       ],
       hasMore: true,
       nextCursor: "c1",
-    }));
+    });
     const res = await searchFiles("a", "c0", 50);
     expect(mockAuthFetch.mock.calls[0][0]).toBe("/api/search?q=a&limit=50&cursor=c0");
     expect(res.items[0]).toMatchObject({ key: "docs/a.txt", name: "a.txt", isDir: false });
@@ -133,7 +107,7 @@ describe("transfer / searchFiles", () => {
   });
 
   test("失败抛错", async () => {
-    mockAuthFetch.mockResolvedValue(jsonResponse({}, false, 500));
+    mockAuthFetch.mockError(500);
     await expect(searchFiles("a")).rejects.toThrow("Search failed");
   });
 });
@@ -145,14 +119,14 @@ describe("transfer / fetchFolderCounts", () => {
       expect(init?.method).toBe("POST");
       const body = JSON.parse(String(init?.body)) as { paths: string[] };
       expect(body.paths).toEqual(["a", "bad"]);
-      return jsonResponse({ counts: { a: 3, "bad-x": 0 } }, true, 200);
+      return jsonResponse({ counts: { a: 3, "bad-x": 0 } });
     });
     const counts = await fetchFolderCounts(["a", "bad"]);
     expect(counts).toEqual({ a: 3, "bad-x": 0 });
   });
 
   test("端点失败时返回空对象", async () => {
-    mockAuthFetch.mockImplementation(async () => jsonResponse({}, false, 500));
+    mockAuthFetch.mockError(500);
     const counts = await fetchFolderCounts(["a"]);
     expect(counts).toEqual({});
   });
@@ -174,13 +148,13 @@ describe("transfer / createFolder", () => {
   });
 
   test("成功 MKCOL", async () => {
-    mockAuthFetch.mockResolvedValue({ ok: true, status: 201 } as unknown as Response);
+    mockAuthFetch.mockOk({}, 201);
     await createFolder("docs/", "notes");
     expect(mockAuthFetch).toHaveBeenCalledWith("/webdav/docs/notes", { method: "MKCOL" });
   });
 
   test("MKCOL 失败抛错", async () => {
-    mockAuthFetch.mockResolvedValue({ ok: false, status: 405, text: async () => "no" } as unknown as Response);
+    mockAuthFetch.mockError(405, "no");
     await expect(createFolder("", "notes")).rejects.toThrow("新建文件夹失败");
   });
 });
@@ -189,7 +163,7 @@ describe("transfer / copyPaste", () => {
   beforeEach(() => setLang("zh"));
 
   test("COPY 与 MOVE 使用不同方法并设置 Destination", async () => {
-    mockAuthFetch.mockResolvedValue({ ok: true, status: 200 } as unknown as Response);
+    mockAuthFetch.mockOk({});
 
     await copyPaste("a.txt", "b.txt");
     let [url, init] = mockAuthFetch.mock.calls[0];
@@ -198,21 +172,21 @@ describe("transfer / copyPaste", () => {
     expect(String(init.headers.Destination)).toContain("/webdav/b.txt");
 
     mockAuthFetch.mockReset();
-    mockAuthFetch.mockResolvedValue({ ok: true, status: 200 } as unknown as Response);
+    mockAuthFetch.mockOk({});
     await copyPaste("a.txt", "b.txt", true);
     [url, init] = mockAuthFetch.mock.calls[0];
     expect(init.method).toBe("MOVE");
   });
 
   test("失败抛错", async () => {
-    mockAuthFetch.mockResolvedValue({ ok: false, status: 409, text: async () => "x" } as unknown as Response);
+    mockAuthFetch.mockError(409, "x");
     await expect(copyPaste("a", "b")).rejects.toThrow("复制失败");
   });
 });
 
 describe("transfer / ensureParentDirs", () => {
   test("逐级 MKCOL，重复目录跳过", async () => {
-    mockAuthFetch.mockResolvedValue({ ok: true, status: 201 } as unknown as Response);
+    mockAuthFetch.mockOk({}, 201);
     await ensureParentDirs("a/b/c/file.txt");
     expect(mockAuthFetch).toHaveBeenCalledTimes(3);
     expect(mockAuthFetch.mock.calls[0][0]).toBe("/webdav/a");

--- a/src/app/__tests__/transferCoverage.test.ts
+++ b/src/app/__tests__/transferCoverage.test.ts
@@ -12,6 +12,11 @@ import {
 } from "../transfer";
 import { authFetch, basicAuthHeader } from "../auth";
 import { setLang } from "../strings";
+import {
+  asAuthFetchMock,
+  propfindResponse,
+  type PropfindEntry,
+} from "../testUtils";
 
 jest.mock("p-limit", () => ({
   __esModule: true,
@@ -23,20 +28,20 @@ jest.mock("../auth", () => ({
   basicAuthHeader: jest.fn(() => "Basic abc"),
 }));
 
-const mockAuthFetch = authFetch as unknown as jest.Mock;
+const mockAuthFetch = asAuthFetchMock(authFetch);
 const mockBasic = basicAuthHeader as unknown as jest.Mock;
 
-function xmlResponse(body: string) {
-  return {
-    ok: true,
-    status: 207,
-    headers: {
-      get: (n: string) =>
-        n.toLowerCase() === "content-type" ? "application/xml; charset=utf-8" : null,
-    },
-    text: async () => body,
-  } as unknown as Response;
-}
+// 空 href 跳过 / 纯 collection 目录 / 带缩略图的图片（等价于原手写 XML）
+const PROPFIND_LEFTOVERS: PropfindEntry[] = [
+  { href: "" },
+  { href: "/webdav/docs/", isDir: true },
+  {
+    href: "/webdav/pic.png",
+    contentType: "image/png",
+    size: 9,
+    thumbnail: "abc",
+  },
+];
 
 beforeEach(() => {
   mockAuthFetch.mockReset();
@@ -58,26 +63,7 @@ describe("davHrefToKey leftovers", () => {
 
 describe("fetchPath leftovers", () => {
   test("parses collection dirs, thumbnails, and skips empty href", async () => {
-    const xml = `<?xml version="1.0"?>
-<multistatus>
-  <response><href></href><propstat><prop/></propstat></response>
-  <response>
-    <href>/webdav/docs/</href>
-    <propstat><prop>
-      <resourcetype><collection/></resourcetype>
-    </prop></propstat>
-  </response>
-  <response>
-    <href>/webdav/pic.png</href>
-    <propstat><prop>
-      <getcontenttype>image/png</getcontenttype>
-      <getcontentlength>9</getcontentlength>
-      <getlastmodified></getlastmodified>
-      <thumbnail xmlns="flaredrive">abc</thumbnail>
-    </prop></propstat>
-  </response>
-</multistatus>`;
-    mockAuthFetch.mockResolvedValue(xmlResponse(xml));
+    mockAuthFetch.mockResolvedValue(propfindResponse(PROPFIND_LEFTOVERS));
     const items = await fetchPath("");
     const dir = items.find((i) => i.key === "docs");
     const pic = items.find((i) => i.key === "pic.png");

--- a/src/app/__tests__/transferExtra.test.ts
+++ b/src/app/__tests__/transferExtra.test.ts
@@ -10,6 +10,7 @@ import {
 } from "../transfer";
 import { authFetch } from "../auth";
 import { setLang } from "../strings";
+import { asAuthFetchMock } from "../testUtils";
 
 jest.mock("p-limit", () => ({
   __esModule: true,
@@ -21,7 +22,7 @@ jest.mock("../auth", () => ({
   basicAuthHeader: jest.fn(),
 }));
 
-const mockAuthFetch = authFetch as unknown as jest.Mock;
+const mockAuthFetch = asAuthFetchMock(authFetch);
 
 function blobResponse(ok = true) {
   return {

--- a/src/app/__tests__/transferMultipart.test.ts
+++ b/src/app/__tests__/transferMultipart.test.ts
@@ -1,0 +1,609 @@
+/**
+ * transfer.ts 分块上传（multipartUpload）与 processTransferTask 的分支补充：
+ * 创建/分片/重试/断点续传/完成各阶段失败路径，缩略图副作用，收集与选择器回退。
+ */
+import {
+  collectFilesFromDataTransfer,
+  copyPaste,
+  davHrefToKey,
+  fetchFolderCounts,
+  generateThumbnail,
+  multipartUpload,
+  processTransferTask,
+  selectDirectoryFiles,
+  SIZE_LIMIT,
+} from "../transfer";
+import { authFetch, basicAuthHeader } from "../auth";
+import { setLang } from "../strings";
+import { asAuthFetchMock, jsonResponse } from "../testUtils";
+import type { UploadPart } from "../types";
+
+jest.mock("p-limit", () => ({
+  __esModule: true,
+  default: () => (fn: () => Promise<unknown>) => fn(),
+}));
+
+jest.mock("../auth", () => ({
+  authFetch: jest.fn(),
+  basicAuthHeader: jest.fn(() => "Basic abc"),
+}));
+
+const mockAuthFetch = asAuthFetchMock(authFetch);
+const mockBasic = basicAuthHeader as unknown as jest.Mock;
+
+beforeEach(() => {
+  mockAuthFetch.mockReset();
+  mockBasic.mockReturnValue("Basic abc");
+  setLang("zh");
+  if (!(URL as any).createObjectURL) {
+    (URL as any).createObjectURL = jest.fn(() => "blob:x");
+  }
+  if (!(URL as any).revokeObjectURL) {
+    (URL as any).revokeObjectURL = jest.fn();
+  }
+  // jsdom 的 Blob 可能缺 arrayBuffer()，blobDigest 依赖它；用 FileReader 补齐
+  if (typeof (Blob.prototype as any).arrayBuffer !== "function") {
+    (Blob.prototype as any).arrayBuffer = async function () {
+      return new Promise<ArrayBuffer>((resolve, reject) => {
+        const reader = new FileReader();
+        reader.onload = () => resolve(reader.result as ArrayBuffer);
+        reader.onerror = () => reject(reader.error);
+        reader.readAsArrayBuffer(this);
+      });
+    };
+  }
+  jest.spyOn(console, "log").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  (console.log as jest.Mock).mockRestore();
+});
+
+function bigFile(size = SIZE_LIMIT * 2, type = "application/octet-stream"): File {
+  const file = new File(["chunk"], "big.bin", { type });
+  Object.defineProperty(file, "size", { value: size });
+  file.slice = jest.fn((start: number, end: number) => {
+    const len = Math.max(0, Math.min(end, size) - start);
+    return new Blob([new Uint8Array(len)]);
+  }) as any;
+  return file;
+}
+
+function okCreate(uploadId = "u1") {
+  return {
+    ok: true,
+    status: 200,
+    headers: { get: () => null },
+    json: async () => ({ uploadId }),
+    text: async () => "",
+  } as unknown as Response;
+}
+
+function okComplete() {
+  return {
+    ok: true,
+    status: 200,
+    headers: { get: () => null },
+    text: async () => "done",
+  } as unknown as Response;
+}
+
+class MockXHR {
+  static mode: "ok" | "status500" | "noEtag" = "ok";
+  static sends = 0;
+  upload = { onprogress: null as any };
+  status = 200;
+  responseText = "part";
+  onload: any;
+  onerror: any;
+  onabort: any;
+  open() {}
+  setRequestHeader() {}
+  getAllResponseHeaders() {
+    if (MockXHR.mode === "status500") return "";
+    return "etag: \"etag-1\"\r\nContent-Length: 2";
+  }
+  abort() {
+    this.onabort?.();
+  }
+  send() {
+    MockXHR.sends += 1;
+    if (this.upload.onprogress) {
+      this.upload.onprogress({ loaded: 2, total: 2 });
+    }
+    if (MockXHR.mode === "status500") {
+      this.status = 500;
+      this.responseText = "boom";
+      this.onload?.();
+      return;
+    }
+    if (MockXHR.mode === "noEtag") {
+      (this as any).getAllResponseHeaders = () => "Content-Length: 2";
+      this.status = 200;
+      this.onload?.();
+      return;
+    }
+    this.status = 200;
+    this.onload?.();
+  }
+}
+
+beforeEach(() => {
+  (global as any).XMLHttpRequest = MockXHR;
+  MockXHR.mode = "ok";
+  MockXHR.sends = 0;
+});
+
+describe("multipartUpload 失败路径", () => {
+  test("创建会话失败：非 ok 抛出 text() 内容", async () => {
+    mockAuthFetch.mockResolvedValue({
+      ok: false,
+      status: 500,
+      headers: { get: () => null },
+      text: async () => "create denied",
+    } as unknown as Response);
+    await expect(
+      multipartUpload("big.bin", bigFile(SIZE_LIMIT))
+    ).rejects.toThrow("create denied");
+  });
+
+  test("创建会话失败：空 body 走默认文案", async () => {
+    mockAuthFetch.mockResolvedValue({
+      ok: false,
+      status: 502,
+      headers: { get: () => null },
+      text: async () => "",
+    } as unknown as Response);
+    await expect(
+      multipartUpload("big.bin", bigFile(SIZE_LIMIT))
+    ).rejects.toThrow();
+  });
+
+  test("分片请求前 signal 已 abort 抛 AbortError", async () => {
+    mockAuthFetch.mockResolvedValue(okCreate());
+    const controller = new AbortController();
+    controller.abort();
+    await expect(
+      multipartUpload("big.bin", bigFile(SIZE_LIMIT), { signal: controller.signal })
+    ).rejects.toThrow("Aborted");
+  });
+
+  test("signal 在创建之后、分片之前被置位也抛 AbortError", async () => {
+    mockAuthFetch.mockResolvedValue(okCreate());
+    // 第一次读 aborted=false（hook 内检查），xhrFetch 里再读为 true
+    let reads = 0;
+    const signal = {
+      get aborted() {
+        reads += 1;
+        return reads > 1;
+      },
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+    } as unknown as AbortSignal;
+    await expect(
+      multipartUpload("big.bin", bigFile(SIZE_LIMIT), { signal })
+    ).rejects.toThrow("Aborted");
+  });
+
+  test("分片返回 500：抛出响应文本", async () => {
+    MockXHR.mode = "status500";
+    mockAuthFetch.mockResolvedValueOnce(okCreate());
+    mockAuthFetch.mockResolvedValueOnce(okComplete());
+    await expect(
+      multipartUpload("big.bin", bigFile(SIZE_LIMIT))
+    ).rejects.toThrow("boom");
+  });
+
+  test("分片缺少 ETag：抛 partMissingEtag", async () => {
+    MockXHR.mode = "noEtag";
+    mockAuthFetch.mockResolvedValueOnce(okCreate());
+    mockAuthFetch.mockResolvedValueOnce(okComplete());
+    await expect(
+      multipartUpload("big.bin", bigFile(SIZE_LIMIT))
+    ).rejects.toThrow();
+  });
+
+  test("complete 失败：抛出响应文本", async () => {
+    mockAuthFetch
+      .mockResolvedValueOnce(okCreate())
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 400,
+        headers: { get: () => null },
+        text: async () => "complete rejected",
+      } as unknown as Response);
+    await expect(
+      multipartUpload("big.bin", bigFile(SIZE_LIMIT))
+    ).rejects.toThrow("complete rejected");
+  });
+});
+
+describe("multipartUpload 成功与续传", () => {
+  test("上传单分片文件：进度回调与 onState 持久化", async () => {
+    mockAuthFetch.mockResolvedValueOnce(okCreate());
+    mockAuthFetch.mockResolvedValueOnce(okComplete());
+    const onUploadProgress = jest.fn();
+    const onState = jest.fn();
+    const res = await multipartUpload("big.bin", bigFile(SIZE_LIMIT), {
+      onUploadProgress,
+      onState,
+    });
+    expect(res.ok).toBe(true);
+    expect(onUploadProgress).toHaveBeenCalledWith({
+      loaded: SIZE_LIMIT,
+      total: SIZE_LIMIT,
+    });
+    expect(onState).toHaveBeenCalledWith({
+      uploadId: "u1",
+      uploadedParts: [{ partNumber: 1, etag: '"etag-1"' }],
+      loaded: SIZE_LIMIT,
+    });
+    // complete 请求体带上已传分片
+    const completeInit = mockAuthFetch.mock.calls[1][1] as RequestInit;
+    expect(JSON.parse(String(completeInit.body))).toEqual({
+      parts: [{ partNumber: 1, etag: '"etag-1"' }],
+    });
+  });
+
+  test("断点续传：已有 uploadId + uploadedParts 只补缺失分片", async () => {
+    mockAuthFetch.mockResolvedValueOnce(okComplete());
+    const onUploadProgress = jest.fn();
+    const uploadedParts: UploadPart[] = [{ partNumber: 1, etag: '"e1"' }];
+    const res = await multipartUpload("big.bin", bigFile(SIZE_LIMIT * 2), {
+      uploadId: "u9",
+      uploadedParts,
+      onUploadProgress,
+    });
+    expect(res.ok).toBe(true);
+    // 只应 PUT 一个缺失分片（part 2）
+    expect(MockXHR.sends).toBe(1);
+    // 进度初值含已传分片大小
+    expect(onUploadProgress).toHaveBeenCalledWith({
+      loaded: SIZE_LIMIT,
+      total: SIZE_LIMIT * 2,
+    });
+    const completeInit = mockAuthFetch.mock.calls[0][1] as RequestInit;
+    const body = JSON.parse(String(completeInit.body));
+    expect(body.parts).toEqual([
+      { partNumber: 1, etag: '"e1"' },
+      { partNumber: 2, etag: '"etag-1"' },
+    ]);
+    // 分片按 partNumber 升序
+    expect(body.parts[0].partNumber).toBeLessThan(body.parts[1].partNumber);
+  });
+});
+
+describe("processTransferTask 缩略图副作用与分块路径", () => {
+  // ensureParentDirs 用模块级 ensuredDirs 缓存，跨用例共享；
+  // 每个用例用不同目录，避免 MKCOL 被前一个用例吞掉导致断言错位。
+  let caseSeq = 0;
+  function uploadTask(file: File, extra: Record<string, unknown> = {}) {
+    caseSeq += 1;
+    const remoteKey = `docs${caseSeq}/big.bin`;
+    return {
+      id: `t${caseSeq}`,
+      type: "upload",
+      status: "in-progress",
+      name: file.name,
+      basedir: `docs${caseSeq}/`,
+      remoteKey,
+      loaded: 0,
+      total: file.size,
+      file,
+      ...extra,
+    } as any;
+  }
+
+  test("大文件走 multipart，且缩略图上传成功时带 fd-thumbnail", async () => {
+    // 图片缩略图：MockImage 立即 onload
+    class MockImage {
+      onload: (() => void) | null = null;
+      onerror: (() => void) | null = null;
+      set src(_v: string) {
+        queueMicrotask(() => this.onload?.());
+      }
+    }
+    (global as any).Image = MockImage;
+    HTMLCanvasElement.prototype.getContext = jest.fn(
+      () => ({ drawImage: jest.fn() }) as any
+    ) as any;
+    HTMLCanvasElement.prototype.toBlob = function (cb: BlobCallback) {
+      cb(new Blob(["png"], { type: "image/png" }));
+    } as any;
+
+    // MKCOL(ensureParentDirs) + 缩略图 PUT + create + complete
+    mockAuthFetch
+      .mockResolvedValueOnce(jsonResponse({}, true, 201)) // MKCOL docs
+      .mockResolvedValueOnce(jsonResponse({}, true)) // thumbnail PUT
+      .mockResolvedValueOnce(okCreate())
+      .mockResolvedValueOnce(okComplete());
+
+    const file = bigFile(SIZE_LIMIT * 2, "image/png");
+    const onTaskState = jest.fn();
+    const res = await processTransferTask({
+      task: uploadTask(file),
+      onTaskState,
+    });
+    expect(res.ok).toBe(true);
+    const thumbnailCall = mockAuthFetch.mock.calls[1];
+    expect(String(thumbnailCall[0])).toContain("_$flaredrive$/thumbnails/");
+    const createInit = mockAuthFetch.mock.calls[2][1] as RequestInit;
+    expect((createInit.headers as Record<string, string>)["fd-thumbnail"]).toBeDefined();
+    expect(onTaskState).toHaveBeenCalled();
+  });
+
+  test("缩略图 PUT 失败不阻塞上传且不带 fd-thumbnail", async () => {
+    class MockImage {
+      onload: (() => void) | null = null;
+      onerror: (() => void) | null = null;
+      set src(_v: string) {
+        queueMicrotask(() => this.onload?.());
+      }
+    }
+    (global as any).Image = MockImage;
+    HTMLCanvasElement.prototype.getContext = jest.fn(
+      () => ({ drawImage: jest.fn() }) as any
+    ) as any;
+    HTMLCanvasElement.prototype.toBlob = function (cb: BlobCallback) {
+      cb(new Blob(["png"], { type: "image/png" }));
+    } as any;
+
+    mockAuthFetch
+      .mockResolvedValueOnce(jsonResponse({}, true, 201)) // MKCOL
+      .mockRejectedValueOnce(new Error("thumb put fail")) // 缩略图 PUT 失败
+      .mockResolvedValueOnce(okCreate())
+      .mockResolvedValueOnce(okComplete());
+
+    const res = await processTransferTask({
+      task: uploadTask(bigFile(SIZE_LIMIT * 2, "image/png")),
+    });
+    expect(res.ok).toBe(true);
+    const createInit = mockAuthFetch.mock.calls[2][1] as RequestInit;
+    expect((createInit.headers as Record<string, string>)["fd-thumbnail"]).toBeUndefined();
+  });
+
+  test("generateThumbnail 失败不阻塞上传（video 载入失败分支）", async () => {
+    // video/mp4：创建 video 后手动触发 onerror
+    const origCreate = document.createElement.bind(document);
+    jest.spyOn(document, "createElement").mockImplementation((tag: string) => {
+      const el = origCreate(tag);
+      if (tag === "video") {
+        queueMicrotask(() => (el as HTMLVideoElement).onerror?.(new Event("error")));
+      }
+      return el;
+    });
+    HTMLCanvasElement.prototype.getContext = jest.fn(
+      () => ({ drawImage: jest.fn() }) as any
+    ) as any;
+    HTMLCanvasElement.prototype.toBlob = function (cb: BlobCallback) {
+      cb(new Blob(["png"], { type: "image/png" }));
+    } as any;
+
+    mockAuthFetch
+      .mockResolvedValueOnce(jsonResponse({}, true, 201)) // MKCOL
+      .mockResolvedValueOnce(okCreate())
+      .mockResolvedValueOnce(okComplete());
+
+    const res = await processTransferTask({
+      task: uploadTask(bigFile(SIZE_LIMIT * 2, "video/mp4")),
+    });
+    expect(res.ok).toBe(true);
+    (document.createElement as jest.Mock).mockRestore();
+  });
+
+  test("video 缩略图成功分支：loadeddata + play", async () => {
+    jest
+      .spyOn(HTMLVideoElement.prototype, "play")
+      .mockResolvedValue(undefined as unknown as Promise<void>);
+    const origCreate = document.createElement.bind(document);
+    jest.spyOn(document, "createElement").mockImplementation((tag: string) => {
+      const el = origCreate(tag);
+      if (tag === "video") {
+        queueMicrotask(() => (el as HTMLVideoElement).onloadeddata?.(new Event("loadeddata")));
+      }
+      return el;
+    });
+    HTMLCanvasElement.prototype.getContext = jest.fn(
+      () => ({ drawImage: jest.fn() }) as any
+    ) as any;
+    HTMLCanvasElement.prototype.toBlob = function (cb: BlobCallback) {
+      cb(new Blob(["png"], { type: "image/png" }));
+    } as any;
+
+    mockAuthFetch
+      .mockResolvedValueOnce(jsonResponse({}, true, 201))
+      .mockResolvedValueOnce(jsonResponse({}, true))
+      .mockResolvedValueOnce(okCreate())
+      .mockResolvedValueOnce(okComplete());
+
+    const res = await processTransferTask({
+      task: uploadTask(bigFile(SIZE_LIMIT * 2, "video/mp4")),
+    });
+    expect(res.ok).toBe(true);
+    (document.createElement as jest.Mock).mockRestore();
+  });
+
+  test("非媒体类型跳过缩略图直接上传（小文件）", async () => {
+    mockAuthFetch
+      .mockResolvedValueOnce(jsonResponse({}, true, 201)) // MKCOL
+      .mockResolvedValueOnce(okComplete());
+
+    const file = new File(["hello"], "plain.txt", { type: "text/plain" });
+    const onTaskProgress = jest.fn();
+    const res = await processTransferTask({
+      task: uploadTask(file),
+      onTaskProgress,
+    });
+    expect(res.ok).toBe(true);
+    // 仅 MKCOL 一次；文件本体走 XHR PUT，无缩略图请求
+    expect(mockAuthFetch).toHaveBeenCalledTimes(1);
+  });
+
+  test("普通类型达到阈值也走 multipart（非媒体 → 无缩略图）", async () => {
+    mockAuthFetch
+      .mockResolvedValueOnce(jsonResponse({}, true, 201))
+      .mockResolvedValueOnce(okCreate())
+      .mockResolvedValueOnce(okComplete());
+    const res = await processTransferTask({
+      task: uploadTask(bigFile(SIZE_LIMIT * 2, "application/octet-stream")),
+    });
+    expect(res.ok).toBe(true);
+    expect(mockAuthFetch).toHaveBeenCalledTimes(3); // MKCOL + create + complete
+  });
+});
+
+describe("generateThumbnail / pdf 分支", () => {
+  test("pdf 走远程 pdf.js 动态导入，测试环境加载失败即拒绝", async () => {
+    HTMLCanvasElement.prototype.getContext = jest.fn(
+      () => ({ drawImage: jest.fn() }) as any
+    ) as any;
+    await expect(
+      generateThumbnail(new File(["pdf"], "a.pdf", { type: "application/pdf" }))
+    ).rejects.toThrow();
+  });
+
+  test("非图片/视频/pdf 直接出空画布缩略图", async () => {
+    HTMLCanvasElement.prototype.getContext = jest.fn(
+      () => ({ drawImage: jest.fn() }) as any
+    ) as any;
+    HTMLCanvasElement.prototype.toBlob = function (cb: BlobCallback) {
+      cb(new Blob(["png"], { type: "image/png" }));
+    } as any;
+    const blob = await generateThumbnail(
+      new File(["x"], "a.txt", { type: "text/plain" })
+    );
+    expect(blob).toBeInstanceOf(Blob);
+  });
+});
+
+describe("collectFilesFromDataTransfer 补充分支", () => {
+  test("files 为空、items 也为空时返回空数组", async () => {
+    const dt = { files: null, items: [] } as unknown as DataTransfer;
+    await expect(collectFilesFromDataTransfer(dt)).resolves.toEqual([]);
+  });
+
+  test("entry.file 拒绝时整体失败", async () => {
+    const dt = {
+      files: [],
+      items: [
+        {
+          webkitGetAsEntry: () => ({
+            isFile: true,
+            isDirectory: false,
+            name: "bad.txt",
+            file: (
+              _resolve: (f: File) => void,
+              reject: (e: Error) => void
+            ) => reject(new Error("read denied")),
+          }),
+        },
+      ],
+    } as unknown as DataTransfer;
+    await expect(collectFilesFromDataTransfer(dt)).rejects.toThrow("read denied");
+  });
+
+  test("目录 readEntries 拒绝时整体失败", async () => {
+    const dt = {
+      files: [],
+      items: [
+        {
+          webkitGetAsEntry: () => ({
+            isFile: false,
+            isDirectory: true,
+            name: "d",
+            createReader: () => ({
+              readEntries: (
+                _resolve: (e: unknown[]) => void,
+                reject: (err: Error) => void
+              ) => reject(new Error("entry denied")),
+            }),
+          }),
+        },
+      ],
+    } as unknown as DataTransfer;
+    await expect(collectFilesFromDataTransfer(dt)).rejects.toThrow("entry denied");
+  });
+});
+
+describe("selectDirectoryFiles 补充分支", () => {
+  afterEach(() => {
+    delete (window as any).showDirectoryPicker;
+  });
+
+  test("picker 非 AbortError 失败时回退 input 选择器", async () => {
+    (window as any).showDirectoryPicker = async () => {
+      throw new Error("security");
+    };
+    const orig = document.createElement.bind(document);
+    jest.spyOn(document, "createElement").mockImplementation((tag: string) => {
+      const el = orig(tag) as HTMLInputElement;
+      if (tag === "input") {
+        el.click = () => {
+          Object.defineProperty(el, "files", {
+            value: [new File(["a"], "fallback.txt")],
+            configurable: true,
+          });
+          el.onchange?.(new Event("change") as any);
+        };
+      }
+      return el;
+    });
+    const files = await selectDirectoryFiles();
+    expect(files[0].name).toBe("fallback.txt");
+    (document.createElement as jest.Mock).mockRestore();
+  });
+
+  test("input oncancel 返回空数组", async () => {
+    delete (window as any).showDirectoryPicker;
+    const orig = document.createElement.bind(document);
+    jest.spyOn(document, "createElement").mockImplementation((tag: string) => {
+      const el = orig(tag) as HTMLInputElement;
+      if (tag === "input") {
+        el.click = () => el.oncancel?.(new Event("cancel") as any);
+      }
+      return el;
+    });
+    await expect(selectDirectoryFiles()).resolves.toEqual([]);
+    (document.createElement as jest.Mock).mockRestore();
+  });
+});
+
+describe("其余小分支", () => {
+  test("davHrefToKey：非法协议且含 /webdav/ 时回退切片", () => {
+    expect(davHrefToKey("::::/webdav/x.txt")).toBe("x.txt");
+  });
+
+  test("davHrefToKey：非法协议且无 /webdav/ 时原样返回", () => {
+    expect(davHrefToKey("::::foo")).toBe("::::foo");
+  });
+
+  test("fetchFolderCounts：counts 为 null 返回空对象", async () => {
+    mockAuthFetch.mockResolvedValue(jsonResponse({}));
+    await expect(fetchFolderCounts(["a"])).resolves.toEqual({});
+  });
+
+  test("fetchFolderCounts：json 解析失败返回空对象", async () => {
+    mockAuthFetch.mockResolvedValue({
+      ok: true,
+      headers: { get: () => null },
+      json: async () => {
+        throw new Error("bad json");
+      },
+    } as unknown as Response);
+    await expect(fetchFolderCounts(["a"])).resolves.toEqual({});
+  });
+
+  test("copyPaste MOVE 失败抛移动失败文案", async () => {
+    mockAuthFetch.mockError(409, "x");
+    await expect(copyPaste("a", "b", true)).rejects.toThrow("移动失败");
+  });
+
+  test("xhrFetch：Blob/字符串之外的非空 body 不会 send（记录现状）", async () => {
+    // 佐证 xhrFetch 只对 Blob/字符串 send：用 multipartUpload 的 Blob 分片路径
+    // 覆盖正常分支即可，此处直接验证分片确实以 Blob 发送（MockXHR.sends）。
+    mockAuthFetch.mockResolvedValueOnce(okCreate());
+    mockAuthFetch.mockResolvedValueOnce(okComplete());
+    await multipartUpload("big.bin", bigFile(SIZE_LIMIT));
+    expect(MockXHR.sends).toBe(1);
+  });
+});

--- a/src/app/__tests__/trash.test.ts
+++ b/src/app/__tests__/trash.test.ts
@@ -6,21 +6,13 @@ import {
 } from "../trash";
 import { authFetch } from "../auth";
 import { setLang } from "../strings";
+import { asAuthFetchMock } from "../testUtils";
 
 jest.mock("../auth", () => ({
   authFetch: jest.fn(),
 }));
 
-const mockAuthFetch = authFetch as unknown as jest.Mock;
-
-function jsonResponse(body: unknown, ok = true, status = 200) {
-  return {
-    ok,
-    status,
-    json: async () => body,
-    text: async () => JSON.stringify(body),
-  } as unknown as Response;
-}
+const mockAuthFetch = asAuthFetchMock(authFetch);
 
 beforeEach(() => {
   mockAuthFetch.mockReset();
@@ -29,12 +21,12 @@ beforeEach(() => {
 describe("trash / listTrash", () => {
   test("成功返回 JSON", async () => {
     const items = [{ trashKey: "t", originalKey: "a.txt", name: "a.txt", deletedAt: "", size: 1 }];
-    mockAuthFetch.mockResolvedValue(jsonResponse(items));
+    mockAuthFetch.mockOk(items);
     await expect(listTrash()).resolves.toEqual(items);
   });
 
   test("失败抛出默认文案", async () => {
-    mockAuthFetch.mockResolvedValue({ ok: false, status: 500, text: async () => "" } as unknown as Response);
+    mockAuthFetch.mockError(500);
     setLang("zh");
     await expect(listTrash()).rejects.toThrow("获取回收站失败");
   });
@@ -43,7 +35,7 @@ describe("trash / listTrash", () => {
 describe("trash / moveToTrash", () => {
   test("POST keys 并返回 results", async () => {
     const result = { results: [{ key: "a.txt", id: "t1" }] };
-    mockAuthFetch.mockResolvedValue(jsonResponse(result));
+    mockAuthFetch.mockOk(result);
     await moveToTrash(["a.txt", "b.txt"]);
     const [url, init] = mockAuthFetch.mock.calls[0];
     expect(url).toBe("/api/trash");
@@ -54,7 +46,7 @@ describe("trash / moveToTrash", () => {
 
 describe("trash / restoreTrash", () => {
   test("POST restore action", async () => {
-    mockAuthFetch.mockResolvedValue(jsonResponse([]));
+    mockAuthFetch.mockOk([]);
     await restoreTrash(["t1"]);
     const [url, init] = mockAuthFetch.mock.calls[0];
     expect(url).toBe("/api/trash?action=restore");
@@ -65,7 +57,7 @@ describe("trash / restoreTrash", () => {
 
 describe("trash / permanentDeleteTrash", () => {
   test("DELETE 默认 all=false", async () => {
-    mockAuthFetch.mockResolvedValue({ ok: true, status: 200 } as unknown as Response);
+    mockAuthFetch.mockOk({});
     await permanentDeleteTrash(["t1"]);
     const [url, init] = mockAuthFetch.mock.calls[0];
     expect(url).toBe("/api/trash");
@@ -74,7 +66,7 @@ describe("trash / permanentDeleteTrash", () => {
   });
 
   test("DELETE all=true", async () => {
-    mockAuthFetch.mockResolvedValue({ ok: true, status: 200 } as unknown as Response);
+    mockAuthFetch.mockOk({});
     await permanentDeleteTrash([], true);
     expect(JSON.parse(mockAuthFetch.mock.calls[0][1].body)).toEqual({ trashKeys: [], all: true });
   });
@@ -82,18 +74,18 @@ describe("trash / permanentDeleteTrash", () => {
 
 describe("trash / 错误路径", () => {
   test("moveToTrash 失败抛出响应文本", async () => {
-    mockAuthFetch.mockResolvedValue({ ok: false, status: 400, text: async () => "bad move" } as unknown as Response);
+    mockAuthFetch.mockError(400, "bad move");
     await expect(moveToTrash(["a"])).rejects.toThrow("bad move");
   });
 
   test("restoreTrash 失败抛出默认文案", async () => {
-    mockAuthFetch.mockResolvedValue({ ok: false, status: 500, text: async () => "" } as unknown as Response);
+    mockAuthFetch.mockError(500);
     setLang("zh");
     await expect(restoreTrash(["t"])).rejects.toThrow("恢复失败");
   });
 
   test("permanentDeleteTrash 失败抛出默认文案", async () => {
-    mockAuthFetch.mockResolvedValue({ ok: false, status: 500, text: async () => "" } as unknown as Response);
+    mockAuthFetch.mockError(500);
     setLang("zh");
     await expect(permanentDeleteTrash(["t"])).rejects.toThrow("彻底删除失败");
   });

--- a/src/app/__tests__/trashApi.test.ts
+++ b/src/app/__tests__/trashApi.test.ts
@@ -1,0 +1,434 @@
+/**
+ * functions/api/trash.ts 分支级直测：软删 marker 生成、列表、还原（含父目录
+ * marker 重建 / 虚拟目录补 marker）、清空、过期惰性清理、鉴权、内部前缀保护。
+ */
+import {
+  onRequestDelete,
+  onRequestGet,
+  onRequestPost,
+  softDeleteKeys,
+} from "../../../functions/api/trash";
+import {
+  InMemoryBucket,
+  basicAuthHeader,
+  makeContext,
+} from "../testInMemoryBucket";
+
+const AUTH = basicAuthHeader("user", "pass");
+const TRASH_PREFIX = "_$flaredrive$/trash/";
+
+function makeEnv(bucket: InMemoryBucket, extra: Record<string, unknown> = {}) {
+  return {
+    BUCKET: bucket.asBucket(),
+    WEBDAV_USERNAME: "user",
+    WEBDAV_PASSWORD: "pass",
+    ...extra,
+  };
+}
+
+function get(path = "/api/trash"): Request {
+  return new Request(`http://drive.example.com${path}`, {
+    method: "GET",
+    headers: { Authorization: AUTH },
+  });
+}
+
+function post(path: string, body?: unknown): Request {
+  return new Request(`http://drive.example.com${path}`, {
+    method: "POST",
+    headers: { Authorization: AUTH, "Content-Type": "application/json" },
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+}
+
+function del(path: string, body?: unknown): Request {
+  return new Request(`http://drive.example.com${path}`, {
+    method: "DELETE",
+    headers: { Authorization: AUTH, "Content-Type": "application/json" },
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+}
+
+function noAuth(path: string, method: string, body?: unknown): Request {
+  return new Request(`http://drive.example.com${path}`, {
+    method,
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+}
+
+async function softDeleteViaApi(
+  bucket: InMemoryBucket,
+  keys: string[]
+): Promise<Array<{ key: string; id: string }>> {
+  const response = await onRequestPost(
+    makeContext(post("/api/trash", { keys }), makeEnv(bucket))
+  );
+  expect(response.status).toBe(200);
+  const body = (await response.json()) as { results: Array<{ key: string; id: string }> };
+  return body.results;
+}
+
+describe("trash auth", () => {
+  test("GET/POST/DELETE without credentials are 401", async () => {
+    const bucket = new InMemoryBucket();
+    for (const [request, handler] of [
+      [noAuth("/api/trash", "GET"), onRequestGet],
+      [noAuth("/api/trash", "POST", { keys: ["a.txt"] }), onRequestPost],
+      [noAuth("/api/trash", "DELETE", { trashKeys: ["x"] }), onRequestDelete],
+    ] as const) {
+      const response = await handler(makeContext(request, makeEnv(bucket)));
+      expect(response.status).toBe(401);
+    }
+  });
+
+  test("empty configured credentials fail closed (401)", async () => {
+    const bucket = new InMemoryBucket();
+    const response = await onRequestGet(
+      makeContext(get("/api/trash"), makeEnv(bucket, { WEBDAV_USERNAME: "", WEBDAV_PASSWORD: "" }))
+    );
+    expect(response.status).toBe(401);
+  });
+
+  test("wrong password is 401", async () => {
+    const bucket = new InMemoryBucket();
+    const request = new Request("http://drive.example.com/api/trash", {
+      headers: { Authorization: basicAuthHeader("user", "wrong") },
+    });
+    const response = await onRequestGet(makeContext(request, makeEnv(bucket)));
+    expect(response.status).toBe(401);
+  });
+});
+
+describe("trash soft delete", () => {
+  test("file: creates trash metadata + moves content, original removed", async () => {
+    const bucket = new InMemoryBucket();
+    bucket.seed([{ key: "report.txt", body: "REPORT", contentType: "text/plain" }]);
+    const results = await softDeleteViaApi(bucket, ["report.txt"]);
+    expect(results).toEqual([
+      { key: "report.txt", id: results[0].id },
+    ]);
+    expect(bucket.has("report.txt")).toBe(false);
+
+    const metaKey = `${TRASH_PREFIX}${results[0].id}.json`;
+    const meta = bucket.rawJson<{
+      originalKey: string;
+      name: string;
+      deletedAt: string;
+      size: number;
+      virtualDir: boolean;
+      items: Array<{ source: string; target: string }>;
+    }>(metaKey);
+    expect(meta?.originalKey).toBe("report.txt");
+    expect(meta?.name).toBe("report.txt");
+    expect(meta?.virtualDir).toBe(false);
+    expect(Number.isFinite(Date.parse(meta?.deletedAt ?? ""))).toBe(true);
+    expect(meta?.size).toBe(6);
+    expect(meta?.items).toHaveLength(1);
+    expect(meta?.items[0].source).toBe("report.txt");
+    expect(meta?.items[0].target).toBe(`${TRASH_PREFIX}${results[0].id}/report.txt`);
+    expect(bucket.rawText(meta!.items[0].target)).toBe("REPORT");
+  });
+
+  test("directory with marker: marker + descendants are moved", async () => {
+    const bucket = new InMemoryBucket();
+    bucket.seedDir("docs");
+    bucket.seed([{ key: "docs/a.txt", body: "A" }, { key: "docs/sub/b.txt", body: "B" }]);
+    const results = await softDeleteViaApi(bucket, ["docs/"]);
+    expect(results).toHaveLength(1);
+    const id = results[0].id;
+    expect(bucket.has("docs")).toBe(false);
+    expect(bucket.has("docs/a.txt")).toBe(false);
+    expect(bucket.rawText(`${TRASH_PREFIX}${id}/a.txt`)).toBe("A");
+    expect(bucket.rawText(`${TRASH_PREFIX}${id}/sub/b.txt`)).toBe("B");
+    const marker = await bucket.asBucket().head(`${TRASH_PREFIX}${id}/docs`);
+    expect(marker?.httpMetadata?.contentType).toBe("application/x-directory");
+  });
+
+  test("virtual directory (no marker) is detected and flagged", async () => {
+    const bucket = new InMemoryBucket();
+    bucket.seed([{ key: "vdir/inner.txt", body: "I" }]);
+    const results = await softDeleteViaApi(bucket, ["vdir"]);
+    expect(results).toHaveLength(1);
+    const meta = bucket.rawJson<{ virtualDir: boolean; items: unknown[] }>(
+      `${TRASH_PREFIX}${results[0].id}.json`
+    );
+    expect(meta?.virtualDir).toBe(true);
+    // 虚拟目录没有 marker 对象，items 只包含后代
+    expect(meta?.items).toHaveLength(1);
+  });
+
+  test("skips nonexistent keys and internal prefixes", async () => {
+    const bucket = new InMemoryBucket();
+    bucket.seed([{ key: "_$flaredrive$/apikeys/k.json", body: "{}" }]);
+    bucket.seed([{ key: "wrap/_$flaredrive$/nested", body: "N" }]);
+    const results = await softDeleteViaApi(bucket, [
+      "ghost.txt",
+      "_$flaredrive$/apikeys/k.json",
+      "wrap/_$flaredrive$/nested",
+    ]);
+    expect(results).toEqual([]);
+    expect(bucket.has("_$flaredrive$/apikeys/k.json")).toBe(true);
+    expect(bucket.rawText("wrap/_$flaredrive$/nested")).toBe("N");
+  });
+
+  test("invalid JSON body is 400; empty keys is 400", async () => {
+    const bucket = new InMemoryBucket();
+    const badJson = new Request("http://drive.example.com/api/trash", {
+      method: "POST",
+      headers: { Authorization: AUTH },
+      body: "{nope",
+    });
+    expect((await onRequestPost(makeContext(badJson, makeEnv(bucket)))).status).toBe(400);
+    expect(
+      (await onRequestPost(makeContext(post("/api/trash", { keys: [] }), makeEnv(bucket)))).status
+    ).toBe(400);
+  });
+
+  test("softDeleteKeys (exported) works without HTTP context", async () => {
+    const bucket = new InMemoryBucket();
+    bucket.seed([{ key: "solo.txt", body: "S" }]);
+    const results = await softDeleteKeys(bucket.asBucket(), ["solo.txt"]);
+    expect(results).toHaveLength(1);
+    expect(bucket.has("solo.txt")).toBe(false);
+  });
+});
+
+describe("trash list (GET)", () => {
+  test("lists items with metadata from trash markers", async () => {
+    const bucket = new InMemoryBucket();
+    bucket.seed([{ key: "a.txt", body: "AAA" }]);
+    const [{ id }] = await softDeleteViaApi(bucket, ["a.txt"]);
+    const response = await onRequestGet(makeContext(get(), makeEnv(bucket)));
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Content-Type")).toContain("application/json");
+    const items = (await response.json()) as Array<Record<string, unknown>>;
+    expect(items).toHaveLength(1);
+    expect(items[0]).toMatchObject({
+      trashKey: id,
+      originalKey: "a.txt",
+      name: "a.txt",
+      size: 3,
+    });
+    expect(items[0].trashKey).toBe(id);
+    expect(typeof items[0].deletedAt).toBe("string");
+  });
+
+  test("corrupt or incomplete trash metadata entries are skipped, not 500", async () => {
+    const bucket = new InMemoryBucket();
+    bucket.seed([
+      { key: `${TRASH_PREFIX}broken.json`, body: "{not json" },
+      { key: `${TRASH_PREFIX}incomplete.json`, body: JSON.stringify({ name: "x" }) },
+      { key: `${TRASH_PREFIX}nested/deep.json`, body: JSON.stringify({ originalKey: "y" }) },
+    ]);
+    const response = await onRequestGet(makeContext(get(), makeEnv(bucket)));
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual([]);
+  });
+});
+
+describe("trash restore", () => {
+  test("restores file content and metadata, removes trash state", async () => {
+    const bucket = new InMemoryBucket();
+    bucket.seed([{ key: "a.txt", body: "AAA", customMetadata: { thumbnail: "t" } }]);
+    const [{ id }] = await softDeleteViaApi(bucket, ["a.txt"]);
+    const response = await onRequestPost(
+      makeContext(post("/api/trash?action=restore", { trashKeys: [id] }), makeEnv(bucket))
+    );
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual([{ trashKey: id, status: "restored" }]);
+    expect(bucket.rawText("a.txt")).toBe("AAA");
+    const head = await bucket.asBucket().head("a.txt");
+    expect(head?.customMetadata?.thumbnail).toBe("t");
+    expect(bucket.has(`${TRASH_PREFIX}${id}.json`)).toBe(false);
+    expect(bucket.has(`${TRASH_PREFIX}${id}/a.txt`)).toBe(false);
+  });
+
+  test("restore rebuilds missing parent folder markers", async () => {
+    const bucket = new InMemoryBucket();
+    bucket.seedDir("docs");
+    bucket.seedDir("docs/sub");
+    bucket.seed([{ key: "docs/sub/inner.txt", body: "I" }]);
+    const [{ id }] = await softDeleteViaApi(bucket, ["docs/sub"]);
+    expect(bucket.has("docs/sub")).toBe(false);
+    // 还原前父级 marker 消失（例如父目录随后被单独删除）
+    bucket.asBucket().delete("docs");
+    const response = await onRequestPost(
+      makeContext(post("/api/trash?action=restore", { trashKeys: [id] }), makeEnv(bucket))
+    );
+    const body = (await response.json()) as Array<{ status: string }>;
+    expect(body[0].status).toBe("restored");
+    const docs = await bucket.asBucket().head("docs");
+    expect(docs?.httpMetadata?.contentType).toBe("application/x-directory");
+    expect(bucket.rawText("docs/sub/inner.txt")).toBe("I");
+    const sub = await bucket.asBucket().head("docs/sub");
+    expect(sub?.httpMetadata?.contentType).toBe("application/x-directory");
+  });
+
+  test("restore of virtual directory recreates the collection marker", async () => {
+    const bucket = new InMemoryBucket();
+    bucket.seed([{ key: "vdir/inner.txt", body: "I" }]);
+    const [{ id }] = await softDeleteViaApi(bucket, ["vdir"]);
+    const response = await onRequestPost(
+      makeContext(post("/api/trash?action=restore", { trashKeys: [id] }), makeEnv(bucket))
+    );
+    expect(((await response.json()) as Array<{ status: string }>)[0].status).toBe("restored");
+    const marker = await bucket.asBucket().head("vdir");
+    expect(marker?.httpMetadata?.contentType).toBe("application/x-directory");
+    expect(bucket.rawText("vdir/inner.txt")).toBe("I");
+  });
+
+  test("restore conflict when original key exists again", async () => {
+    const bucket = new InMemoryBucket();
+    bucket.seed([{ key: "a.txt", body: "OLD" }]);
+    const [{ id }] = await softDeleteViaApi(bucket, ["a.txt"]);
+    bucket.seed([{ key: "a.txt", body: "NEW" }]);
+    const response = await onRequestPost(
+      makeContext(post("/api/trash?action=restore", { trashKeys: [id] }), makeEnv(bucket))
+    );
+    const body = (await response.json()) as Array<{ status: string; message?: string }>;
+    expect(body[0].status).toBe("conflict");
+    expect(body[0].message).toContain("a.txt");
+    expect(bucket.rawText("a.txt")).toBe("NEW");
+    // 冲突不消费回收站条目
+    expect(bucket.has(`${TRASH_PREFIX}${id}.json`)).toBe(true);
+  });
+
+  test("restore of unknown / corrupt trash keys reports error", async () => {
+    const bucket = new InMemoryBucket();
+    const response = await onRequestPost(
+      makeContext(post("/api/trash?action=restore", { trashKeys: ["ghost"] }), makeEnv(bucket))
+    );
+    expect(await response.json()).toEqual([
+      { trashKey: "ghost", status: "error", message: "回收站项目不存在" },
+    ]);
+
+    bucket.seed([{ key: `${TRASH_PREFIX}corrupt.json`, body: "{oops" }]);
+    const corruptResponse = await onRequestPost(
+      makeContext(post("/api/trash?action=restore", { trashKeys: ["corrupt"] }), makeEnv(bucket))
+    );
+    const corruptBody = (await corruptResponse.json()) as Array<{ status: string }>;
+    expect(corruptBody[0].status).toBe("error");
+  });
+
+  test("restore with invalid JSON body is 400", async () => {
+    const bucket = new InMemoryBucket();
+    const request = new Request("http://drive.example.com/api/trash?action=restore", {
+      method: "POST",
+      headers: { Authorization: AUTH },
+      body: "{nope",
+    });
+    expect((await onRequestPost(makeContext(request, makeEnv(bucket)))).status).toBe(400);
+  });
+});
+
+describe("trash delete endpoints", () => {
+  test("DELETE specific trashKeys removes descendants + metadata", async () => {
+    const bucket = new InMemoryBucket();
+    bucket.seed([{ key: "a.txt", body: "AAA" }, { key: "docs/b.txt", body: "B" }]);
+    const [first, second] = await softDeleteViaApi(bucket, ["a.txt", "docs/b.txt"]);
+    const response = await onRequestDelete(
+      makeContext(del("/api/trash", { trashKeys: [first.id] }), makeEnv(bucket))
+    );
+    expect(response.status).toBe(204);
+    expect(bucket.has(`${TRASH_PREFIX}${first.id}.json`)).toBe(false);
+    expect(bucket.has(`${TRASH_PREFIX}${first.id}/a.txt`)).toBe(false);
+    // 未选中的保留
+    expect(bucket.has(`${TRASH_PREFIX}${second.id}.json`)).toBe(true);
+  });
+
+  test("DELETE all empties the whole trash prefix", async () => {
+    const bucket = new InMemoryBucket();
+    bucket.seed([{ key: "a.txt", body: "A" }, { key: "b.txt", body: "B" }]);
+    await softDeleteViaApi(bucket, ["a.txt", "b.txt"]);
+    const response = await onRequestDelete(
+      makeContext(del("/api/trash", { all: true }), makeEnv(bucket))
+    );
+    expect(response.status).toBe(204);
+    const listing = await bucket.asBucket().list({ prefix: TRASH_PREFIX });
+    expect(listing.objects).toHaveLength(0);
+  });
+
+  test("DELETE with invalid JSON is 400", async () => {
+    const bucket = new InMemoryBucket();
+    const request = new Request("http://drive.example.com/api/trash", {
+      method: "DELETE",
+      headers: { Authorization: AUTH },
+      body: "{nope",
+    });
+    expect((await onRequestDelete(makeContext(request, makeEnv(bucket)))).status).toBe(400);
+  });
+});
+
+describe("trash lazy expiry purge", () => {
+  function seedTrashItem(
+    bucket: InMemoryBucket,
+    trashId: string,
+    deletedAtIso: string,
+    content = "old"
+  ) {
+    bucket.seed([
+      {
+        key: `${TRASH_PREFIX}${trashId}.json`,
+        body: JSON.stringify({ originalKey: `${trashId}.txt`, deletedAt: deletedAtIso }),
+        contentType: "application/json",
+      },
+      { key: `${TRASH_PREFIX}${trashId}/${trashId}.txt`, body: content },
+    ]);
+  }
+
+  test("expired items (retention 0) are purged with descendants on GET", async () => {
+    const bucket = new InMemoryBucket();
+    seedTrashItem(bucket, "old-one", "2020-01-01T00:00:00.000Z");
+    seedTrashItem(bucket, "still-fresh", "9999-01-01T00:00:00.000Z");
+    const env = makeEnv(bucket, { TRASH_RETENTION_DAYS: "0" });
+    const response = await onRequestGet(makeContext(get(), env));
+    expect(response.status).toBe(200);
+    const items = (await response.json()) as Array<{ trashKey: string }>;
+    expect(items.map((item) => item.trashKey)).toEqual(["still-fresh"]);
+    expect(bucket.has(`${TRASH_PREFIX}old-one.json`)).toBe(false);
+    expect(bucket.has(`${TRASH_PREFIX}old-one/old-one.txt`)).toBe(false);
+  });
+
+  test("negative retention disables purging", async () => {
+    const bucket = new InMemoryBucket();
+    seedTrashItem(bucket, "ancient", "2020-01-01T00:00:00.000Z");
+    const env = makeEnv(bucket, { TRASH_RETENTION_DAYS: "-1" });
+    const response = await onRequestGet(makeContext(get(), env));
+    expect(response.status).toBe(200);
+    expect(bucket.has(`${TRASH_PREFIX}ancient.json`)).toBe(true);
+  });
+
+  test("invalid retention value falls back to default 30 days", async () => {
+    const bucket = new InMemoryBucket();
+    seedTrashItem(bucket, "recent", new Date(Date.now() - 5 * 24 * 60 * 60 * 1000).toISOString());
+    const env = makeEnv(bucket, { TRASH_RETENTION_DAYS: "not-a-number" });
+    const response = await onRequestGet(makeContext(get(), env));
+    expect(response.status).toBe(200);
+    expect(bucket.has(`${TRASH_PREFIX}recent.json`)).toBe(true);
+  });
+
+  test("corrupt trash json is left alone by the purge pass", async () => {
+    const bucket = new InMemoryBucket();
+    bucket.seed([
+      { key: `${TRASH_PREFIX}corrupt.json`, body: "{oops", contentType: "application/json" },
+    ]);
+    const env = makeEnv(bucket, { TRASH_RETENTION_DAYS: "0" });
+    const response = await onRequestGet(makeContext(get(), env));
+    expect(response.status).toBe(200);
+    expect(bucket.has(`${TRASH_PREFIX}corrupt.json`)).toBe(true);
+  });
+
+  test("nested keys under the trash prefix are not treated as expiry markers", async () => {
+    const bucket = new InMemoryBucket();
+    bucket.seed([
+      {
+        key: `${TRASH_PREFIX}folder/deep.json`,
+        body: JSON.stringify({ originalKey: "x", deletedAt: "2020-01-01T00:00:00.000Z" }),
+      },
+    ]);
+    const env = makeEnv(bucket, { TRASH_RETENTION_DAYS: "0" });
+    const response = await onRequestGet(makeContext(get(), env));
+    expect(response.status).toBe(200);
+    expect(bucket.has(`${TRASH_PREFIX}folder/deep.json`)).toBe(true);
+  });
+});

--- a/src/app/__tests__/uploadApi.test.ts
+++ b/src/app/__tests__/uploadApi.test.ts
@@ -1,0 +1,535 @@
+/**
+ * functions/api/upload.ts 分支级直测：单发上传（raw body 路径）、重名/覆盖、
+ * 413/400/401 分支、目录 marker 自动补建、三段式分块上传
+ * （create → part → complete，乱序/缺块/etag 校验、abort 清理）。
+ *
+ * 说明：multipart/form-data 分支（request.formData()）在 whatwg-fetch 测试
+ * 环境无法解析 multipart 请求体，属于环境限制，由 e2e 覆盖。
+ */
+import {
+  onRequestDelete,
+  onRequestPost,
+  onRequestPut,
+} from "../../../functions/api/upload";
+import { InMemoryBucket, makeContext } from "../testInMemoryBucket";
+
+const HOST = "http://drive.example.com";
+const API_KEY = "fd_test_key_1234567890";
+const KEYS_PREFIX = "_$flaredrive$/apikeys/";
+
+async function sha256Hex(value: string): Promise<string> {
+  const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(value));
+  return Array.from(new Uint8Array(digest))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+function makeEnv(bucket: InMemoryBucket) {
+  return { BUCKET: bucket.asBucket() };
+}
+
+function authed(
+  path: string,
+  method: string,
+  body?: unknown,
+  extra: Record<string, string> = {}
+) {
+  const isRaw =
+    typeof body === "string" ||
+    body === undefined ||
+    body instanceof Uint8Array ||
+    body instanceof Blob;
+  return new Request(`${HOST}${path}`, {
+    method,
+    headers: { "X-Api-Key": API_KEY, ...extra },
+    body: isRaw ? (body as BodyInit | undefined) : JSON.stringify(body),
+  });
+}
+
+function withRawBody(request: Request, bytes: Uint8Array): Request {
+  // whatwg-fetch 的 Request 没有 body getter；分块 PUT 依赖 request.body 存在
+  Object.defineProperty(request, "body", { value: bytes });
+  return request;
+}
+
+async function seedApiKey(bucket: InMemoryBucket, expiresAt: string | null = null) {
+  bucket.seed([
+    {
+      key: `${KEYS_PREFIX}testrecord.json`,
+      body: JSON.stringify({
+        id: "testrecord",
+        name: "test",
+        prefix: "fd_",
+        keyHash: await sha256Hex(API_KEY),
+        createdAt: "2026-01-01T00:00:00.000Z",
+        expiresAt,
+      }),
+      contentType: "application/json",
+    },
+  ]);
+}
+
+function newBucket(): InMemoryBucket {
+  return new InMemoryBucket();
+}
+
+describe("upload auth", () => {
+  test("missing / invalid / disabled API key is 401", async () => {
+    const anonymous = new Request(`${HOST}/api/upload`, { method: "POST" });
+    const anonymousResponse = await onRequestPost(
+      makeContext(anonymous, makeEnv(newBucket()))
+    );
+    expect(anonymousResponse.status).toBe(401);
+    expect(await anonymousResponse.text()).toBe("缺少 API 密钥");
+
+    const invalid = await onRequestPost(
+      makeContext(
+        new Request(`${HOST}/api/upload`, {
+          method: "POST",
+          headers: { "X-Api-Key": "fd_wrong" },
+        }),
+        makeEnv(newBucket())
+      )
+    );
+    expect(invalid.status).toBe(401);
+    expect(await invalid.text()).toBe("无效的 API 密钥");
+
+    const bucket = newBucket();
+    await seedApiKey(bucket);
+    bucket.seed([
+      {
+        key: "_$flaredrive$/config.json",
+        body: JSON.stringify({ apiKey: false }),
+        contentType: "application/json",
+      },
+    ]);
+    const disabled = await onRequestPost(
+      makeContext(authed("/api/upload", "POST"), makeEnv(bucket))
+    );
+    expect(disabled.status).toBe(401);
+    expect(await disabled.text()).toBe("API 密钥已关闭");
+  });
+
+  test("expired API key is 401", async () => {
+    const bucket = newBucket();
+    await seedApiKey(bucket, "2020-01-01T00:00:00.000Z");
+    const response = await onRequestPost(
+      makeContext(authed("/api/upload", "POST"), makeEnv(bucket))
+    );
+    expect(response.status).toBe(401);
+    expect(await response.text()).toBe("API 密钥已过期");
+  });
+});
+
+describe("single-shot upload (POST /api/upload)", () => {
+  test("raw body upload stores the object and touches lastUsed", async () => {
+    const bucket = newBucket();
+    await seedApiKey(bucket);
+    const response = await onRequestPost(
+      makeContext(
+        authed("/api/upload?path=docs", "POST", "file-content", {
+          "X-File-Name": "notes.txt",
+          "Content-Type": "text/plain",
+        }),
+        makeEnv(bucket)
+      )
+    );
+    expect(response.status).toBe(201);
+    const body = (await response.json()) as Record<string, unknown>;
+    expect(body).toEqual({
+      key: "docs/notes.txt",
+      name: "notes.txt",
+      size: 12,
+      path: "docs/",
+      overwritten: false,
+    });
+    expect(bucket.rawText("docs/notes.txt")).toBe("file-content");
+    const stored = await bucket.asBucket().head("docs/notes.txt");
+    expect(stored?.httpMetadata?.contentType).toBe("text/plain");
+    // 上传过程自动补齐目录 marker
+    const marker = await bucket.asBucket().head("docs");
+    expect(marker?.httpMetadata?.contentType).toBe("application/x-directory");
+    // lastUsed 写回 API key 记录
+    const record = bucket.rawJson<{ lastUsedAt?: string }>(`${KEYS_PREFIX}testrecord.json`);
+    expect(typeof record?.lastUsedAt).toBe("string");
+  });
+
+  test("duplicate names are de-duplicated as 'name (2).ext'", async () => {
+    const bucket = newBucket();
+    await seedApiKey(bucket);
+    bucket.seed([{ key: "a.txt", body: "1" }, { key: "a (2).txt", body: "2" }]);
+    const response = await onRequestPost(
+      makeContext(
+        authed("/api/upload", "POST", "3", { "X-File-Name": "a.txt" }),
+        makeEnv(bucket)
+      )
+    );
+    const body = (await response.json()) as { name: string; key: string };
+    expect(body.name).toBe("a (3).txt");
+    expect(bucket.rawText("a (3).txt")).toBe("3");
+    expect(bucket.rawText("a.txt")).toBe("1");
+  });
+
+  test("overwrite=1 replaces an existing file and reports overwritten", async () => {
+    const bucket = newBucket();
+    await seedApiKey(bucket);
+    bucket.seed([{ key: "docs/a.txt", body: "old" }]);
+    const response = await onRequestPost(
+      makeContext(
+        authed("/api/upload?path=docs&overwrite=1", "POST", "new", { "X-File-Name": "a.txt" }),
+        makeEnv(bucket)
+      )
+    );
+    const body = (await response.json()) as { overwritten: boolean };
+    expect(body.overwritten).toBe(true);
+    expect(bucket.rawText("docs/a.txt")).toBe("new");
+  });
+
+  test("overwrite=1 against a directory marker is 409", async () => {
+    const bucket = newBucket();
+    await seedApiKey(bucket);
+    bucket.seedDir("docs/folder");
+    const response = await onRequestPost(
+      makeContext(
+        authed("/api/upload?path=docs&overwrite=1", "POST", "x", { "X-File-Name": "folder" }),
+        makeEnv(bucket)
+      )
+    );
+    expect(response.status).toBe(409);
+    expect(await response.text()).toBe("目标已存在且为目录，无法覆盖");
+  });
+
+  test("overwrite=1 against a virtual directory (children only) is 409", async () => {
+    const bucket = newBucket();
+    await seedApiKey(bucket);
+    bucket.seed([{ key: "docs/vdir/inner.txt", body: "I" }]);
+    const response = await onRequestPost(
+      makeContext(
+        authed("/api/upload?path=docs&overwrite=1", "POST", "x", { "X-File-Name": "vdir" }),
+        makeEnv(bucket)
+      )
+    );
+    expect(response.status).toBe(409);
+    expect(bucket.rawText("docs/vdir/inner.txt")).toBe("I");
+  });
+
+  test("Content-Length over the 100MB cap is 413", async () => {
+    const bucket = newBucket();
+    await seedApiKey(bucket);
+    const response = await onRequestPost(
+      makeContext(
+        authed("/api/upload", "POST", "x", {
+          "X-File-Name": "big.bin",
+          "Content-Length": String(100 * 1024 * 1024),
+        }),
+        makeEnv(bucket)
+      )
+    );
+    expect(response.status).toBe(413);
+  });
+
+  test("empty body, missing X-File-Name are 400", async () => {
+    const bucket = newBucket();
+    await seedApiKey(bucket);
+    const empty = await onRequestPost(
+      makeContext(
+        authed("/api/upload", "POST", "", { "X-File-Name": "a.txt" }),
+        makeEnv(bucket)
+      )
+    );
+    expect(empty.status).toBe(400);
+    expect(await empty.text()).toBe("文件内容为空");
+    const noName = await onRequestPost(
+      makeContext(authed("/api/upload", "POST", "x"), makeEnv(bucket))
+    );
+    expect(noName.status).toBe(400);
+    expect(await noName.text()).toBe("原始请求体上传需要提供 X-File-Name 头");
+  });
+
+  test("path traversal and internal prefix paths are rejected", async () => {
+    const bucket = newBucket();
+    await seedApiKey(bucket);
+    const traversal = await onRequestPost(
+      makeContext(
+        authed("/api/upload?path=..%2Fescape", "POST", "x", { "X-File-Name": "a.txt" }),
+        makeEnv(bucket)
+      )
+    );
+    expect(traversal.status).toBe(400);
+    expect(await traversal.text()).toBe("路径不合法");
+    const internal = await onRequestPost(
+      makeContext(
+        authed("/api/upload?path=_$flaredrive$/trash", "POST", "x", { "X-File-Name": "a.txt" }),
+        makeEnv(bucket)
+      )
+    );
+    expect(internal.status).toBe(400);
+    expect(await internal.text()).toBe("禁止写入内部目录");
+    expect(bucket.rawBytes("escape/a.txt")).toBeUndefined();
+  });
+
+  test("file name is sanitized (backslash basename, control chars stripped)", async () => {
+    const bucket = newBucket();
+    await seedApiKey(bucket);
+    const response = await onRequestPost(
+      makeContext(
+        authed("/api/upload", "POST", "x", {
+          "X-File-Name": "dir\\na\tme .txt",
+        }),
+        makeEnv(bucket)
+      )
+    );
+    const body = (await response.json()) as { name: string };
+    expect(body.name).toBe("name .txt");
+  });
+});
+
+describe("multipart upload (uploads / part / complete / abort)", () => {
+  test("POST ?uploads creates the upload and folder markers", async () => {
+    const bucket = newBucket();
+    await seedApiKey(bucket);
+    const response = await onRequestPost(
+      makeContext(
+        authed("/api/upload?uploads&path=docs%2Fbig.bin", "POST"),
+        makeEnv(bucket)
+      )
+    );
+    expect(response.status).toBe(201);
+    const body = (await response.json()) as { key: string; uploadId: string };
+    expect(body.key).toBe("docs/big.bin");
+    expect(typeof body.uploadId).toBe("string");
+    const marker = await bucket.asBucket().head("docs");
+    expect(marker?.httpMetadata?.contentType).toBe("application/x-directory");
+  });
+
+  test("POST ?uploads validates path (traversal / internal / empty)", async () => {
+    const bucket = newBucket();
+    await seedApiKey(bucket);
+    const traversal = await onRequestPost(
+      makeContext(
+        authed("/api/upload?uploads&path=..%2Fbig.bin", "POST"),
+        makeEnv(bucket)
+      )
+    );
+    expect(traversal.status).toBe(400);
+    const internal = await onRequestPost(
+      makeContext(
+        authed("/api/upload?uploads&path=_$flaredrive$/evil.bin", "POST"),
+        makeEnv(bucket)
+      )
+    );
+    expect(internal.status).toBe(400);
+    expect(await internal.text()).toBe("禁止写入内部目录");
+    const missing = await onRequestPost(
+      makeContext(authed("/api/upload?uploads", "POST"), makeEnv(bucket))
+    );
+    expect(missing.status).toBe(400);
+  });
+
+  async function startUpload(bucket: InMemoryBucket, path = "big.bin"): Promise<string> {
+    const response = await onRequestPost(
+      makeContext(
+        authed(`/api/upload?uploads&path=${encodeURIComponent(path)}`, "POST"),
+        makeEnv(bucket)
+      )
+    );
+    expect(response.status).toBe(201);
+    return ((await response.json()) as { uploadId: string }).uploadId;
+  }
+
+  async function uploadPart(
+    bucket: InMemoryBucket,
+    uploadId: string,
+    partNumber: number,
+    content: string
+  ) {
+    return onRequestPut(
+      makeContext(
+        withRawBody(
+          authed(
+            `/api/upload?path=${encodeURIComponent("big.bin")}&uploadId=${uploadId}&partNumber=${partNumber}`,
+            "PUT"
+          ),
+          new TextEncoder().encode(content)
+        ),
+        makeEnv(bucket)
+      )
+    );
+  }
+
+  test("full three-step flow assembles the object in order", async () => {
+    const bucket = newBucket();
+    await seedApiKey(bucket);
+    const uploadId = await startUpload(bucket);
+
+    const part1 = await uploadPart(bucket, uploadId, 1, "hello-");
+    expect(part1.status).toBe(200);
+    const part1Body = (await part1.json()) as { partNumber: number; etag: string };
+    expect(part1Body.partNumber).toBe(1);
+
+    const part2 = await uploadPart(bucket, uploadId, 2, "world");
+    const part2Body = (await part2.json()) as { etag: string };
+
+    const complete = await onRequestPost(
+      makeContext(
+        authed(`/api/upload?path=${encodeURIComponent("big.bin")}&uploadId=${uploadId}`, "POST", {
+          parts: [
+            { partNumber: 1, etag: part1Body.etag },
+            { partNumber: 2, etag: part2Body.etag },
+          ],
+        }),
+        makeEnv(bucket)
+      )
+    );
+    expect(complete.status).toBe(200);
+    const doneBody = (await complete.json()) as { key: string; size: number; etag: string };
+    expect(doneBody.key).toBe("big.bin");
+    expect(doneBody.size).toBe(11);
+    expect(doneBody.etag).toMatch(/^"/);
+    expect(bucket.rawText("big.bin")).toBe("hello-world");
+  });
+
+  test("out-of-order partNumbers in complete are rejected with 400", async () => {
+    const bucket = newBucket();
+    await seedApiKey(bucket);
+    const uploadId = await startUpload(bucket);
+    await uploadPart(bucket, uploadId, 1, "a");
+    await uploadPart(bucket, uploadId, 2, "b");
+    const response = await onRequestPost(
+      makeContext(
+        authed(`/api/upload?path=big.bin&uploadId=${uploadId}`, "POST", {
+          parts: [
+            { partNumber: 2, etag: "e2" },
+            { partNumber: 1, etag: "e1" },
+          ],
+        }),
+        makeEnv(bucket)
+      )
+    );
+    expect(response.status).toBe(400);
+    expect(await response.text()).toBe("parts 参数不合法");
+  });
+
+  test("missing part in complete fails with the R2 error message", async () => {
+    const bucket = newBucket();
+    await seedApiKey(bucket);
+    const uploadId = await startUpload(bucket);
+    const part1 = (await (await uploadPart(bucket, uploadId, 1, "a")).json()) as { etag: string };
+    const response = await onRequestPost(
+      makeContext(
+        authed(`/api/upload?path=big.bin&uploadId=${uploadId}`, "POST", {
+          parts: [
+            { partNumber: 1, etag: part1.etag },
+            { partNumber: 2, etag: "never-uploaded" },
+          ],
+        }),
+        makeEnv(bucket)
+      )
+    );
+    expect(response.status).toBe(400);
+    expect(await response.text()).toContain("part 2");
+    expect(bucket.has("big.bin")).toBe(false);
+  });
+
+  test("complete validates parts: empty / duplicate / out-of-range / missing etag / bad json", async () => {
+    const bucket = newBucket();
+    await seedApiKey(bucket);
+    const uploadId = await startUpload(bucket);
+    const cases: unknown[] = [
+      { parts: [] },
+      { parts: [{ partNumber: 1, etag: "e" }, { partNumber: 1, etag: "e" }] },
+      { parts: [{ partNumber: 0, etag: "e" }] },
+      { parts: [{ partNumber: 10001, etag: "e" }] },
+      { parts: [{ partNumber: 1.5, etag: "e" }] },
+      { parts: [{ partNumber: 1, etag: "" }] },
+      { noParts: true },
+    ];
+    for (const payload of cases) {
+      const response = await onRequestPost(
+        makeContext(
+          authed(`/api/upload?path=big.bin&uploadId=${uploadId}`, "POST", payload),
+          makeEnv(bucket)
+        )
+      );
+      expect(response.status).toBe(400);
+    }
+    const badJson = new Request(`${HOST}/api/upload?path=big.bin&uploadId=${uploadId}`, {
+      method: "POST",
+      headers: { "X-Api-Key": API_KEY },
+      body: "{nope",
+    });
+    expect((await onRequestPost(makeContext(badJson, makeEnv(bucket)))).status).toBe(400);
+  });
+
+  test("PUT part validates uploadId / partNumber / body", async () => {
+    const bucket = newBucket();
+    await seedApiKey(bucket);
+    const noUploadId = await onRequestPut(
+      makeContext(
+        withRawBody(authed("/api/upload?path=big.bin&partNumber=1", "PUT"), new TextEncoder().encode("x")),
+        makeEnv(bucket)
+      )
+    );
+    expect(noUploadId.status).toBe(400);
+    expect(await noUploadId.text()).toBe("缺少 uploadId");
+    const badPart = await onRequestPut(
+      makeContext(
+        withRawBody(authed("/api/upload?path=big.bin&uploadId=u&partNumber=0", "PUT"), new TextEncoder().encode("x")),
+        makeEnv(bucket)
+      )
+    );
+    expect(badPart.status).toBe(400);
+    const bigPart = await onRequestPut(
+      makeContext(
+        withRawBody(authed("/api/upload?path=big.bin&uploadId=u&partNumber=10001", "PUT"), new TextEncoder().encode("x")),
+        makeEnv(bucket)
+      )
+    );
+    expect(bigPart.status).toBe(400);
+    const noBody = await onRequestPut(
+      makeContext(
+        authed("/api/upload?path=big.bin&uploadId=u&partNumber=1", "PUT"),
+        makeEnv(bucket)
+      )
+    );
+    expect(noBody.status).toBe(400);
+    expect(await noBody.text()).toBe("缺少分块内容");
+    const unknownId = await uploadPart(bucket, "unknown-upload", 1, "x");
+    expect(unknownId.status).toBe(400);
+  });
+
+  test("abort discards the upload; unknown uploadId abort is idempotent", async () => {
+    const bucket = newBucket();
+    await seedApiKey(bucket);
+    const uploadId = await startUpload(bucket);
+    await uploadPart(bucket, uploadId, 1, "chunk");
+    const aborted = await onRequestDelete(
+      makeContext(
+        authed(`/api/upload?path=${encodeURIComponent("big.bin")}&uploadId=${uploadId}`, "DELETE"),
+        makeEnv(bucket)
+      )
+    );
+    expect(aborted.status).toBe(204);
+    // abort 后分块上传不可再用
+    const afterAbort = await uploadPart(bucket, uploadId, 2, "more");
+    expect(afterAbort.status).toBe(400);
+    expect(bucket.has("big.bin")).toBe(false);
+    // 未知 uploadId 幂等 204
+    const unknown = await onRequestDelete(
+      makeContext(
+        authed("/api/upload?path=big.bin&uploadId=never-existed", "DELETE"),
+        makeEnv(bucket)
+      )
+    );
+    expect(unknown.status).toBe(204);
+  });
+
+  test("missing uploadId on DELETE is 400", async () => {
+    const bucket = newBucket();
+    await seedApiKey(bucket);
+    const response = await onRequestDelete(
+      makeContext(authed("/api/upload?path=big.bin", "DELETE"), makeEnv(bucket))
+    );
+    expect(response.status).toBe(400);
+  });
+});

--- a/src/app/__tests__/webdavProtocol.test.ts
+++ b/src/app/__tests__/webdavProtocol.test.ts
@@ -1,0 +1,1408 @@
+/**
+ * functions/webdav/protocol.ts 分支级直测。
+ *
+ * 覆盖 e2e 打不到的条件分支：304/206/412/423/405/409/415、Range 边界、
+ * If-Match / If-None-Match、Overwrite 头、LOCK token 校验、鉴权 fail-closed、
+ * 内部前缀保护等。通过真实 Request/Response + InMemoryBucket 驱动 onRequest。
+ */
+import { onRequest, type WebDavEnv } from "../../../functions/webdav/protocol";
+import {
+  InMemoryBucket,
+  basicAuthHeader,
+  makeContext,
+} from "../testInMemoryBucket";
+
+const AUTH = basicAuthHeader("user", "pass");
+const HOST = "http://drive.example.com";
+
+function makeEnv(bucket: InMemoryBucket, extra: Record<string, unknown> = {}): WebDavEnv {
+  return {
+    BUCKET: bucket.asBucket(),
+    WEBDAV_USERNAME: "user",
+    WEBDAV_PASSWORD: "pass",
+    ...extra,
+  };
+}
+
+function req(
+  path: string,
+  method: string,
+  headers?: Record<string, string>,
+  body?: BodyInit
+): Request {
+  return new Request(`${HOST}${path}`, { method, headers, body });
+}
+
+function withRawBody(
+  request: Request,
+  bytes: Uint8Array
+): Request {
+  // whatwg-fetch 的 Request 没有 body getter，WebDAV/上传的分块 PUT 用到
+  Object.defineProperty(request, "body", { value: bytes });
+  return request;
+}
+
+async function call(request: Request, env: WebDavEnv) {
+  return onRequest(makeContext(request, env));
+}
+
+const LOCK_BODY =
+  '<?xml version="1.0" encoding="utf-8"?><D:lockinfo xmlns:D="DAV:"><D:lockscope><D:exclusive/></D:lockscope><D:locktype><D:write/></D:locktype><D:owner>tester</D:owner></D:lockinfo>';
+
+const SHARED_LOCK_BODY =
+  '<?xml version="1.0" encoding="utf-8"?><D:lockinfo xmlns:D="DAV:"><D:lockscope><D:shared/></D:lockscope><D:locktype><D:write/></D:locktype></D:lockinfo>';
+
+async function seedLockedFile(
+  bucket: InMemoryBucket,
+  key = "locked.txt",
+  depth: "0" | "infinity" = "0"
+): Promise<string> {
+  bucket.seed([{ key, body: "locked" }]);
+  const response = await call(
+    req(`/webdav/${key}`, "LOCK", {
+      Authorization: AUTH,
+      Depth: depth,
+      "Content-Type": "application/xml",
+    }),
+    makeEnv(bucket)
+  );
+  expect(response.status).toBe(201);
+  const tokenHeader = response.headers.get("Lock-Token") ?? "";
+  const token = tokenHeader.replace(/^<urn:uuid:/, "").replace(/>$/, "");
+  expect(token).not.toBe("");
+  return token;
+}
+
+describe("webdav OPTIONS / redirect / auth", () => {
+  test("OPTIONS returns DAV class and Allow without auth", async () => {
+    const bucket = new InMemoryBucket();
+    const response = await call(
+      req("/webdav/", "OPTIONS"),
+      makeEnv(bucket)
+    );
+    expect(response.status).toBe(200);
+    expect(response.headers.get("DAV")).toBe("1, 2");
+    const allow = response.headers.get("Allow") ?? "";
+    for (const method of [
+      "OPTIONS",
+      "PROPFIND",
+      "MKCOL",
+      "GET",
+      "PUT",
+      "DELETE",
+      "COPY",
+      "MOVE",
+      "LOCK",
+      "UNLOCK",
+    ]) {
+      expect(allow).toContain(method);
+    }
+  });
+
+  test("/webdav without trailing slash is a 307 redirect (no auth needed)", async () => {
+    const bucket = new InMemoryBucket();
+    const response = await call(req("/webdav", "GET"), makeEnv(bucket));
+    expect(response.status).toBe(307);
+    expect(response.headers.get("Location")).toBe(`${HOST}/webdav/`);
+  });
+
+  test("missing Authorization is 401 with WWW-Authenticate", async () => {
+    const bucket = new InMemoryBucket();
+    bucket.seed([{ key: "a.txt", body: "x" }]);
+    const response = await call(req("/webdav/a.txt", "GET"), makeEnv(bucket));
+    expect(response.status).toBe(401);
+    expect(response.headers.get("WWW-Authenticate")).toBe('Basic realm="WebDAV"');
+  });
+
+  test("wrong credentials are 401", async () => {
+    const bucket = new InMemoryBucket();
+    bucket.seed([{ key: "a.txt", body: "x" }]);
+    const response = await call(
+      req("/webdav/a.txt", "GET", { Authorization: basicAuthHeader("user", "nope") }),
+      makeEnv(bucket)
+    );
+    expect(response.status).toBe(401);
+  });
+
+  test("empty configured credentials fail closed with 403", async () => {
+    const bucket = new InMemoryBucket();
+    bucket.seed([{ key: "a.txt", body: "x" }]);
+    const response = await call(
+      req("/webdav/a.txt", "GET", { Authorization: AUTH }),
+      makeEnv(bucket, { WEBDAV_USERNAME: "", WEBDAV_PASSWORD: "" })
+    );
+    expect(response.status).toBe(403);
+    expect(await response.text()).toBe("WebDAV protocol is not enabled");
+  });
+
+  test("WEBDAV_PUBLIC_READ=1 lets GET through but not PUT", async () => {
+    const bucket = new InMemoryBucket();
+    bucket.seed([{ key: "a.txt", body: "x" }]);
+    const env = makeEnv(bucket, { WEBDAV_PUBLIC_READ: "1" });
+    const read = await call(req("/webdav/a.txt", "GET"), env);
+    expect(read.status).toBe(200);
+    const write = await call(req("/webdav/b.txt", "PUT", undefined, "y"), env);
+    expect(write.status).toBe(401);
+  });
+
+  test("unknown method is 405 with Allow header", async () => {
+    const bucket = new InMemoryBucket();
+    const response = await call(
+      req("/webdav/a.txt", "TRACE", { Authorization: AUTH }),
+      makeEnv(bucket)
+    );
+    expect(response.status).toBe(405);
+    expect(response.headers.get("Allow")).toContain("PROPFIND");
+    expect(response.headers.get("DAV")).toBe("1, 2");
+  });
+});
+
+describe("webdav PROPFIND", () => {
+  test("root collection with Depth 1 lists immediate children only", async () => {
+    const bucket = new InMemoryBucket();
+    bucket.seedDir("docs");
+    bucket.seed([{ key: "docs/a.txt", body: "A", contentType: "text/plain" }, { key: "root.txt", body: "R" }]);
+    const response = await call(
+      req("/webdav/", "PROPFIND", { Authorization: AUTH, Depth: "1" }),
+      makeEnv(bucket)
+    );
+    expect(response.status).toBe(207);
+    expect(response.headers.get("Content-Type")).toContain("application/xml");
+    const xml = await response.text();
+    expect(xml).toContain("<href>/webdav/</href>");
+    expect(xml).toContain("<href>/webdav/docs/</href>");
+    expect(xml).toContain("<href>/webdav/root.txt</href>");
+    // Depth 1 只列直接子项：孙辈文件被 delimiter 语义折叠
+    expect(xml).not.toContain("docs/a.txt");
+  });
+
+  test("Depth 1 on a subdirectory lists its files with metadata", async () => {
+    const bucket = new InMemoryBucket();
+    bucket.seed([{ key: "docs/a.txt", body: "A", contentType: "text/plain" }]);
+    const response = await call(
+      req("/webdav/docs/", "PROPFIND", { Authorization: AUTH, Depth: "1" }),
+      makeEnv(bucket)
+    );
+    expect(response.status).toBe(207);
+    const xml = await response.text();
+    expect(xml).toContain("<href>/webdav/docs/</href>");
+    expect(xml).toContain("<href>/webdav/docs/a.txt</href>");
+    expect(xml).toContain("<getcontentlength>1</getcontentlength>");
+    expect(xml).toContain("<getcontenttype>text/plain</getcontenttype>");
+  });
+
+  test("Depth infinity on root also lists grandchildren", async () => {
+    const bucket = new InMemoryBucket();
+    bucket.seedDir("docs");
+    bucket.seed([{ key: "docs/a.txt", body: "A" }]);
+    const response = await call(
+      req("/webdav/", "PROPFIND", { Authorization: AUTH, Depth: "infinity" }),
+      makeEnv(bucket)
+    );
+    expect(response.status).toBe(207);
+    const xml = await response.text();
+    expect(xml).toContain("<href>/webdav/docs/a.txt</href>");
+  });
+
+  test("Depth 0 on a file returns only itself", async () => {
+    const bucket = new InMemoryBucket();
+    bucket.seed([{ key: "a.txt", body: "A" }]);
+    const response = await call(
+      req("/webdav/a.txt", "PROPFIND", { Authorization: AUTH, Depth: "0" }),
+      makeEnv(bucket)
+    );
+    expect(response.status).toBe(207);
+    const xml = await response.text();
+    expect(xml).toContain("<href>/webdav/a.txt</href>");
+    expect(xml).not.toContain("<response>\n    <href>/webdav/a.txt/</href>");
+  });
+
+  test("missing resource is 404", async () => {
+    const bucket = new InMemoryBucket();
+    const response = await call(
+      req("/webdav/ghost.txt", "PROPFIND", { Authorization: AUTH }),
+      makeEnv(bucket)
+    );
+    expect(response.status).toBe(404);
+  });
+
+  test("virtual directory (prefix without marker) still propfinds", async () => {
+    const bucket = new InMemoryBucket();
+    bucket.seed([{ key: "vdir/inner.txt", body: "i" }]);
+    const response = await call(
+      req("/webdav/vdir/", "PROPFIND", { Authorization: AUTH, Depth: "1" }),
+      makeEnv(bucket)
+    );
+    expect(response.status).toBe(207);
+    const xml = await response.text();
+    expect(xml).toContain("<href>/webdav/vdir/</href>");
+    expect(xml).toContain("<href>/webdav/vdir/inner.txt</href>");
+  });
+
+  test("invalid Depth header is 400", async () => {
+    const bucket = new InMemoryBucket();
+    bucket.seedDir("docs");
+    const response = await call(
+      req("/webdav/docs/", "PROPFIND", { Authorization: AUTH, Depth: "2" }),
+      makeEnv(bucket)
+    );
+    expect(response.status).toBe(400);
+  });
+
+  test("malformed XML body is 400", async () => {
+    const bucket = new InMemoryBucket();
+    const response = await call(
+      req("/webdav/", "PROPFIND", { Authorization: AUTH }, "<propfind><broken"),
+      makeEnv(bucket)
+    );
+    expect(response.status).toBe(400);
+  });
+
+  test("prop mode returns 404 propstat for missing property", async () => {
+    const bucket = new InMemoryBucket();
+    bucket.seed([{ key: "a.txt", body: "A" }]);
+    const response = await call(
+      req(
+        "/webdav/a.txt",
+        "PROPFIND",
+        { Authorization: AUTH, "Content-Type": "application/xml" },
+        '<?xml version="1.0"?><propfind xmlns="DAV:"><prop><getcontentlength/><quota-used/></prop></propfind>'
+      ),
+      makeEnv(bucket)
+    );
+    expect(response.status).toBe(207);
+    const xml = await response.text();
+    expect(xml).toContain("HTTP/1.1 200 OK");
+    expect(xml).toContain("HTTP/1.1 404 Not Found");
+    expect(xml).toContain("<getcontentlength>1</getcontentlength>");
+  });
+
+  test("internal prefix is 404 even with auth", async () => {
+    const bucket = new InMemoryBucket();
+    bucket.seed([{ key: "_$flaredrive$/trash/x.json", body: "{}" }]);
+    const response = await call(
+      req("/webdav/_$flaredrive$/trash/x.json", "PROPFIND", { Authorization: AUTH }),
+      makeEnv(bucket)
+    );
+    expect(response.status).toBe(404);
+  });
+});
+
+describe("webdav MKCOL", () => {
+  test("creates a collection with 201 + Location", async () => {
+    const bucket = new InMemoryBucket();
+    const response = await call(
+      req("/webdav/newdir", "MKCOL", { Authorization: AUTH }),
+      makeEnv(bucket)
+    );
+    expect(response.status).toBe(201);
+    expect(response.headers.get("Location")).toBe("/webdav/newdir/");
+    expect(bucket.rawText("newdir")).toBe("");
+    expect(bucket.rawJson("newdir")).toBeUndefined();
+    const head = await bucket.asBucket().head("newdir");
+    expect(head?.httpMetadata?.contentType).toBe("application/x-directory");
+  });
+
+  test("existing resource is 405", async () => {
+    const bucket = new InMemoryBucket();
+    bucket.seed([{ key: "taken.txt", body: "x" }]);
+    const response = await call(
+      req("/webdav/taken.txt", "MKCOL", { Authorization: AUTH }),
+      makeEnv(bucket)
+    );
+    expect(response.status).toBe(405);
+  });
+
+  test("request body is 415", async () => {
+    const bucket = new InMemoryBucket();
+    const response = await call(
+      req("/webdav/d", "MKCOL", { Authorization: AUTH }, "unexpected"),
+      makeEnv(bucket)
+    );
+    expect(response.status).toBe(415);
+  });
+
+  test("missing parent collection is 409", async () => {
+    const bucket = new InMemoryBucket();
+    const response = await call(
+      req("/webdav/ghost/child", "MKCOL", { Authorization: AUTH }),
+      makeEnv(bucket)
+    );
+    expect(response.status).toBe(409);
+  });
+});
+
+describe("webdav GET / HEAD", () => {
+  test("GET returns content with metadata headers", async () => {
+    const bucket = new InMemoryBucket();
+    bucket.seed([
+      { key: "a.txt", body: "Hello World", contentType: "text/plain" },
+    ]);
+    const response = await call(
+      req("/webdav/a.txt", "GET", { Authorization: AUTH }),
+      makeEnv(bucket)
+    );
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Content-Type")).toBe("text/plain");
+    expect(response.headers.get("Accept-Ranges")).toBe("bytes");
+    expect(response.headers.get("ETag")).toMatch(/^"/);
+    expect(await response.text()).toBe("Hello World");
+  });
+
+  test("GET missing file is 404", async () => {
+    const bucket = new InMemoryBucket();
+    const response = await call(
+      req("/webdav/ghost.txt", "GET", { Authorization: AUTH }),
+      makeEnv(bucket)
+    );
+    expect(response.status).toBe(404);
+  });
+
+  test("GET collection without trailing slash redirects 301", async () => {
+    const bucket = new InMemoryBucket();
+    bucket.seedDir("docs");
+    const response = await call(
+      req("/webdav/docs", "GET", { Authorization: AUTH }),
+      makeEnv(bucket)
+    );
+    expect(response.status).toBe(301);
+    expect(response.headers.get("Location")).toBe(`${HOST}/webdav/docs/`);
+  });
+
+  test("GET directory listing with trailing slash returns HTML", async () => {
+    const bucket = new InMemoryBucket();
+    bucket.seedDir("docs");
+    bucket.seed([{ key: "docs/a.txt", body: "A" }]);
+    const response = await call(
+      req("/webdav/docs/", "GET", { Authorization: AUTH }),
+      makeEnv(bucket)
+    );
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Content-Type")).toContain("text/html");
+    const html = await response.text();
+    expect(html).toContain("FlareDrive");
+    expect(html).toContain('href="/webdav/docs/a.txt"');
+    expect(html).toContain('href="/webdav/"');
+  });
+
+  test("If-None-Match hit returns 304 with ETag", async () => {
+    const bucket = new InMemoryBucket();
+    bucket.seed([{ key: "a.txt", body: "A" }]);
+    const first = await call(
+      req("/webdav/a.txt", "GET", { Authorization: AUTH }),
+      makeEnv(bucket)
+    );
+    const etag = first.headers.get("ETag") ?? "";
+    expect(etag).not.toBe("");
+    const second = await call(
+      req("/webdav/a.txt", "GET", { Authorization: AUTH, "If-None-Match": etag }),
+      makeEnv(bucket)
+    );
+    expect(second.status).toBe(304);
+    expect(second.headers.get("ETag")).toBe(etag);
+    expect(await second.text()).toBe("");
+  });
+
+  test("If-None-Match list with weak prefix and star matches", async () => {
+    const bucket = new InMemoryBucket();
+    bucket.seed([{ key: "a.txt", body: "A" }]);
+    const head = await bucket.asBucket().head("a.txt");
+    const etag = head!.etag;
+    for (const header of [
+      `W/"${etag}", "other"`,
+      "*",
+      `"nope", "${etag}"`,
+    ]) {
+      const response = await call(
+        req("/webdav/a.txt", "GET", { Authorization: AUTH, "If-None-Match": header }),
+        makeEnv(bucket)
+      );
+      expect(response.status).toBe(304);
+    }
+  });
+
+  test("If-None-Match miss returns full 200", async () => {
+    const bucket = new InMemoryBucket();
+    bucket.seed([{ key: "a.txt", body: "A" }]);
+    const response = await call(
+      req("/webdav/a.txt", "GET", {
+        Authorization: AUTH,
+        "If-None-Match": '"different"',
+      }),
+      makeEnv(bucket)
+    );
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe("A");
+  });
+
+  test("Range bytes=0-4 returns 206 with Content-Range", async () => {
+    const bucket = new InMemoryBucket();
+    bucket.seed([{ key: "a.txt", body: "Hello World" }]);
+    const response = await call(
+      req("/webdav/a.txt", "GET", {
+        Authorization: AUTH,
+        Range: "bytes=0-4",
+      }),
+      makeEnv(bucket)
+    );
+    expect(response.status).toBe(206);
+    expect(response.headers.get("Content-Range")).toBe("bytes 0-4/11");
+    expect(response.headers.get("Content-Length")).toBe("5");
+    expect(await response.text()).toBe("Hello");
+  });
+
+  test("Range open-ended and suffix forms", async () => {
+    const bucket = new InMemoryBucket();
+    bucket.seed([{ key: "a.txt", body: "Hello World" }]);
+    const openEnded = await call(
+      req("/webdav/a.txt", "GET", { Authorization: AUTH, Range: "bytes=6-" }),
+      makeEnv(bucket)
+    );
+    expect(openEnded.status).toBe(206);
+    expect(await openEnded.text()).toBe("World");
+    const suffix = await call(
+      req("/webdav/a.txt", "GET", { Authorization: AUTH, Range: "bytes=-3" }),
+      makeEnv(bucket)
+    );
+    expect(suffix.status).toBe(206);
+    expect(suffix.headers.get("Content-Range")).toBe("bytes 8-10/11");
+    expect(await suffix.text()).toBe("rld");
+  });
+
+  test("invalid and unsatisfiable Range fall back to full 200", async () => {
+    const bucket = new InMemoryBucket();
+    bucket.seed([{ key: "a.txt", body: "Hello World" }]);
+    for (const range of ["bytes=abc", "bytes=0-1,3-4", "bytes=999-", "bytes=-0"]) {
+      const response = await call(
+        req("/webdav/a.txt", "GET", { Authorization: AUTH, Range: range }),
+        makeEnv(bucket)
+      );
+      expect(response.status).toBe(200);
+      expect(await response.text()).toBe("Hello World");
+    }
+  });
+
+  test("failing If-Match on GET is 412", async () => {
+    const bucket = new InMemoryBucket();
+    bucket.seed([{ key: "a.txt", body: "A" }]);
+    const response = await call(
+      req("/webdav/a.txt", "GET", {
+        Authorization: AUTH,
+        "If-Match": '"stale-etag"',
+      }),
+      makeEnv(bucket)
+    );
+    expect(response.status).toBe(412);
+  });
+
+  test("HEAD mirrors GET status and headers with empty body", async () => {
+    const bucket = new InMemoryBucket();
+    bucket.seed([
+      { key: "a.txt", body: "Hello", contentType: "text/plain" },
+    ]);
+    const response = await call(
+      req("/webdav/a.txt", "HEAD", { Authorization: AUTH }),
+      makeEnv(bucket)
+    );
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Content-Type")).toBe("text/plain");
+    expect(response.headers.get("Content-Length")).toBe("5");
+    expect(await response.text()).toBe("");
+  });
+
+  test("thumbnail GET skips auth and pins cache lifetime", async () => {
+    const bucket = new InMemoryBucket();
+    bucket.seed([
+      {
+        key: "_$flaredrive$/thumbnails/abc",
+        body: "png-bytes",
+        contentType: "image/png",
+      },
+    ]);
+    const response = await call(
+      req("/webdav/_$flaredrive$/thumbnails/abc", "GET"),
+      makeEnv(bucket)
+    );
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Cache-Control")).toBe("max-age=31536000");
+    expect(await response.text()).toBe("png-bytes");
+  });
+
+  test("non-thumbnail internal prefix GET is 404", async () => {
+    const bucket = new InMemoryBucket();
+    bucket.seed([{ key: "_$flaredrive$/trash/x.json", body: "{}" }]);
+    const response = await call(
+      req("/webdav/_$flaredrive$/trash/x.json", "GET", { Authorization: AUTH }),
+      makeEnv(bucket)
+    );
+    expect(response.status).toBe(404);
+  });
+});
+
+describe("webdav PUT", () => {
+  test("create new file is 201 with Location", async () => {
+    const bucket = new InMemoryBucket();
+    const response = await call(
+      req("/webdav/new.txt", "PUT", { Authorization: AUTH }, "hi"),
+      makeEnv(bucket)
+    );
+    expect(response.status).toBe(201);
+    expect(response.headers.get("Location")).toBe("/webdav/new.txt");
+    expect(bucket.rawText("new.txt")).toBe("hi");
+  });
+
+  test("overwrite existing file is 204 and preserves custom metadata", async () => {
+    const bucket = new InMemoryBucket();
+    bucket.seed([{ key: "a.txt", body: "old", customMetadata: { thumbnail: "t" } }]);
+    const response = await call(
+      req(
+        "/webdav/a.txt",
+        "PUT",
+        { Authorization: AUTH, "Content-Type": "text/plain", "fd-thumbnail": "new-t" },
+        "new"
+      ),
+      makeEnv(bucket)
+    );
+    expect(response.status).toBe(204);
+    expect(bucket.rawText("a.txt")).toBe("new");
+    const head = await bucket.asBucket().head("a.txt");
+    expect(head?.customMetadata?.thumbnail).toBe("new-t");
+    expect(head?.httpMetadata?.contentType).toBe("text/plain");
+  });
+
+  test("If-Match mismatch is 412, match succeeds", async () => {
+    const bucket = new InMemoryBucket();
+    bucket.seed([{ key: "a.txt", body: "old" }]);
+    const stale = await call(
+      req("/webdav/a.txt", "PUT", {
+        Authorization: AUTH,
+        "If-Match": '"stale-etag"',
+      }, "new"),
+      makeEnv(bucket)
+    );
+    expect(stale.status).toBe(412);
+    expect(bucket.rawText("a.txt")).toBe("old");
+
+    const head = await bucket.asBucket().head("a.txt");
+    const fresh = await call(
+      req("/webdav/a.txt", "PUT", {
+        Authorization: AUTH,
+        "If-Match": `"${head!.etag}"`,
+      }, "new"),
+      makeEnv(bucket)
+    );
+    expect(fresh.status).toBe(204);
+    expect(bucket.rawText("a.txt")).toBe("new");
+  });
+
+  test("If-None-Match * on existing is 412, on new is 201", async () => {
+    const bucket = new InMemoryBucket();
+    bucket.seed([{ key: "a.txt", body: "old" }]);
+    const existing = await call(
+      req("/webdav/a.txt", "PUT", {
+        Authorization: AUTH,
+        "If-None-Match": "*",
+      }, "new"),
+      makeEnv(bucket)
+    );
+    expect(existing.status).toBe(412);
+    expect(bucket.rawText("a.txt")).toBe("old");
+
+    const fresh = await call(
+      req("/webdav/b.txt", "PUT", {
+        Authorization: AUTH,
+        "If-None-Match": "*",
+      }, "new"),
+      makeEnv(bucket)
+    );
+    expect(fresh.status).toBe(201);
+    expect(bucket.rawText("b.txt")).toBe("new");
+  });
+
+  test("PUT to a collection is 405", async () => {
+    const bucket = new InMemoryBucket();
+    bucket.seedDir("docs");
+    const response = await call(
+      req("/webdav/docs", "PUT", { Authorization: AUTH }, "x"),
+      makeEnv(bucket)
+    );
+    expect(response.status).toBe(405);
+  });
+
+  test("PUT with missing parent is 409", async () => {
+    const bucket = new InMemoryBucket();
+    const response = await call(
+      req("/webdav/ghost/child.txt", "PUT", { Authorization: AUTH }, "x"),
+      makeEnv(bucket)
+    );
+    expect(response.status).toBe(409);
+  });
+
+  test("PUT into internal prefix (non-thumbnail) is 404", async () => {
+    const bucket = new InMemoryBucket();
+    const response = await call(
+      req("/webdav/_$flaredrive$/trash/evil.json", "PUT", { Authorization: AUTH }, "{}"),
+      makeEnv(bucket)
+    );
+    expect(response.status).toBe(404);
+    expect(bucket.has("_$flaredrive$/trash/evil.json")).toBe(false);
+  });
+
+  test("PUT thumbnail prefix is allowed", async () => {
+    const bucket = new InMemoryBucket();
+    bucket.seed([{ key: "_$flaredrive$/thumbnails/seed", body: "s" }]);
+    const response = await call(
+      req("/webdav/_$flaredrive$/thumbnails/abc", "PUT", { Authorization: AUTH }, "png"),
+      makeEnv(bucket)
+    );
+    expect(response.status).toBe(201);
+    expect(bucket.rawText("_$flaredrive$/thumbnails/abc")).toBe("png");
+  });
+
+  test("Content-Length over the single-request cap is 413", async () => {
+    const bucket = new InMemoryBucket();
+    const response = await call(
+      req("/webdav/big.bin", "PUT", {
+        Authorization: AUTH,
+        "Content-Length": String(100 * 1024 * 1024),
+      }, "x"),
+      makeEnv(bucket)
+    );
+    expect(response.status).toBe(413);
+  });
+});
+
+describe("webdav DELETE", () => {
+  test("deletes a file", async () => {
+    const bucket = new InMemoryBucket();
+    bucket.seed([{ key: "a.txt", body: "A" }]);
+    const response = await call(
+      req("/webdav/a.txt", "DELETE", { Authorization: AUTH }),
+      makeEnv(bucket)
+    );
+    expect(response.status).toBe(204);
+    expect(bucket.has("a.txt")).toBe(false);
+  });
+
+  test("deletes a directory tree including marker", async () => {
+    const bucket = new InMemoryBucket();
+    bucket.seedDir("docs");
+    bucket.seed([{ key: "docs/a.txt", body: "A" }, { key: "docs/sub/b.txt", body: "B" }]);
+    const response = await call(
+      req("/webdav/docs", "DELETE", { Authorization: AUTH }),
+      makeEnv(bucket)
+    );
+    expect(response.status).toBe(204);
+    expect(bucket.has("docs")).toBe(false);
+    expect(bucket.has("docs/a.txt")).toBe(false);
+    expect(bucket.has("docs/sub/b.txt")).toBe(false);
+  });
+
+  test("missing resource is 404", async () => {
+    const bucket = new InMemoryBucket();
+    const response = await call(
+      req("/webdav/ghost.txt", "DELETE", { Authorization: AUTH }),
+      makeEnv(bucket)
+    );
+    expect(response.status).toBe(404);
+  });
+
+  test("internal prefix is protected", async () => {
+    const bucket = new InMemoryBucket();
+    bucket.seed([{ key: "_$flaredrive$/trash/x.json", body: "{}" }]);
+    const response = await call(
+      req("/webdav/_$flaredrive$/trash/x.json", "DELETE", { Authorization: AUTH }),
+      makeEnv(bucket)
+    );
+    expect(response.status).toBe(404);
+    expect(bucket.has("_$flaredrive$/trash/x.json")).toBe(true);
+  });
+
+  test("locked descendant blocks DELETE with 423 unless token provided", async () => {
+    const bucket = new InMemoryBucket();
+    bucket.seedDir("docs");
+    const token = await seedLockedFile(bucket, "docs/locked.txt");
+    const withoutToken = await call(
+      req("/webdav/docs", "DELETE", { Authorization: AUTH }),
+      makeEnv(bucket)
+    );
+    expect(withoutToken.status).toBe(423);
+    expect(bucket.has("docs/locked.txt")).toBe(true);
+
+    const withToken = await call(
+      req("/webdav/docs", "DELETE", {
+        Authorization: AUTH,
+        If: `<urn:uuid:${token}>`,
+      }),
+      makeEnv(bucket)
+    );
+    expect(withToken.status).toBe(204);
+    expect(bucket.has("docs/locked.txt")).toBe(false);
+  });
+});
+
+describe("webdav MOVE", () => {
+  test("moves a file to a new key", async () => {
+    const bucket = new InMemoryBucket();
+    bucket.seed([{ key: "a.txt", body: "A" }]);
+    const response = await call(
+      req("/webdav/a.txt", "MOVE", {
+        Authorization: AUTH,
+        Destination: `${HOST}/webdav/b.txt`,
+      }),
+      makeEnv(bucket)
+    );
+    expect(response.status).toBe(201);
+    expect(response.headers.get("Location")).toBe("/webdav/b.txt");
+    expect(bucket.has("a.txt")).toBe(false);
+    expect(bucket.rawText("b.txt")).toBe("A");
+  });
+
+  test("moves a directory with descendants", async () => {
+    const bucket = new InMemoryBucket();
+    bucket.seedDir("docs");
+    bucket.seed([{ key: "docs/a.txt", body: "A" }, { key: "docs/sub/b.txt", body: "B" }]);
+    const response = await call(
+      req("/webdav/docs", "MOVE", {
+        Authorization: AUTH,
+        Destination: `${HOST}/webdav/archive`,
+      }),
+      makeEnv(bucket)
+    );
+    expect(response.status).toBe(201);
+    expect(bucket.has("docs")).toBe(false);
+    expect(bucket.has("docs/a.txt")).toBe(false);
+    expect(bucket.rawText("archive/a.txt")).toBe("A");
+    expect(bucket.rawText("archive/sub/b.txt")).toBe("B");
+    const marker = await bucket.asBucket().head("archive");
+    expect(marker?.httpMetadata?.contentType).toBe("application/x-directory");
+  });
+
+  test("overwrite default replaces existing destination with 204", async () => {
+    const bucket = new InMemoryBucket();
+    bucket.seed([{ key: "a.txt", body: "A" }, { key: "b.txt", body: "B" }]);
+    const response = await call(
+      req("/webdav/a.txt", "MOVE", {
+        Authorization: AUTH,
+        Destination: `${HOST}/webdav/b.txt`,
+      }),
+      makeEnv(bucket)
+    );
+    expect(response.status).toBe(204);
+    expect(bucket.rawText("b.txt")).toBe("A");
+    expect(bucket.has("a.txt")).toBe(false);
+  });
+
+  test("Overwrite F with existing destination is 412", async () => {
+    const bucket = new InMemoryBucket();
+    bucket.seed([{ key: "a.txt", body: "A" }, { key: "b.txt", body: "B" }]);
+    const response = await call(
+      req("/webdav/a.txt", "MOVE", {
+        Authorization: AUTH,
+        Destination: `${HOST}/webdav/b.txt`,
+        Overwrite: "F",
+      }),
+      makeEnv(bucket)
+    );
+    expect(response.status).toBe(412);
+    expect(bucket.rawText("b.txt")).toBe("B");
+    expect(bucket.rawText("a.txt")).toBe("A");
+  });
+
+  test("missing source is 404", async () => {
+    const bucket = new InMemoryBucket();
+    const response = await call(
+      req("/webdav/ghost.txt", "MOVE", {
+        Authorization: AUTH,
+        Destination: `${HOST}/webdav/b.txt`,
+      }),
+      makeEnv(bucket)
+    );
+    expect(response.status).toBe(404);
+  });
+
+  test("destination below source is 400", async () => {
+    const bucket = new InMemoryBucket();
+    bucket.seedDir("docs");
+    const response = await call(
+      req("/webdav/docs", "MOVE", {
+        Authorization: AUTH,
+        Destination: `${HOST}/webdav/docs/inner`,
+      }),
+      makeEnv(bucket)
+    );
+    expect(response.status).toBe(400);
+  });
+
+  test("destination inside internal prefix is 404", async () => {
+    const bucket = new InMemoryBucket();
+    bucket.seed([{ key: "a.txt", body: "A" }]);
+    const response = await call(
+      req("/webdav/a.txt", "MOVE", {
+        Authorization: AUTH,
+        Destination: `${HOST}/webdav/_$flaredrive$/trash/evil.json`,
+      }),
+      makeEnv(bucket)
+    );
+    expect(response.status).toBe(404);
+  });
+
+  test("missing Destination header is 400", async () => {
+    const bucket = new InMemoryBucket();
+    const response = await call(
+      req("/webdav/a.txt", "MOVE", { Authorization: AUTH }),
+      makeEnv(bucket)
+    );
+    expect(response.status).toBe(400);
+  });
+
+  test("destination parent missing is 409", async () => {
+    const bucket = new InMemoryBucket();
+    bucket.seed([{ key: "a.txt", body: "A" }]);
+    const response = await call(
+      req("/webdav/a.txt", "MOVE", {
+        Authorization: AUTH,
+        Destination: `${HOST}/webdav/ghost/b.txt`,
+      }),
+      makeEnv(bucket)
+    );
+    expect(response.status).toBe(409);
+  });
+
+  test("locked source requires token", async () => {
+    const bucket = new InMemoryBucket();
+    const token = await seedLockedFile(bucket, "locked.txt");
+    const withoutToken = await call(
+      req("/webdav/locked.txt", "MOVE", {
+        Authorization: AUTH,
+        Destination: `${HOST}/webdav/moved.txt`,
+      }),
+      makeEnv(bucket)
+    );
+    expect(withoutToken.status).toBe(423);
+    const withToken = await call(
+      req("/webdav/locked.txt", "MOVE", {
+        Authorization: AUTH,
+        Destination: `${HOST}/webdav/moved.txt`,
+        If: `<urn:uuid:${token}>`,
+      }),
+      makeEnv(bucket)
+    );
+    expect(withToken.status).toBe(201);
+    expect(bucket.rawText("moved.txt")).toBe("locked");
+  });
+});
+
+describe("webdav COPY", () => {
+  test("copies a file, keeping the source", async () => {
+    const bucket = new InMemoryBucket();
+    bucket.seed([{ key: "a.txt", body: "A" }]);
+    const response = await call(
+      req("/webdav/a.txt", "COPY", {
+        Authorization: AUTH,
+        Destination: `${HOST}/webdav/copy.txt`,
+      }),
+      makeEnv(bucket)
+    );
+    expect(response.status).toBe(201);
+    expect(bucket.rawText("a.txt")).toBe("A");
+    expect(bucket.rawText("copy.txt")).toBe("A");
+  });
+
+  test("copies a directory recursively (Depth infinity default)", async () => {
+    const bucket = new InMemoryBucket();
+    bucket.seedDir("docs");
+    bucket.seed([{ key: "docs/a.txt", body: "A" }, { key: "docs/sub/b.txt", body: "B" }]);
+    const response = await call(
+      req("/webdav/docs", "COPY", {
+        Authorization: AUTH,
+        Destination: `${HOST}/webdav/docs-copy`,
+      }),
+      makeEnv(bucket)
+    );
+    expect(response.status).toBe(201);
+    expect(bucket.rawText("docs/a.txt")).toBe("A");
+    expect(bucket.rawText("docs-copy/a.txt")).toBe("A");
+    expect(bucket.rawText("docs-copy/sub/b.txt")).toBe("B");
+  });
+
+  test("Overwrite F with existing destination is 412", async () => {
+    const bucket = new InMemoryBucket();
+    bucket.seed([{ key: "a.txt", body: "A" }, { key: "b.txt", body: "B" }]);
+    const response = await call(
+      req("/webdav/a.txt", "COPY", {
+        Authorization: AUTH,
+        Destination: `${HOST}/webdav/b.txt`,
+        Overwrite: "F",
+      }),
+      makeEnv(bucket)
+    );
+    expect(response.status).toBe(412);
+    expect(bucket.rawText("b.txt")).toBe("B");
+  });
+
+  test("default overwrite replaces destination with 204", async () => {
+    const bucket = new InMemoryBucket();
+    bucket.seed([{ key: "a.txt", body: "A" }, { key: "b.txt", body: "B" }]);
+    const response = await call(
+      req("/webdav/a.txt", "COPY", {
+        Authorization: AUTH,
+        Destination: `${HOST}/webdav/b.txt`,
+      }),
+      makeEnv(bucket)
+    );
+    expect(response.status).toBe(204);
+    expect(bucket.rawText("b.txt")).toBe("A");
+    expect(bucket.rawText("a.txt")).toBe("A");
+  });
+
+  test("missing source is 404", async () => {
+    const bucket = new InMemoryBucket();
+    const response = await call(
+      req("/webdav/ghost.txt", "COPY", {
+        Authorization: AUTH,
+        Destination: `${HOST}/webdav/b.txt`,
+      }),
+      makeEnv(bucket)
+    );
+    expect(response.status).toBe(404);
+  });
+
+  test("destination inside internal prefix is 404", async () => {
+    const bucket = new InMemoryBucket();
+    bucket.seed([{ key: "a.txt", body: "A" }]);
+    const response = await call(
+      req("/webdav/a.txt", "COPY", {
+        Authorization: AUTH,
+        Destination: `${HOST}/webdav/_$flaredrive$/shares/evil.json`,
+      }),
+      makeEnv(bucket)
+    );
+    expect(response.status).toBe(404);
+  });
+
+  test("cross-origin Destination is 400", async () => {
+    const bucket = new InMemoryBucket();
+    bucket.seed([{ key: "a.txt", body: "A" }]);
+    const response = await call(
+      req("/webdav/a.txt", "COPY", {
+        Authorization: AUTH,
+        Destination: "http://other.example.com/webdav/b.txt",
+      }),
+      makeEnv(bucket)
+    );
+    expect(response.status).toBe(400);
+  });
+});
+
+describe("webdav LOCK / UNLOCK", () => {
+  test("new exclusive lock returns 201 with Lock-Token and lockdiscovery", async () => {
+    const bucket = new InMemoryBucket();
+    bucket.seed([{ key: "a.txt", body: "A" }]);
+    const response = await call(
+      req("/webdav/a.txt", "LOCK", {
+        Authorization: AUTH,
+        "Content-Type": "application/xml",
+        Timeout: "Second-120",
+      }, LOCK_BODY),
+      makeEnv(bucket)
+    );
+    expect(response.status).toBe(201);
+    const tokenHeader = response.headers.get("Lock-Token") ?? "";
+    expect(tokenHeader).toMatch(/^<urn:uuid:[0-9a-f-]+>$/);
+    const xml = await response.text();
+    expect(xml).toContain("<locktoken><href>urn:uuid:");
+    expect(xml).toContain("<owner>tester</owner>");
+    expect(xml).toContain("Second-120");
+    // 内容不变，锁写进 customMetadata
+    expect(bucket.rawText("a.txt")).toBe("A");
+  });
+
+  test("second exclusive lock without token is 423", async () => {
+    const bucket = new InMemoryBucket();
+    await seedLockedFile(bucket, "locked.txt");
+    const response = await call(
+      req("/webdav/locked.txt", "LOCK", {
+        Authorization: AUTH,
+        "Content-Type": "application/xml",
+      }, LOCK_BODY),
+      makeEnv(bucket)
+    );
+    expect(response.status).toBe(423);
+  });
+
+  test("shared lock while exclusive held is 423 and vice versa", async () => {
+    const bucket = new InMemoryBucket();
+    await seedLockedFile(bucket, "locked.txt");
+    const shared = await call(
+      req("/webdav/locked.txt", "LOCK", {
+        Authorization: AUTH,
+        "Content-Type": "application/xml",
+      }, SHARED_LOCK_BODY),
+      makeEnv(bucket)
+    );
+    expect(shared.status).toBe(423);
+
+    const bucket2 = new InMemoryBucket();
+    bucket2.seed([{ key: "s.txt", body: "S" }]);
+    await call(
+      req("/webdav/s.txt", "LOCK", {
+        Authorization: AUTH,
+        "Content-Type": "application/xml",
+      }, SHARED_LOCK_BODY),
+      makeEnv(bucket2)
+    );
+    const exclusive = await call(
+      req("/webdav/s.txt", "LOCK", {
+        Authorization: AUTH,
+        "Content-Type": "application/xml",
+      }, LOCK_BODY),
+      makeEnv(bucket2)
+    );
+    expect(exclusive.status).toBe(423);
+  });
+
+  test("LOCK refresh with If token returns 200 and keeps the token", async () => {
+    const bucket = new InMemoryBucket();
+    const token = await seedLockedFile(bucket, "locked.txt");
+    const response = await call(
+      req("/webdav/locked.txt", "LOCK", {
+        Authorization: AUTH,
+        If: `<urn:uuid:${token}>`,
+        Timeout: "Second-60",
+      }),
+      makeEnv(bucket)
+    );
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Lock-Token")).toBe(`<urn:uuid:${token}>`);
+    const xml = await response.text();
+    expect(xml).toContain(`urn:uuid:${token}`);
+    expect(xml).toContain("Second-60");
+  });
+
+  test("LOCK on missing resource creates a lockable empty file", async () => {
+    const bucket = new InMemoryBucket();
+    const response = await call(
+      req("/webdav/virgin.txt", "LOCK", {
+        Authorization: AUTH,
+        "Content-Type": "application/xml",
+      }, LOCK_BODY),
+      makeEnv(bucket)
+    );
+    expect(response.status).toBe(201);
+    expect(bucket.has("virgin.txt")).toBe(true);
+    expect(response.headers.get("Location")).toBe("/webdav/virgin.txt");
+  });
+
+  test("LOCK without existing parent is 409", async () => {
+    const bucket = new InMemoryBucket();
+    const response = await call(
+      req("/webdav/ghost/child.txt", "LOCK", {
+        Authorization: AUTH,
+        "Content-Type": "application/xml",
+      }, LOCK_BODY),
+      makeEnv(bucket)
+    );
+    expect(response.status).toBe(409);
+  });
+
+  test("LOCK body without locktype is 400 and invalid Depth is 400", async () => {
+    const bucket = new InMemoryBucket();
+    bucket.seed([{ key: "a.txt", body: "A" }]);
+    const badBody = await call(
+      req("/webdav/a.txt", "LOCK", {
+        Authorization: AUTH,
+        "Content-Type": "application/xml",
+      }, '<?xml version="1.0"?><D:lockinfo xmlns:D="DAV:"><D:lockscope><D:exclusive/></D:lockscope></D:lockinfo>'),
+      makeEnv(bucket)
+    );
+    expect(badBody.status).toBe(400);
+    const badDepth = await call(
+      req("/webdav/a.txt", "LOCK", {
+        Authorization: AUTH,
+        Depth: "1",
+        "Content-Type": "application/xml",
+      }, LOCK_BODY),
+      makeEnv(bucket)
+    );
+    expect(badDepth.status).toBe(400);
+  });
+
+  test("If: <DAV:no-lock> precondition is 412", async () => {
+    const bucket = new InMemoryBucket();
+    bucket.seed([{ key: "a.txt", body: "A" }]);
+    const response = await call(
+      req("/webdav/a.txt", "LOCK", {
+        Authorization: AUTH,
+        If: "<DAV:no-lock>",
+      }, LOCK_BODY),
+      makeEnv(bucket)
+    );
+    expect(response.status).toBe(412);
+  });
+
+  test("depth-infinity lock on a directory blocks child PUT without token", async () => {
+    const bucket = new InMemoryBucket();
+    bucket.seedDir("docs");
+    const lockResponse = await call(
+      req("/webdav/docs", "LOCK", {
+        Authorization: AUTH,
+        Depth: "infinity",
+        "Content-Type": "application/xml",
+      }, LOCK_BODY),
+      makeEnv(bucket)
+    );
+    expect(lockResponse.status).toBe(201);
+    const token = (lockResponse.headers.get("Lock-Token") ?? "")
+      .replace(/^<urn:uuid:/, "")
+      .replace(/>$/, "");
+    const blocked = await call(
+      req("/webdav/docs/child.txt", "PUT", { Authorization: AUTH }, "x"),
+      makeEnv(bucket)
+    );
+    expect(blocked.status).toBe(423);
+    const allowed = await call(
+      req("/webdav/docs/child.txt", "PUT", {
+        Authorization: AUTH,
+        If: `<urn:uuid:${token}>`,
+      }, "x"),
+      makeEnv(bucket)
+    );
+    expect(allowed.status).toBe(201);
+    expect(bucket.rawText("docs/child.txt")).toBe("x");
+  });
+
+  test("UNLOCK with the right token returns 204 and frees the resource", async () => {
+    const bucket = new InMemoryBucket();
+    const token = await seedLockedFile(bucket, "locked.txt");
+    const response = await call(
+      req("/webdav/locked.txt", "UNLOCK", {
+        Authorization: AUTH,
+        "Lock-Token": `<urn:uuid:${token}>`,
+      }),
+      makeEnv(bucket)
+    );
+    expect(response.status).toBe(204);
+    // 释放后可以再次加独占锁
+    const again = await call(
+      req("/webdav/locked.txt", "LOCK", {
+        Authorization: AUTH,
+        "Content-Type": "application/xml",
+      }, LOCK_BODY),
+      makeEnv(bucket)
+    );
+    expect(again.status).toBe(201);
+  });
+
+  test("UNLOCK mismatches: wrong token 409 (with valid If), wrong token alone 423", async () => {
+    const bucket = new InMemoryBucket();
+    const token = await seedLockedFile(bucket, "locked.txt");
+    // Lock-Token 携带错误 token 且 If 携带有效 token：锁校验通过但
+    // Lock-Token 解析出的 token 不在锁记录里 → 409 Conflict
+    const wrongWithValidIf = await call(
+      req("/webdav/locked.txt", "UNLOCK", {
+        Authorization: AUTH,
+        "Lock-Token": "<urn:uuid:not-the-token>",
+        If: `<urn:uuid:${token}>`,
+      }),
+      makeEnv(bucket)
+    );
+    expect(wrongWithValidIf.status).toBe(409);
+    // 只带错误 token：锁权限校验先失败 → 423 Locked
+    const wrongOnly = await call(
+      req("/webdav/locked.txt", "UNLOCK", {
+        Authorization: AUTH,
+        "Lock-Token": "<urn:uuid:not-the-token>",
+      }),
+      makeEnv(bucket)
+    );
+    expect(wrongOnly.status).toBe(423);
+  });
+
+  test("UNLOCK without header is 400 and on unlocked/missing resource is 409/404", async () => {
+    const bucket = new InMemoryBucket();
+    bucket.seed([{ key: "plain.txt", body: "P" }]);
+    const missingHeader = await call(
+      req("/webdav/plain.txt", "UNLOCK", { Authorization: AUTH }),
+      makeEnv(bucket)
+    );
+    expect(missingHeader.status).toBe(400);
+    const unlocked = await call(
+      req("/webdav/plain.txt", "UNLOCK", {
+        Authorization: AUTH,
+        "Lock-Token": "<urn:uuid:whatever>",
+      }),
+      makeEnv(bucket)
+    );
+    expect(unlocked.status).toBe(409);
+    const absent = await call(
+      req("/webdav/ghost.txt", "UNLOCK", {
+        Authorization: AUTH,
+        "Lock-Token": "<urn:uuid:whatever>",
+      }),
+      makeEnv(bucket)
+    );
+    expect(absent.status).toBe(404);
+  });
+});
+
+describe("webdav POST multipart (uploads/complete)", () => {
+  test("POST ?uploads creates a multipart upload", async () => {
+    const bucket = new InMemoryBucket();
+    const response = await call(
+      req("/webdav/big.bin?uploads", "POST", { Authorization: AUTH }),
+      makeEnv(bucket)
+    );
+    expect(response.status).toBe(200);
+    const body = JSON.parse(await response.text());
+    expect(body.key).toBe("big.bin");
+    expect(typeof body.uploadId).toBe("string");
+  });
+
+  test("three-step multipart upload assembles the object", async () => {
+    const bucket = new InMemoryBucket();
+    const create = await call(
+      req("/webdav/big.bin?uploads", "POST", { Authorization: AUTH }),
+      makeEnv(bucket)
+    );
+    const { uploadId } = JSON.parse(await create.text());
+
+    const part1 = await call(
+      withRawBody(
+        req(`/webdav/big.bin?uploadId=${uploadId}&partNumber=1`, "PUT", { Authorization: AUTH }),
+        new TextEncoder().encode("hello-")
+      ),
+      makeEnv(bucket)
+    );
+    expect(part1.status).toBe(200);
+    const etag1 = part1.headers.get("etag") ?? "";
+    expect(etag1).not.toBe("");
+
+    const part2 = await call(
+      withRawBody(
+        req(`/webdav/big.bin?uploadId=${uploadId}&partNumber=2`, "PUT", { Authorization: AUTH }),
+        new TextEncoder().encode("world")
+      ),
+      makeEnv(bucket)
+    );
+    expect(part2.status).toBe(200);
+    const etag2 = part2.headers.get("etag") ?? "";
+
+    const complete = await call(
+      req(
+        `/webdav/big.bin?uploadId=${uploadId}`,
+        "POST",
+        { Authorization: AUTH, "Content-Type": "application/json" },
+        JSON.stringify({
+          parts: [
+            { partNumber: 1, etag: etag1 },
+            { partNumber: 2, etag: etag2 },
+          ],
+        })
+      ),
+      makeEnv(bucket)
+    );
+    expect(complete.status).toBe(200);
+    expect(complete.headers.get("etag")).toMatch(/^"/);
+    expect(bucket.rawText("big.bin")).toBe("hello-world");
+  });
+
+  test("complete with fabricated part etag is 400", async () => {
+    const bucket = new InMemoryBucket();
+    const create = await call(
+      req("/webdav/big.bin?uploads", "POST", { Authorization: AUTH }),
+      makeEnv(bucket)
+    );
+    const { uploadId } = JSON.parse(await create.text());
+    const response = await call(
+      req(
+        `/webdav/big.bin?uploadId=${uploadId}`,
+        "POST",
+        { Authorization: AUTH, "Content-Type": "application/json" },
+        JSON.stringify({ parts: [{ partNumber: 1, etag: "fabricated" }] })
+      ),
+      makeEnv(bucket)
+    );
+    expect(response.status).toBe(400);
+    expect(bucket.has("big.bin")).toBe(false);
+  });
+
+  test("multipart PUT validates partNumber and uploadId", async () => {
+    const bucket = new InMemoryBucket();
+    const badPart = await call(
+      withRawBody(
+        req("/webdav/a.bin?uploadId=abc&partNumber=0", "PUT", { Authorization: AUTH }),
+        new TextEncoder().encode("x")
+      ),
+      makeEnv(bucket)
+    );
+    expect(badPart.status).toBe(400);
+    const nanPart = await call(
+      withRawBody(
+        req("/webdav/a.bin?uploadId=abc&partNumber=xyz", "PUT", { Authorization: AUTH }),
+        new TextEncoder().encode("x")
+      ),
+      makeEnv(bucket)
+    );
+    expect(nanPart.status).toBe(400);
+    const noBody = await call(
+      req("/webdav/a.bin?uploadId=abc&partNumber=1", "PUT", { Authorization: AUTH }),
+      makeEnv(bucket)
+    );
+    expect(noBody.status).toBe(400);
+  });
+
+  test("POST complete with unknown uploadId / bad body is 400", async () => {
+    const bucket = new InMemoryBucket();
+    const unknownId = await call(
+      req(
+        "/webdav/big.bin?uploadId=missing",
+        "POST",
+        { Authorization: AUTH, "Content-Type": "application/json" },
+        JSON.stringify({ parts: [{ partNumber: 1, etag: "e" }] })
+      ),
+      makeEnv(bucket)
+    );
+    expect(unknownId.status).toBe(400);
+    const noUploadId = await call(
+      req(
+        "/webdav/big.bin",
+        "POST",
+        { Authorization: AUTH, "Content-Type": "application/json" },
+        JSON.stringify({ parts: [] })
+      ),
+      makeEnv(bucket)
+    );
+    expect(noUploadId.status).toBe(405);
+    const badJson = await call(
+      req(
+        "/webdav/big.bin?uploadId=missing",
+        "POST",
+        { Authorization: AUTH, "Content-Type": "application/json" },
+        "{not json"
+      ),
+      makeEnv(bucket)
+    );
+    expect(badJson.status).toBe(400);
+    const badParts = await call(
+      req(
+        "/webdav/big.bin?uploadId=missing",
+        "POST",
+        { Authorization: AUTH, "Content-Type": "application/json" },
+        JSON.stringify({ parts: "nope" })
+      ),
+      makeEnv(bucket)
+    );
+    expect(badParts.status).toBe(400);
+  });
+
+  test("POST without uploads/uploadId params is 405", async () => {
+    const bucket = new InMemoryBucket();
+    const response = await call(
+      req("/webdav/a.txt", "POST", { Authorization: AUTH }),
+      makeEnv(bucket)
+    );
+    expect(response.status).toBe(405);
+    expect(response.headers.get("Allow")).toContain("PUT");
+  });
+});

--- a/src/app/testInMemoryBucket.ts
+++ b/src/app/testInMemoryBucket.ts
@@ -1,0 +1,710 @@
+/**
+ * 测试用 R2Bucket 内存实现（R2 语义尽量忠实）。
+ *
+ * 仅模拟 functions/ 实际用到的 API 面：
+ * - head/get/put/delete（含 onlyIf 条件、Range 切片、Headers 形式的 httpMetadata）
+ * - list（prefix/cursor/limit/delimiter/include；键按 UTF-8 字典序；
+ *   cursor 从上次截断处续传；delimiter 聚合 delimitedPrefixes）
+ * - multipart：createMultipartUpload / resumeMultipartUpload / uploadPart /
+ *   complete / abort（R2 语义：uploadPart 对顺序宽松、partNumber 1..10000、
+ *   未知 uploadId 懒失败；complete 要求升序且分块已上传、etag 匹配）
+ *
+ * 简化点（有意为之，不影响被测逻辑）：
+ * - 不做版本/checksums/md5 校验
+ * - complete 不强制除末块外 ≥5MiB（测试分块都是小体积；真实 R2 对单块上传豁免）
+ * - body 为 Uint8Array（whatwg-fetch 测试环境无法流转真实 ReadableStream，
+ *   R2ObjectBody 的其他消费方式 getReader/asyncIterator 由 buffer 直读）
+ *
+ * 注意：本文件不放在 __tests__（CRA 会把 __tests__ 下所有文件当测试套件），
+ * 并已在 package.json 的 jest.collectCoverageFrom 中排除。
+ */
+import { ReadableStream as NodeReadableStream } from "stream/web";
+
+const R2_PART_MAX = 10000;
+
+interface StoredObject {
+  key: string;
+  bytes: Uint8Array;
+  uploaded: Date;
+  etag: string;
+  httpMetadata?: R2HTTPMetadata;
+  customMetadata?: Record<string, string>;
+}
+
+interface MultipartState {
+  key: string;
+  uploadId: string;
+  parts: Map<number, { etag: string; bytes: Uint8Array }>;
+  finalized: boolean;
+  aborted: boolean;
+}
+
+export interface SeedEntry {
+  key: string;
+  body?: string | Uint8Array;
+  contentType?: string;
+  httpMetadata?: R2HTTPMetadata;
+  customMetadata?: Record<string, string>;
+  uploaded?: Date;
+  size?: number;
+  etag?: string;
+}
+
+function randomHex(bytes: number): string {
+  const buf = new Uint8Array(bytes);
+  crypto.getRandomValues(buf);
+  return Array.from(buf)
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+/** R2 键序 = UTF-8 字节字典序（JS 默认排序是 UTF-16 码元序，对 ASCII 一致，这里显式对齐）。 */
+function compareKeys(a: string, b: string): number {
+  const ba = Buffer.from(a, "utf8");
+  const bb = Buffer.from(b, "utf8");
+  const len = Math.min(ba.length, bb.length);
+  for (let i = 0; i < len; i++) {
+    if (ba[i] !== bb[i]) return ba[i] - bb[i];
+  }
+  return ba.length - bb.length;
+}
+
+function toBytes(value: unknown): Uint8Array | null {
+  if (value === null || value === undefined) return new Uint8Array(0);
+  if (typeof value === "string") return new TextEncoder().encode(value);
+  if (value instanceof Uint8Array) return value;
+  if (value instanceof ArrayBuffer) return new Uint8Array(value);
+  if (ArrayBuffer.isView(value)) {
+    const view = value as ArrayBufferView;
+    return new Uint8Array(view.buffer, view.byteOffset, view.byteLength);
+  }
+  return null; // Blob / ReadableStream 交给 streamToBytes 异步处理
+}
+
+async function streamToBytes(value: unknown): Promise<Uint8Array> {
+  const sync = toBytes(value);
+  if (sync !== null) return sync;
+  if (typeof (value as ReadableStream).getReader === "function") {
+    const reader = (value as ReadableStream).getReader();
+    const chunks: Uint8Array[] = [];
+    let total = 0;
+    while (true) {
+      const { done, value: chunk } = await reader.read();
+      if (done) break;
+      if (chunk) {
+        chunks.push(chunk);
+        total += chunk.byteLength;
+      }
+    }
+    const out = new Uint8Array(total);
+    let offset = 0;
+    for (const chunk of chunks) {
+      out.set(chunk, offset);
+      offset += chunk.byteLength;
+    }
+    return out;
+  }
+  if (typeof Blob !== "undefined" && value instanceof Blob) {
+    return new Uint8Array(await value.arrayBuffer());
+  }
+  throw new Error(
+    "testInMemoryBucket: unsupported put value (not bytes/string/blob/stream)"
+  );
+}
+
+function httpMetadataFromHeaders(headers: Headers): R2HTTPMetadata {
+  const metadata: R2HTTPMetadata = {};
+  const map: Array<[string, keyof R2HTTPMetadata]> = [
+    ["content-type", "contentType"],
+    ["content-language", "contentLanguage"],
+    ["content-disposition", "contentDisposition"],
+    ["content-encoding", "contentEncoding"],
+    ["cache-control", "cacheControl"],
+  ];
+  for (const [headerName, field] of map) {
+    const value = headers.get(headerName);
+    if (value !== null) {
+      (metadata as Record<string, unknown>)[field] = value;
+    }
+  }
+  return metadata;
+}
+
+function normalizeHttpMetadata(
+  input: R2HTTPMetadata | Headers | undefined
+): R2HTTPMetadata | undefined {
+  if (!input) return undefined;
+  if (typeof (input as Headers).get === "function") {
+    return httpMetadataFromHeaders(input as Headers);
+  }
+  return { ...(input as R2HTTPMetadata) };
+}
+
+function normalizeEtag(value: string): string {
+  return value.trim().replace(/^W\//, "").replace(/^"|"$/g, "");
+}
+
+/** R2 onlyIf 语义：Headers 形式解析 if-match/if-none-match/if-(un)modified-since。 */
+function evaluateOnlyIf(
+  onlyIf: R2Conditional | Headers | undefined,
+  object: StoredObject | undefined
+): boolean {
+  if (onlyIf === undefined || onlyIf === null) return true;
+  let etagMatches: string | undefined;
+  let etagDoesNotMatch: string | undefined;
+  let uploadedBefore: Date | undefined;
+  let uploadedAfter: Date | undefined;
+
+  if (typeof (onlyIf as Headers).get === "function") {
+    const headers = onlyIf as Headers;
+    const ifMatch = headers.get("if-match");
+    const ifNoneMatch = headers.get("if-none-match");
+    const ifModifiedSince = headers.get("if-modified-since");
+    const ifUnmodifiedSince = headers.get("if-unmodified-since");
+    if (ifMatch !== null) etagMatches = ifMatch;
+    if (ifNoneMatch !== null) etagDoesNotMatch = ifNoneMatch;
+    if (ifModifiedSince !== null) {
+      const ts = Date.parse(ifModifiedSince);
+      if (Number.isFinite(ts)) uploadedAfter = new Date(ts);
+    }
+    if (ifUnmodifiedSince !== null) {
+      const ts = Date.parse(ifUnmodifiedSince);
+      if (Number.isFinite(ts)) uploadedBefore = new Date(ts);
+    }
+  } else {
+    const condition = onlyIf as R2Conditional;
+    etagMatches = condition.etagMatches;
+    etagDoesNotMatch = condition.etagDoesNotMatch;
+    uploadedBefore = condition.uploadedBefore;
+    uploadedAfter = condition.uploadedAfter;
+  }
+
+  if (etagMatches !== undefined) {
+    if (object === undefined) return false;
+    if (etagMatches.trim() === "*") return true;
+    const etag = normalizeEtag(etagMatches);
+    if (etag !== object.etag && etag !== normalizeEtag(`"${object.etag}"`)) {
+      return false;
+    }
+  }
+  if (etagDoesNotMatch !== undefined) {
+    if (etagDoesNotMatch.trim() === "*") {
+      if (object !== undefined) return false;
+    } else if (object !== undefined) {
+      const etag = normalizeEtag(etagDoesNotMatch);
+      if (etag === object.etag || etag === normalizeEtag(`"${object.etag}"`)) {
+        return false;
+      }
+    }
+  }
+  if (uploadedBefore !== undefined && object !== undefined) {
+    if (object.uploaded.getTime() >= uploadedBefore.getTime()) return false;
+  }
+  if (uploadedAfter !== undefined && object !== undefined) {
+    if (object.uploaded.getTime() <= uploadedAfter.getTime()) return false;
+  }
+  return true;
+}
+
+/** 解析 Range 头为 R2Range；非法/多段范围抛错（R2 InvalidRange，HTTP 416 同类）。 */
+function rangeFromHeaders(headers: Headers, size: number): R2Range | undefined {
+  const raw = headers.get("range");
+  if (raw === null) return undefined;
+  const match = /^bytes=(\d*)-(\d*)$/.exec(raw.trim());
+  if (!match || (match[1] === "" && match[2] === "")) {
+    throw new Error(`R2 InvalidRange: ${raw}`);
+  }
+  if (match[1] === "") {
+    const suffix = Number(match[2]);
+    if (suffix === 0) throw new Error("R2 InvalidRange: unsatisfiable suffix");
+    return { suffix };
+  }
+  const offset = Number(match[1]);
+  if (offset >= size) {
+    throw new Error(`R2 InvalidRange: start ${offset} >= size ${size}`);
+  }
+  if (match[2] === "") return { offset };
+  const end = Number(match[2]);
+  if (end < offset) throw new Error(`R2 InvalidRange: ${raw}`);
+  return { offset, length: end - offset + 1 };
+}
+
+function decodeCursor(cursor: string): string {
+  try {
+    return Buffer.from(cursor, "base64").toString("utf8");
+  } catch {
+    return "";
+  }
+}
+
+export class InMemoryBucket {
+  private objects = new Map<string, StoredObject>();
+  private multiparts = new Map<string, MultipartState>();
+
+  /** 用作 PagesFunction env.BUCKET 时的显式收口。 */
+  asBucket(): R2Bucket {
+    return this as unknown as R2Bucket;
+  }
+
+  /** 测试造数据：直接写入对象（目录标记用 seedDir / 给 contentType）。 */
+  seed(entries: SeedEntry[]): void {
+    for (const entry of entries) {
+      const bytes =
+        typeof entry.body === "string"
+          ? new TextEncoder().encode(entry.body)
+          : entry.body ?? new Uint8Array(0);
+      const httpMetadata = normalizeHttpMetadata(
+        entry.httpMetadata ??
+          (entry.contentType ? { contentType: entry.contentType } : undefined)
+      );
+      this.objects.set(entry.key, {
+        key: entry.key,
+        bytes,
+        uploaded: entry.uploaded ?? new Date("2026-01-01T00:00:00.000Z"),
+        etag: entry.etag ?? randomHex(16),
+        httpMetadata,
+        customMetadata: entry.customMetadata
+          ? { ...entry.customMetadata }
+          : undefined,
+      });
+    }
+  }
+
+  /** 目录标记对象（0 字节 + x-directory），与 MKCOL/ensureFolders 写法一致。 */
+  seedDir(key: string, uploaded?: Date): void {
+    this.seed([
+      {
+        key,
+        body: new Uint8Array(0),
+        contentType: "application/x-directory",
+        customMetadata: { resourcetype: "<collection />" },
+        uploaded,
+      },
+    ]);
+  }
+
+  /** 测试断言辅助：读当前字节内容。 */
+  rawBytes(key: string): Uint8Array | undefined {
+    return this.objects.get(key)?.bytes;
+  }
+
+  rawText(key: string): string | undefined {
+    const stored = this.objects.get(key);
+    return stored ? new TextDecoder().decode(stored.bytes) : undefined;
+  }
+
+  rawJson<T = Record<string, unknown>>(key: string): T | undefined {
+    const text = this.rawText(key);
+    if (text === undefined || text.trim() === "") return undefined;
+    return JSON.parse(text) as T;
+  }
+
+  has(key: string): boolean {
+    return this.objects.has(key);
+  }
+
+  async head(key: string): Promise<R2Object | null> {
+    const stored = this.objects.get(key);
+    if (!stored) return null;
+    return this.toR2Object(stored);
+  }
+
+  async get(key: string, options?: R2GetOptions): Promise<R2ObjectBody | null>;
+  async get(
+    key: string,
+    options: R2GetOptions & { onlyIf: R2Conditional | Headers }
+  ): Promise<R2ObjectBody | R2Object | null>;
+  async get(
+    key: string,
+    options?: R2GetOptions & { onlyIf?: R2Conditional | Headers }
+  ): Promise<R2ObjectBody | R2Object | null> {
+    const stored = this.objects.get(key);
+    if (!stored) return null;
+    if (!evaluateOnlyIf(options?.onlyIf, stored)) {
+      // R2：条件失败返回无 body 的 R2Object（HTTP 412 语义）
+      return this.toR2Object(stored);
+    }
+    let range: R2Range | undefined;
+    if (options?.range) {
+      if (typeof (options.range as Headers).get === "function") {
+        range = rangeFromHeaders(options.range as Headers, stored.bytes.length);
+      } else {
+        range = options.range as R2Range;
+        if ("suffix" in range) {
+          if (range.suffix === 0) {
+            throw new Error("R2 InvalidRange: unsatisfiable suffix");
+          }
+        } else if ((range.offset ?? 0) >= stored.bytes.length) {
+          throw new Error("R2 InvalidRange: unsatisfiable offset");
+        }
+      }
+    }
+    return this.toR2ObjectBody(stored, range);
+  }
+
+  async put(
+    key: string,
+    value: ReadableStream | ArrayBuffer | ArrayBufferView | string | null | Blob,
+    options?: R2PutOptions
+  ): Promise<R2Object>;
+  async put(
+    key: string,
+    value: ReadableStream | ArrayBuffer | ArrayBufferView | string | null | Blob,
+    options: R2PutOptions & { onlyIf: R2Conditional | Headers }
+  ): Promise<R2Object | null>;
+  async put(
+    key: string,
+    value:
+      | ReadableStream
+      | ArrayBuffer
+      | ArrayBufferView
+      | string
+      | null
+      | Blob,
+    options?: R2PutOptions & { onlyIf?: R2Conditional | Headers }
+  ): Promise<R2Object | null> {
+    const existing = this.objects.get(key);
+    if (!evaluateOnlyIf(options?.onlyIf, existing)) {
+      return null;
+    }
+    const bytes = await streamToBytes(value);
+    const stored: StoredObject = {
+      key,
+      bytes,
+      uploaded: new Date(),
+      etag: randomHex(16),
+      httpMetadata: normalizeHttpMetadata(options?.httpMetadata),
+      customMetadata: options?.customMetadata
+        ? { ...options.customMetadata }
+        : undefined,
+    };
+    this.objects.set(key, stored);
+    return this.toR2Object(stored);
+  }
+
+  async delete(keys: string | string[]): Promise<void> {
+    const list = Array.isArray(keys) ? keys : [keys];
+    for (const key of list) {
+      this.objects.delete(key);
+    }
+  }
+
+  async list(options: R2ListOptions = {}): Promise<R2Objects> {
+    const {
+      prefix,
+      cursor,
+      delimiter,
+      limit,
+      startAfter,
+      include,
+    } = options;
+    const after =
+      cursor !== undefined
+        ? decodeCursor(cursor)
+        : startAfter !== undefined
+          ? startAfter
+          : "";
+
+    const allKeys = [...this.objects.keys()]
+      .filter((key) => (prefix ? key.startsWith(prefix) : true))
+      .filter((key) => compareKeys(key, after) > 0)
+      .sort(compareKeys);
+
+    const objects: R2Object[] = [];
+    const delimitedPrefixes: string[] = [];
+    const seenPrefixes = new Set<string>();
+    const maxResults = limit ?? 1000;
+    let truncated = false;
+    let lastEmitted = "";
+
+    for (const key of allKeys) {
+      if (objects.length + delimitedPrefixes.length >= maxResults) {
+        truncated = true;
+        break;
+      }
+      let rolledPrefix: string | null = null;
+      if (delimiter) {
+        const rest = key.slice(prefix ? prefix.length : 0);
+        const delimiterIndex = rest.indexOf(delimiter);
+        if (delimiterIndex >= 0) {
+          rolledPrefix =
+            (prefix ?? "") + rest.slice(0, delimiterIndex + delimiter.length);
+        }
+      }
+      if (rolledPrefix !== null) {
+        if (!seenPrefixes.has(rolledPrefix)) {
+          seenPrefixes.add(rolledPrefix);
+          delimitedPrefixes.push(rolledPrefix);
+          lastEmitted = rolledPrefix;
+        } else {
+          continue;
+        }
+      } else {
+        objects.push(this.toR2Object(this.objects.get(key)!, include));
+        lastEmitted = key;
+      }
+    }
+
+    const result: R2Objects = truncated
+      ? ({
+          objects,
+          delimitedPrefixes,
+          truncated: true,
+          cursor: Buffer.from(lastEmitted, "utf8").toString("base64"),
+        } as R2Objects)
+      : ({ objects, delimitedPrefixes, truncated: false } as R2Objects);
+    return result;
+  }
+
+  async createMultipartUpload(
+    key: string,
+    options?: R2MultipartOptions
+  ): Promise<R2MultipartUpload> {
+    const uploadId = randomHex(16);
+    this.multiparts.set(uploadId, {
+      key,
+      uploadId,
+      parts: new Map(),
+      finalized: false,
+      aborted: false,
+    });
+    return this.makeMultipartHandle(
+      key,
+      uploadId,
+      normalizeHttpMetadata(options?.httpMetadata),
+      options?.customMetadata
+    );
+  }
+
+  resumeMultipartUpload(key: string, uploadId: string): R2MultipartUpload {
+    return this.makeMultipartHandle(key, uploadId);
+  }
+
+  private getState(uploadId: string): MultipartState {
+    const state = this.multiparts.get(uploadId);
+    if (!state || state.aborted || state.finalized) {
+      throw new Error(
+        `R2 error: multipart upload not found or already closed (${uploadId})`
+      );
+    }
+    return state;
+  }
+
+  private makeMultipartHandle(
+    key: string,
+    uploadId: string,
+    httpMetadata?: R2HTTPMetadata,
+    customMetadata?: Record<string, string>
+  ): R2MultipartUpload {
+    return {
+      key,
+      uploadId,
+      uploadPart: async (
+        partNumber: number,
+        value: ReadableStream | (ArrayBuffer | ArrayBufferView) | string | Blob
+      ): Promise<R2UploadedPart> => {
+        // R2：未知 uploadId 在操作时懒失败（resume 不校验）
+        const state = this.getState(uploadId);
+        if (!Number.isInteger(partNumber) || partNumber < 1 || partNumber > R2_PART_MAX) {
+          throw new Error(`R2 error: part number ${partNumber} out of range 1-${R2_PART_MAX}`);
+        }
+        const bytes = await streamToBytes(value);
+        const etag = randomHex(16);
+        state.parts.set(partNumber, { etag, bytes });
+        return { partNumber, etag };
+      },
+      abort: async (): Promise<void> => {
+        const state = this.multiparts.get(uploadId);
+        if (!state || state.aborted || state.finalized) {
+          throw new Error(`R2 error: multipart upload not found (${uploadId})`);
+        }
+        this.multiparts.delete(uploadId);
+      },
+      complete: async (uploadedParts: R2UploadedPart[]): Promise<R2Object> => {
+        const state = this.getState(uploadId);
+        if (!Array.isArray(uploadedParts) || uploadedParts.length === 0) {
+          throw new Error("R2 error: no parts to complete");
+        }
+        for (let i = 0; i < uploadedParts.length; i++) {
+          if (i > 0 && uploadedParts[i].partNumber <= uploadedParts[i - 1].partNumber) {
+            throw new Error("R2 error: parts must be in ascending partNumber order");
+          }
+        }
+        const bytesChunks: Uint8Array[] = [];
+        let total = 0;
+        for (const part of uploadedParts) {
+          const storedPart = state.parts.get(part.partNumber);
+          if (!storedPart) {
+            throw new Error(`R2 error: part ${part.partNumber} was never uploaded`);
+          }
+          if (part.etag !== storedPart.etag) {
+            throw new Error(`R2 error: etag mismatch on part ${part.partNumber}`);
+          }
+          bytesChunks.push(storedPart.bytes);
+          total += storedPart.bytes.length;
+        }
+        const bytes = new Uint8Array(total);
+        let offset = 0;
+        for (const chunk of bytesChunks) {
+          bytes.set(chunk, offset);
+          offset += chunk.length;
+        }
+        const stored: StoredObject = {
+          key,
+          bytes,
+          uploaded: new Date(),
+          etag: randomHex(16),
+          httpMetadata,
+          customMetadata: customMetadata
+            ? { ...customMetadata }
+            : undefined,
+        };
+        this.objects.set(key, stored);
+        state.finalized = true;
+        this.multiparts.delete(uploadId);
+        return this.toR2Object(stored);
+      },
+    };
+  }
+
+  private toR2Object(
+    stored: StoredObject,
+    include?: ("httpMetadata" | "customMetadata")[]
+  ): R2Object {
+    const showHttp = !include || include.includes("httpMetadata");
+    const showCustom = !include || include.includes("customMetadata");
+    const object = {
+      key: stored.key,
+      version: randomHex(16),
+      size: stored.bytes.length,
+      etag: stored.etag,
+      httpEtag: `"${stored.etag}"`,
+      checksums: { toJSON: () => ({}) },
+      uploaded: stored.uploaded,
+      httpMetadata: showHttp
+        ? stored.httpMetadata
+          ? { ...stored.httpMetadata }
+          : undefined
+        : undefined,
+      customMetadata: showCustom
+        ? stored.customMetadata
+          ? { ...stored.customMetadata }
+          : undefined
+        : undefined,
+      range: undefined,
+      storageClass: "Standard",
+      writeHttpMetadata: (headers: Headers) => {
+        const metadata = stored.httpMetadata;
+        if (!metadata) return;
+        if (metadata.contentType) headers.set("Content-Type", metadata.contentType);
+        if (metadata.contentLanguage) headers.set("Content-Language", metadata.contentLanguage);
+        if (metadata.contentDisposition) headers.set("Content-Disposition", metadata.contentDisposition);
+        if (metadata.contentEncoding) headers.set("Content-Encoding", metadata.contentEncoding);
+        if (metadata.cacheControl) headers.set("Cache-Control", metadata.cacheControl);
+      },
+    };
+    return object as unknown as R2Object;
+  }
+
+  private toR2ObjectBody(stored: StoredObject, range?: R2Range): R2ObjectBody {
+    const base = this.toR2Object(stored) as R2Object & { range?: R2Range };
+    base.range = range;
+    const bytes = rangeSlice(stored.bytes, range);
+    const body = Object.assign(bytes, {
+      // 单块 reader：一次 read 返回全部内容后即 done（zip 流式读取依赖它终止）
+      getReader: () => {
+        let consumed = false;
+        return {
+          read: async (): Promise<ReadableStreamReadResult<Uint8Array>> => {
+            if (consumed || bytes.byteLength === 0) {
+              return { done: true, value: undefined };
+            }
+            consumed = true;
+            return { done: false, value: bytes };
+          },
+        };
+      },
+    }) as unknown as ReadableStream;
+    const objectBody = {
+      ...base,
+      body,
+      bodyUsed: false,
+      arrayBuffer: async () =>
+        bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength),
+      bytes: async () => bytes,
+      text: async () => new TextDecoder().decode(bytes),
+      json: async <T>() => JSON.parse(new TextDecoder().decode(bytes)) as T,
+      blob: async () => new Blob([bytes]),
+    };
+    return objectBody as unknown as R2ObjectBody;
+  }
+}
+
+function rangeSlice(bytes: Uint8Array, range?: R2Range): Uint8Array {
+  if (!range) return bytes;
+  if ("suffix" in range) {
+    const start = Math.max(bytes.length - range.suffix, 0);
+    return bytes.subarray(start);
+  }
+  const offset = range.offset ?? 0;
+  const length = range.length ?? bytes.length - offset;
+  return bytes.subarray(offset, Math.min(offset + length, bytes.length));
+}
+
+/** 便捷 env 工厂：带上 Basic 认证所需的 WEBDAV 凭据。 */
+export function makeEnv(
+  bucket: R2Bucket,
+  extra: Record<string, unknown> = {}
+): Record<string, unknown> {
+  return {
+    BUCKET: bucket,
+    WEBDAV_USERNAME: "user",
+    WEBDAV_PASSWORD: "pass",
+    ...extra,
+  };
+}
+
+/** Basic Authorization 头（与 verifyBasicAuth/isAuthorized 的期望值一致）。 */
+export function basicAuthHeader(
+  username = "user",
+  password = "pass"
+): string {
+  return `Basic ${btoa(`${username}:${password}`)}`;
+}
+
+/** Pages Function EventContext 最小实现（类型上直接对齐 PagesFunction 入参）。 */
+export function makeContext<TEnv extends object>(
+  request: Request,
+  env: TEnv,
+  params: Record<string, string | string[]> = {},
+  next?: () => Promise<Response>
+): Parameters<PagesFunction<TEnv>>[0] {
+  const context = {
+    request,
+    env,
+    params,
+    data: {},
+    next:
+      next ??
+      (async () => new Response(null, { status: 404 })),
+    waitUntil: (_promise: Promise<unknown>) => {},
+    passThroughOnException: () => {},
+  };
+  return context as unknown as Parameters<PagesFunction<TEnv>>[0];
+}
+
+/** 可注入 body/headers 的 GET/PUT 等请求构造（默认补 Authority 便于 new URL）。 */
+export function makeRequest(
+  url: string,
+  method: string,
+  headers?: Record<string, string>,
+  body?: BodyInit | null
+): Request {
+  return new Request(url, {
+    method,
+    headers,
+    body: body ?? undefined,
+  });
+}
+
+export { NodeReadableStream };

--- a/src/app/testUtils.ts
+++ b/src/app/testUtils.ts
@@ -1,0 +1,179 @@
+/**
+ * 共享测试工具：供 src/app/__tests__ 下的测试套件复用。
+ *
+ * 注意：本文件位于 __tests__ 目录之外（CRA 的 testMatch 会把 __tests__ 下
+ * 所有文件当作测试套件），也不计入 collectCoverageFrom 覆盖率。
+ */
+import type { JsonRpcRequest } from "../../functions/_mcp";
+
+/* ------------------------------------------------------------------ *
+ * Response 工厂
+ * ------------------------------------------------------------------ */
+
+/**
+ * 纯对象 Response mock：前端 client 模块（share/trash/apikeys/sites/images/
+ * transfer/features 等）只依赖 ok/status/headers.get/json/text 这几个成员。
+ *
+ * 失败分支（ok=false）时 text() 返回 JSON 序列化结果；需要空文本或自定义
+ * 错误文案时用 mockError()。
+ */
+export function jsonResponse(body: unknown, ok = true, status = 200): Response {
+  return {
+    ok,
+    status,
+    headers: { get: () => null },
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+  } as unknown as Response;
+}
+
+/** 真 Response 工厂：后端 functions 直测 / MCP 用（状态码、headers、流语义与运行时一致）。 */
+export function httpJsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json; charset=utf-8" },
+  });
+}
+
+/* ------------------------------------------------------------------ *
+ * authFetch mock
+ * ------------------------------------------------------------------ */
+
+/** 在 jest.fn() 上附加常用响应 helper 的 authFetch mock 类型。 */
+export interface AuthFetchMock extends jest.Mock {
+  /** 模拟 2xx JSON 响应（默认 200；status=201 可覆盖 created 场景）。 */
+  mockOk(body: unknown, status?: number): AuthFetchMock;
+  /** 模拟非 2xx：text() 返回 message（默认空串，走各 client 的默认文案分支）。 */
+  mockError(status: number, message?: string): AuthFetchMock;
+  /** 同 mockOk，但只对下一次调用生效（等价 mockResolvedValueOnce）。 */
+  mockOkOnce(body: unknown, status?: number): AuthFetchMock;
+  /** 同 mockError，但只对下一次调用生效（等价 mockResolvedValueOnce）。 */
+  mockErrorOnce(status: number, message?: string): AuthFetchMock;
+}
+
+/** 给已存在的 jest.fn（如 jest.mock 工厂里的 authFetch）附加 helper 并返回。 */
+export function asAuthFetchMock(fetchFn: unknown): AuthFetchMock {
+  const fn = fetchFn as AuthFetchMock;
+  fn.mockOk = (body: unknown, status = 200) => {
+    fn.mockResolvedValue(jsonResponse(body, true, status));
+    return fn;
+  };
+  fn.mockError = (status: number, message = "") => {
+    fn.mockResolvedValue({
+      ok: false,
+      status,
+      headers: { get: () => null },
+      json: async () => ({}),
+      text: async () => message,
+    } as unknown as Response);
+    return fn;
+  };
+  fn.mockOkOnce = (body: unknown, status = 200) => {
+    fn.mockResolvedValueOnce(jsonResponse(body, true, status));
+    return fn;
+  };
+  fn.mockErrorOnce = (status: number, message = "") => {
+    fn.mockResolvedValueOnce({
+      ok: false,
+      status,
+      headers: { get: () => null },
+      json: async () => ({}),
+      text: async () => message,
+    } as unknown as Response);
+    return fn;
+  };
+  return fn;
+}
+
+/* ------------------------------------------------------------------ *
+ * storage 清理
+ * ------------------------------------------------------------------ */
+
+/** beforeEach/afterEach 用：清空 localStorage 与 sessionStorage。 */
+export function clearStorage(): void {
+  localStorage.clear();
+  sessionStorage.clear();
+}
+
+/* ------------------------------------------------------------------ *
+ * WebDAV PROPFIND fixture
+ * ------------------------------------------------------------------ */
+
+export interface PropfindEntry {
+  /** 完整 href，如 "/webdav/a.txt"、"/webdav/docs/"（空串模拟服务端空 response）。 */
+  href: string;
+  isDir?: boolean;
+  contentType?: string;
+  size?: number;
+  /** RFC 1123 日期串；缺省时不输出 <getlastmodified>（解析端回退当前时间）。 */
+  lastModified?: string;
+  /** flaredrive 命名空间缩略图标记。 */
+  thumbnail?: string;
+}
+
+/** 构造多文件目录 PROPFIND Multi-Status XML。 */
+export function propfindXml(entries: PropfindEntry[]): string {
+  const responses = entries
+    .map((entry) => {
+      const props = [
+        entry.isDir
+          ? "<resourcetype><collection/></resourcetype>"
+          : "<resourcetype/>",
+      ];
+      if (entry.contentType) {
+        props.push(`<getcontenttype>${entry.contentType}</getcontenttype>`);
+      }
+      if (entry.size !== undefined) {
+        props.push(`<getcontentlength>${entry.size}</getcontentlength>`);
+      }
+      if (entry.lastModified) {
+        props.push(`<getlastmodified>${entry.lastModified}</getlastmodified>`);
+      }
+      if (entry.thumbnail) {
+        props.push(`<thumbnail xmlns="flaredrive">${entry.thumbnail}</thumbnail>`);
+      }
+      return [
+        "  <response>",
+        `    <href>${entry.href}</href>`,
+        "    <propstat>",
+        "      <prop>",
+        ...props.map((p) => `        ${p}`),
+        "      </prop>",
+        "    </propstat>",
+        "  </response>",
+      ].join("\n");
+    })
+    .join("\n");
+  return `<?xml version="1.0" encoding="utf-8"?>\n<multistatus>\n${responses}\n</multistatus>`;
+}
+
+/** 207 Multi-Status 响应 mock（fetchPath 校验 Content-Type: application/xml）。 */
+export function propfindResponse(entries: PropfindEntry[], ok = true): Response {
+  return {
+    ok,
+    status: ok ? 207 : 500,
+    headers: {
+      get: (name: string) =>
+        name.toLowerCase() === "content-type" ? "application/xml; charset=utf-8" : null,
+    },
+    text: async () => propfindXml(entries),
+  } as unknown as Response;
+}
+
+/* ------------------------------------------------------------------ *
+ * MCP JSON-RPC
+ * ------------------------------------------------------------------ */
+
+/** 构造 JSON-RPC 请求体（hasId=false 模拟 notification）。 */
+export function rpc(
+  partial: Partial<JsonRpcRequest> & { method: string }
+): JsonRpcRequest {
+  const hasId = partial.hasId !== undefined ? partial.hasId : true;
+  return {
+    jsonrpc: "2.0",
+    id: hasId ? (partial.id ?? 1) : undefined,
+    method: partial.method,
+    params: partial.params,
+    hasId,
+  };
+}

--- a/src/app/transfer.ts
+++ b/src/app/transfer.ts
@@ -285,7 +285,7 @@ export async function generateThumbnail(file: File) {
 }
 
 export async function blobDigest(blob: Blob) {
-  const digest = await crypto.subtle.digest("SHA-1", await blob.arrayBuffer());
+  const digest = await crypto.subtle.digest("SHA-1", new Uint8Array(await blob.arrayBuffer()));
   const digestArray = Array.from(new Uint8Array(digest));
   const digestHex = digestArray
     .map((b) => b.toString(16).padStart(2, "0"))

--- a/src/app/useMultiSelect.ts
+++ b/src/app/useMultiSelect.ts
@@ -51,10 +51,13 @@ export function useMultiSelect(visibleFiles: FileItem[]) {
 
   const toggleSelect = useCallback(
     (key: string, event?: { shiftKey?: boolean }) => {
+      // updater 是延迟求值的，anchor 必须在进入 updater 前捕获，
+      // 否则第 78 行的覆写先生效，shift 范围选择退化为「原选中 + 目标」
+      const anchor = selectionAnchor.current;
       setSelectedKeys((prev) => {
-        if (event?.shiftKey && selectionAnchor.current) {
+        if (event?.shiftKey && anchor) {
           const anchorIndex = visibleFiles.findIndex(
-            (file) => file.key === selectionAnchor.current
+            (file) => file.key === anchor
           );
           const targetIndex = visibleFiles.findIndex(
             (file) => file.key === key


### PR DESCRIPTION
## 覆盖率成果

| 范围 | 之前 | 现在 |
|---|---|---|
| src/（前端） | lines 84.94% / branches 75.88% | **lines 94.01% / branches 85.04%** |
| functions/（后端，此前完全不在度量内） | lines 18.75% / branches 14.66% | **lines 61.42% / branches 53.73%** |
| cli/ | 无 coverage 配置 | stmts 86.11% / branches 90.09%（client.ts lines 98.56%） |
| 核心模块 | — | protocol.ts 80.2%、trash 98.1%、shares 96.6%、share token 92.9%、upload 92.8%、middleware 97.6%（lines） |

阈值棘轮（实测-0.5）：src 组 91.6/84.5/85.9/93.5，functions 组 58.67/53.23/66.69/60.92——**从此覆盖率掉下去 CI 会红**。

## 内容

### 基础设施
- `src/app/testUtils.ts` 共享测试工具（12 个测试文件去重：jsonResponse ×8、authFetch inline ×19、PROPFIND XML、MCP rpc）
- jest `collectCoverageFrom` 纳入 `functions/**`；`functionsLoader.test.ts` 强制加载全部 functions 模块（绕过 CRA jest roots 限制）
- `.github/workflows/ci.yml`：frontend（typecheck/test/build）+ cli + **e2e**（wrangler@4 钉版本，171 断言本地预演通过）三 job
- cli：vitest coverage 配置 + client/config/util/index 补测（58 用例）

### 后端直测（此前 0 单测的 ~4400 行核心逻辑）
- `src/app/testInMemoryBucket.ts`：忠实模拟 R2 语义（prefix/cursor/delimiter/include/multipart/onlyIf）的内存 bucket
- 185 个后端用例：WebDAV 协议（304/206/412/423/LOCK/Overwrite/内部前缀/鉴权 fail-closed）、回收站（marker/虚拟目录/父级重建/惰性过期）、分享（落地页转义/安全头/提取码/410）、上传三段式（413/乱序/abort）、middleware（SPA/404.html/路径穿越）

### 顺手修的 4 个真 bug（全部由测试发现，各有用例固化）
1. `protocol.ts` 非法 Range 未捕获 R2 InvalidRange → 500（改回退全量 200）
2. `trash.ts` 还原时损坏元数据 JSON → 整个还原 500（改结构化错误响应）
3. `useMultiSelect` shift 范围选择失效（updater 延迟求值期间 anchor 被覆写，退化为「原选中+目标」）
4. `App` Snackbar 队列重开竞态（退场完成前重开 → onExited 永不触发 → 消息每 8s 重闪一次）

## 验证
- `tsc --noEmit` 0 错误；**64 套件 / 754 用例全绿**（基线 53/463）
- `npm run build` 成功；e2e **171 断言全过**；cli `npm test` 58 用例全绿
- 详细记录见 TESTING.md「测试覆盖率体系与后端直测」一节