### PR TITLE
feat: 扩展薄书签 P2/3——双模式工具栏与书签库核心

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -1,14 +1,212 @@
 "use strict";
 
-importScripts("url.js");
+importScripts("url.js", "bookmarks.js", "dav.js");
+
+var MENU_SAVE = "davflare-save-page";
+var MENU_MODE = "davflare-toggle-mode";
+var BOOKMARKS_PAGE = "bookmarks.html";
+
+var MESSAGES = {
+  en: {
+    appTitle: "Davflare",
+    errTitle: "Davflare — action failed",
+    saveOk: "Bookmark saved to your library.",
+    saveExists: "This page is already in your library.",
+    skipPage: "Only http(s) pages can be saved.",
+    modeTitle: "Default mode switched",
+    modeDrive: "Toolbar will open your drive.",
+    modeBookmarks: "Toolbar will open your bookmark library.",
+  },
+  zh: {
+    appTitle: "Davflare",
+    errTitle: "Davflare — 操作失败",
+    saveOk: "已收藏到书签库。",
+    saveExists: "该页面已在书签库中。",
+    skipPage: "只能收藏 http(s) 页面。",
+    modeTitle: "默认模式已切换",
+    modeDrive: "工具栏点击将打开网盘。",
+    modeBookmarks: "工具栏点击将打开书签库。",
+  },
+};
+
+var ERROR_COPY = {
+  disabled: { en: "WebDAV is disabled on this instance.", zh: "该实例已关闭 WebDAV。" },
+  notConfigured: {
+    en: "The server has no WebDAV credentials configured.",
+    zh: "服务端未配置 WebDAV 凭据。",
+  },
+  unauthorized: {
+    en: "Wrong WebDAV username or password. Check options.",
+    zh: "WebDAV 用户名或密码错误，请在选项中检查。",
+  },
+  network: { en: "Cannot reach the instance.", zh: "无法连接实例。" },
+  conflict: {
+    en: "The library changed elsewhere. Please retry.",
+    zh: "书签库已在别处更新，请重试。",
+  },
+};
+
+function pickLang() {
+  return (navigator.language || "en").toLowerCase().indexOf("zh") === 0 ? "zh" : "en";
+}
+
+function t() {
+  return MESSAGES[pickLang()];
+}
+
+function errorText(kind) {
+  var known = ERROR_COPY[kind];
+  return known ? known[pickLang()] : "HTTP " + kind;
+}
+
+function flashBadge(text) {
+  chrome.action.setBadgeText({ text: text });
+  setTimeout(function () {
+    chrome.action.setBadgeText({ text: "" });
+  }, 2500);
+}
+
+function notify(title, message) {
+  try {
+    chrome.notifications.create(
+      {
+        type: "basic",
+        iconUrl: "icons/icon128.png",
+        title: title,
+        message: message,
+      },
+      function () {
+        void chrome.runtime.lastError;
+      }
+    );
+  } catch (err) {
+    /* notifications are best-effort feedback */
+  }
+}
+
+async function loadConfig() {
+  var sync = await chrome.storage.sync.get(["instanceUrl"]);
+  var local = await chrome.storage.local.get(["davUsername", "davPassword"]);
+  return {
+    instanceUrl: mergeSettings(sync).instanceUrl,
+    username: typeof local.davUsername === "string" ? local.davUsername : "",
+    password: typeof local.davPassword === "string" ? local.davPassword : "",
+  };
+}
+
+async function openBookmarksPage() {
+  var url = chrome.runtime.getURL(BOOKMARKS_PAGE);
+  var tabs = await chrome.tabs.query({ url: url });
+  if (tabs && tabs.length > 0) {
+    var tab = tabs[0];
+    await chrome.tabs.update(tab.id, { active: true });
+    if (typeof tab.windowId === "number") {
+      await chrome.windows.update(tab.windowId, { focused: true });
+    }
+    return;
+  }
+  chrome.tabs.create({ url: url });
+}
+
+async function handleToolbarClick() {
+  var stored = await chrome.storage.sync.get(["instanceUrl", "toolbarMode"]);
+  var target = resolveToolbarTarget(mergeSettings(stored));
+  if (target.action === "bookmarks") {
+    await openBookmarksPage();
+    return;
+  }
+  if (target.action === "open") {
+    chrome.tabs.create({ url: target.url });
+    return;
+  }
+  chrome.runtime.openOptionsPage();
+}
+
+async function toggleDefaultMode() {
+  var stored = await chrome.storage.sync.get(["toolbarMode"]);
+  var next = mergeSettings(stored).toolbarMode === "bookmarks" ? "drive" : "bookmarks";
+  await chrome.storage.sync.set({ toolbarMode: next });
+  var copy = t();
+  notify(copy.modeTitle, next === "bookmarks" ? copy.modeBookmarks : copy.modeDrive);
+}
+
+async function savePage(tab) {
+  var copy = t();
+  var url = (tab && tab.url) || "";
+  var title = (tab && tab.title) || "";
+  if (!Bookmarks.isWebUrl(url)) {
+    flashBadge("!");
+    notify(copy.errTitle, copy.skipPage);
+    return;
+  }
+  var client = DavflareDav.createDavClient(await loadConfig());
+  var res = await client.getBookmarks();
+  if (!res.ok) {
+    flashBadge("!");
+    notify(copy.errTitle, errorText(res.kind));
+    return;
+  }
+
+  var model = Bookmarks.parseHtml(res.html || "");
+  if (res.jsonText) {
+    var parsed = Bookmarks.modelFromJson(res.jsonText);
+    if (parsed.ok) model = Bookmarks.adoptRichFields(model, parsed.model);
+  }
+  var add = Bookmarks.addBookmark(model, { title: title, url: url, added: Date.now() });
+  if (!add.added) {
+    flashBadge("✓");
+    notify(copy.appTitle, copy.saveExists);
+    return;
+  }
+
+  var put = await client.putBookmarks({
+    html: Bookmarks.serializeHtml(add.model),
+    json: Bookmarks.modelToJsonText(add.model),
+    etag: res.etag,
+  });
+  if (!put.ok) {
+    flashBadge("!");
+    notify(copy.errTitle, errorText(put.kind));
+    return;
+  }
+  flashBadge("✓");
+  notify(copy.appTitle, copy.saveOk);
+}
 
 chrome.action.onClicked.addListener(function () {
-  chrome.storage.sync.get(["instanceUrl"], function (stored) {
-    var target = resolveToolbarTarget(mergeSettings(stored));
-    if (target.action === "open") {
-      chrome.tabs.create({ url: target.url });
-      return;
+  handleToolbarClick();
+});
+
+chrome.contextMenus.onClicked.addListener(function (info, tab) {
+  if (info.menuItemId === MENU_MODE) {
+    toggleDefaultMode();
+    return;
+  }
+  if (info.menuItemId === MENU_SAVE) {
+    savePage(tab);
+  }
+});
+
+chrome.runtime.onInstalled.addListener(function () {
+  var zh = pickLang() === "zh";
+  chrome.contextMenus.create(
+    {
+      id: MENU_SAVE,
+      title: zh ? "收藏此页到 Davflare" : "Save page to Davflare",
+      contexts: ["page"],
+    },
+    function () {
+      void chrome.runtime.lastError;
     }
-    chrome.runtime.openOptionsPage();
-  });
+  );
+  chrome.contextMenus.create(
+    {
+      id: MENU_MODE,
+      title: zh ? "切换工具栏默认模式" : "Switch toolbar default mode",
+      contexts: ["action"],
+    },
+    function () {
+      void chrome.runtime.lastError;
+    }
+  );
 });

--- a/extension/bookmarks.css
+++ b/extension/bookmarks.css
@@ -1,0 +1,605 @@
+:root {
+  color-scheme: light;
+  --bg: #f4f1ec;
+  --paper: #ffffff;
+  --paper-soft: #faf8f4;
+  --text: #1a1714;
+  --muted: rgba(26, 23, 20, 0.64);
+  --line: rgba(28, 22, 16, 0.08);
+  --orange: #f38020;
+  --orange-dark: #d96e12;
+  --orange-soft: rgba(243, 128, 32, 0.12);
+  --focus: rgba(243, 128, 32, 0.16);
+  --ok: #2e7d4f;
+  --err: #c4472c;
+  --shadow: 0 6px 16px rgba(26, 23, 20, 0.06);
+}
+
+:root[data-theme="dark"] {
+  color-scheme: dark;
+  --bg: #17140f;
+  --paper: #211d17;
+  --paper-soft: #191611;
+  --text: #f0ece4;
+  --muted: rgba(240, 236, 228, 0.6);
+  --line: rgba(240, 236, 228, 0.1);
+  --orange: #f79b45;
+  --orange-dark: #ffb066;
+  --orange-soft: rgba(247, 155, 69, 0.16);
+  --focus: rgba(247, 155, 69, 0.22);
+  --shadow: 0 6px 16px rgba(0, 0, 0, 0.35);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  margin: 0;
+  height: 100%;
+}
+
+body {
+  font-family: "Noto Sans SC", "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei",
+    system-ui, -apple-system, "Segoe UI", sans-serif;
+  background: var(--bg);
+  color: var(--text);
+  line-height: 1.5;
+}
+
+button {
+  appearance: none;
+  border: 0;
+  border-radius: 8px;
+  background: var(--orange);
+  color: #fff;
+  font: inherit;
+  font-weight: 600;
+  padding: 6px 14px;
+  cursor: pointer;
+}
+
+button:hover {
+  background: var(--orange-dark);
+}
+
+button:focus-visible,
+input:focus-visible,
+select:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 4px var(--focus);
+}
+
+button.ghost {
+  background: transparent;
+  color: var(--orange-dark);
+  border: 1px solid var(--orange);
+}
+
+button.ghost:hover {
+  background: var(--orange-soft);
+}
+
+:root[data-theme="dark"] button.ghost {
+  color: var(--orange-dark);
+}
+
+button.danger {
+  background: var(--err);
+}
+
+.app {
+  display: grid;
+  grid-template-columns: 248px 1fr;
+  min-height: 100vh;
+}
+
+/* ---------- sidebar ---------- */
+
+.sidebar {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 20px 14px;
+  background: var(--paper);
+  border-right: 1px solid var(--line);
+  position: sticky;
+  top: 0;
+  height: 100vh;
+  overflow-y: auto;
+}
+
+.brand {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+  padding: 0 6px;
+}
+
+.brand img {
+  border-radius: 9px;
+}
+
+.brand h1 {
+  margin: 0;
+  font-size: 1.05rem;
+  letter-spacing: -0.02em;
+}
+
+.brand p {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.75rem;
+}
+
+.nav {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.navTitle {
+  margin: 12px 8px 2px;
+  font-size: 0.6875rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--muted);
+}
+
+.navItem {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  width: 100%;
+  background: transparent;
+  color: var(--text);
+  font-weight: 500;
+  font-size: 0.875rem;
+  padding: 7px 10px;
+  border-radius: 9px;
+  text-align: left;
+}
+
+.navItem:hover {
+  background: var(--orange-soft);
+  color: var(--text);
+}
+
+.navItem.active {
+  background: var(--orange);
+  color: #fff;
+}
+
+.navItem .count {
+  font-size: 0.75rem;
+  color: var(--muted);
+  background: var(--paper-soft);
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  padding: 0 8px;
+  min-width: 28px;
+  text-align: center;
+}
+
+.navItem.active .count {
+  color: #fff;
+  background: rgba(255, 255, 255, 0.2);
+  border-color: transparent;
+}
+
+.navEmpty {
+  margin: 2px 10px;
+  color: var(--muted);
+}
+
+.sideFoot {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  border-top: 1px solid var(--line);
+  padding-top: 12px;
+}
+
+.syncRow {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 8px;
+  font-size: 0.75rem;
+  padding: 0 4px;
+}
+
+.syncLabel {
+  font-weight: 600;
+  color: var(--muted);
+}
+
+.syncInfo {
+  color: var(--muted);
+}
+
+.syncInfo.flash {
+  color: var(--ok);
+  font-weight: 600;
+}
+
+.footBtns {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.footBtns button {
+  flex: 1 1 auto;
+  font-size: 0.8125rem;
+  padding: 6px 10px;
+}
+
+/* ---------- main ---------- */
+
+.main {
+  padding: 18px 26px 40px;
+  min-width: 0;
+}
+
+.topbar {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 16px;
+}
+
+.topbar input[type="search"] {
+  flex: 1 1 260px;
+  max-width: 460px;
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  padding: 9px 14px;
+  font: inherit;
+  background: var(--paper);
+  color: var(--text);
+}
+
+.topbar select {
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  padding: 8px 10px;
+  font: inherit;
+  background: var(--paper);
+  color: var(--text);
+  max-width: 220px;
+}
+
+.spacer {
+  flex: 1;
+}
+
+.viewToggle {
+  display: flex;
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  overflow: hidden;
+  background: var(--paper);
+}
+
+.viewToggle button {
+  background: transparent;
+  color: var(--muted);
+  border-radius: 0;
+  padding: 7px 12px;
+}
+
+.viewToggle button.active {
+  background: var(--orange);
+  color: #fff;
+}
+
+#themeToggle {
+  background: var(--paper);
+  color: var(--text);
+  border: 1px solid var(--line);
+  padding: 7px 12px;
+}
+
+.banner {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+  background: var(--orange-soft);
+  border: 1px solid var(--orange);
+  color: var(--text);
+  border-radius: 10px;
+  padding: 10px 14px;
+  margin-bottom: 16px;
+  font-size: 0.875rem;
+}
+
+.banner.hidden,
+.hidden {
+  display: none !important;
+}
+
+.loading {
+  color: var(--muted);
+  font-size: 0.8125rem;
+}
+
+.empty {
+  color: var(--muted);
+  text-align: center;
+  margin-top: 80px;
+  font-size: 0.9375rem;
+}
+
+/* ---------- cards ---------- */
+
+.cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
+  gap: 14px;
+}
+
+.card {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  background: var(--paper);
+  border: 1px solid var(--line);
+  border-radius: 14px;
+  box-shadow: var(--shadow);
+  overflow: hidden;
+  transition: transform 0.12s ease, box-shadow 0.12s ease;
+}
+
+.card:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 10px 22px rgba(26, 23, 20, 0.1);
+}
+
+.cardMain {
+  display: block;
+  padding: 14px 16px 10px;
+  color: inherit;
+  text-decoration: none;
+}
+
+.favicon {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 34px;
+  height: 34px;
+  border-radius: 9px;
+  background: var(--orange-soft);
+  color: var(--orange-dark);
+  font-weight: 700;
+  font-size: 0.9375rem;
+  margin-bottom: 8px;
+}
+
+.favicon img {
+  display: none;
+  border-radius: 4px;
+}
+
+.favicon.hasIcon img {
+  display: block;
+}
+
+.favicon.hasIcon .letter {
+  display: none;
+}
+
+.cardMain h3 {
+  margin: 0 0 4px;
+  font-size: 0.9375rem;
+  line-height: 1.35;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.cardMain .domain {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.78125rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.cardMain .note {
+  margin: 8px 0 0;
+  color: var(--muted);
+  font-size: 0.8125rem;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.cardMeta {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 12px 12px;
+  font-size: 0.6875rem;
+  color: var(--muted);
+}
+
+.chip {
+  background: var(--orange-soft);
+  color: var(--orange-dark);
+  border-radius: 999px;
+  padding: 1px 9px;
+  max-width: 130px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.chip.tag {
+  background: var(--paper-soft);
+  border: 1px solid var(--line);
+  color: var(--muted);
+}
+
+.cardMeta time {
+  margin-left: auto;
+}
+
+.cardMeta .del,
+.row .del {
+  background: transparent;
+  color: var(--muted);
+  padding: 2px 6px;
+  font-size: 0.75rem;
+  border-radius: 6px;
+  visibility: hidden;
+}
+
+.card:hover .del,
+.row:hover .del {
+  visibility: visible;
+}
+
+.cardMeta .del:hover,
+.row .del:hover {
+  background: rgba(196, 71, 44, 0.12);
+  color: var(--err);
+}
+
+/* ---------- rows ---------- */
+
+.rows {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  background: var(--paper);
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  padding: 8px 12px;
+  color: inherit;
+  text-decoration: none;
+}
+
+.row:hover {
+  border-color: var(--orange);
+}
+
+.row .favicon {
+  margin-bottom: 0;
+  flex: none;
+}
+
+.rowTitle {
+  font-size: 0.875rem;
+  font-weight: 500;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
+}
+
+.rowDomain {
+  color: var(--muted);
+  font-size: 0.78125rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
+}
+
+.row .chip {
+  flex: none;
+}
+
+.row time {
+  margin-left: auto;
+  color: var(--muted);
+  font-size: 0.75rem;
+  flex: none;
+}
+
+/* ---------- dialogs ---------- */
+
+dialog {
+  border: 1px solid var(--line);
+  border-radius: 14px;
+  background: var(--paper);
+  color: var(--text);
+  padding: 22px;
+  width: min(420px, 92vw);
+  box-shadow: 0 18px 44px rgba(0, 0, 0, 0.22);
+}
+
+dialog::backdrop {
+  background: rgba(0, 0, 0, 0.4);
+}
+
+dialog h2 {
+  margin: 0 0 14px;
+  font-size: 1.05rem;
+}
+
+dialog label {
+  display: block;
+  font-weight: 600;
+  font-size: 0.8125rem;
+  margin: 10px 0 4px;
+}
+
+dialog input {
+  width: 100%;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  padding: 9px 12px;
+  font: inherit;
+  background: var(--bg);
+  color: var(--text);
+}
+
+dialog menu {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  padding: 0;
+  margin: 18px 0 0;
+}
+
+.status {
+  margin: 6px 0 0;
+  font-size: 0.8125rem;
+  color: var(--muted);
+  min-height: 1.2em;
+}
+
+.status.err {
+  color: var(--err);
+}
+
+@media (max-width: 760px) {
+  .app {
+    grid-template-columns: 1fr;
+  }
+
+  .sidebar {
+    position: static;
+    height: auto;
+    border-right: 0;
+    border-bottom: 1px solid var(--line);
+  }
+}

--- a/extension/bookmarks.html
+++ b/extension/bookmarks.html
@@ -1,0 +1,95 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Davflare Bookmarks</title>
+    <link rel="stylesheet" href="bookmarks.css" />
+  </head>
+  <body>
+    <div class="app">
+      <aside class="sidebar">
+        <header class="brand">
+          <img src="icons/icon48.png" width="36" height="36" alt="" />
+          <div>
+            <h1>Davflare</h1>
+            <p id="brandSub">Bookmarks</p>
+          </div>
+        </header>
+
+        <nav class="nav">
+          <button class="navItem" id="navAll" data-filter="all" type="button">
+            <span id="navAllText">All bookmarks</span>
+            <span class="count" id="navAllCount">0</span>
+          </button>
+          <p class="navTitle" id="folderTitle">Folders</p>
+          <div id="folderNav"></div>
+          <p class="navTitle" id="tagTitle">Tags</p>
+          <div id="tagNav"></div>
+        </nav>
+
+        <footer class="sideFoot">
+          <div class="syncRow">
+            <span class="syncLabel" id="syncLabel">WebDAV</span>
+            <span class="syncInfo" id="syncInfo">…</span>
+          </div>
+          <div class="footBtns">
+            <button id="addBtn" class="primary" type="button">Add</button>
+            <button id="importBtn" class="ghost" type="button">Import</button>
+            <button id="exportBtn" class="ghost" type="button">Export</button>
+            <button id="driveBtn" class="ghost" type="button">Drive</button>
+            <button id="settingsBtn" class="ghost" type="button">Settings</button>
+          </div>
+        </footer>
+      </aside>
+
+      <main class="main">
+        <header class="topbar">
+          <input id="search" type="search" spellcheck="false" placeholder="Search bookmarks…" />
+          <select id="folderSelect"></select>
+          <div class="spacer"></div>
+          <div class="viewToggle" role="group" aria-label="View">
+            <button id="viewGrid" class="active" type="button" title="Grid">▦</button>
+            <button id="viewList" type="button" title="List">☰</button>
+          </div>
+          <button id="themeToggle" type="button" title="Theme">☾</button>
+        </header>
+
+        <div id="banner" class="banner hidden"></div>
+        <p id="loading" class="loading hidden">Loading…</p>
+        <section id="cards" class="cards"></section>
+        <section id="rows" class="rows hidden"></section>
+        <p id="emptyState" class="empty hidden"></p>
+      </main>
+    </div>
+
+    <dialog id="addDialog">
+      <form id="addForm" novalidate>
+        <h2 id="addDialogTitle">Add bookmark</h2>
+        <label for="addUrl" id="addUrlLabel">URL</label>
+        <input id="addUrl" type="url" spellcheck="false" placeholder="https://…" />
+        <label for="addTitleInput" id="addTitleLabel">Title</label>
+        <input id="addTitleInput" type="text" spellcheck="false" />
+        <p id="addError" class="status err"></p>
+        <menu>
+          <button id="addCancel" class="ghost" type="button">Cancel</button>
+          <button id="addSave" class="primary" type="submit">Add</button>
+        </menu>
+      </form>
+    </dialog>
+
+    <dialog id="confirmDialog">
+      <p id="confirmText"></p>
+      <menu>
+        <button id="confirmCancel" class="ghost" type="button">Cancel</button>
+        <button id="confirmOk" class="danger" type="button">Delete</button>
+      </menu>
+    </dialog>
+
+    <script src="url.js"></script>
+    <script src="bookmarks.js"></script>
+    <script src="dav.js"></script>
+    <script src="bookmarksView.js"></script>
+    <script src="bookmarksApp.js"></script>
+  </body>
+</html>

--- a/extension/bookmarks.js
+++ b/extension/bookmarks.js
@@ -1,0 +1,354 @@
+"use strict";
+
+/**
+ * Netscape bookmark format codec for the Davflare extension.
+ *
+ * bookmarks.html is the authoritative, browser-importable file. The JSON
+ * sidecar carries rich fields (tags, note, id) that the Netscape format
+ * cannot hold; adoptRichFields() re-attaches them after an html parse.
+ * Plain script with a module.exports guard so vitest can require() it.
+ */
+
+var Bookmarks = (function () {
+  var MODEL_VERSION = 1;
+  var idCounter = 0;
+
+  function emptyModel() {
+    return { version: MODEL_VERSION, bookmarks: [] };
+  }
+
+  function makeId() {
+    idCounter += 1;
+    return "bm-" + Date.now().toString(36) + "-" + idCounter.toString(36);
+  }
+
+  function asString(value) {
+    return typeof value === "string" ? value : "";
+  }
+
+  function sanitizeTags(value) {
+    if (!Array.isArray(value)) return [];
+    var seen = Object.create(null);
+    var out = [];
+    for (var i = 0; i < value.length; i++) {
+      var tag = typeof value[i] === "string" ? value[i].trim() : "";
+      if (!tag || seen[tag]) continue;
+      seen[tag] = true;
+      out.push(tag.slice(0, 64));
+    }
+    return out.slice(0, 32);
+  }
+
+  function sanitizeBookmark(raw) {
+    var src = raw && typeof raw === "object" ? raw : {};
+    var added = typeof src.added === "number" && isFinite(src.added) ? src.added : 0;
+    return {
+      id: asString(src.id) || makeId(),
+      title: asString(src.title),
+      url: asString(src.url),
+      folder: asString(src.folder),
+      tags: sanitizeTags(src.tags),
+      note: asString(src.note),
+      added: added,
+    };
+  }
+
+  function normalizeModel(raw) {
+    if (!raw || typeof raw !== "object" || !Array.isArray(raw.bookmarks)) {
+      return emptyModel();
+    }
+    var out = [];
+    var seenIds = Object.create(null);
+    for (var i = 0; i < raw.bookmarks.length; i++) {
+      var item = sanitizeBookmark(raw.bookmarks[i]);
+      if (!item.url) continue;
+      while (seenIds[item.id]) item.id = makeId();
+      seenIds[item.id] = true;
+      out.push(item);
+    }
+    return { version: MODEL_VERSION, bookmarks: out };
+  }
+
+  function isValidModel(value) {
+    return Boolean(
+      value &&
+        typeof value === "object" &&
+        value.version === MODEL_VERSION &&
+        Array.isArray(value.bookmarks)
+    );
+  }
+
+  function urlKey(url) {
+    var s = String(url == null ? "" : url).trim();
+    if (!s) return "";
+    try {
+      var u = new URL(s);
+      if (u.protocol === "http:" || u.protocol === "https:") {
+        u.hash = "";
+        return u.href;
+      }
+    } catch (err) {
+      /* non-http or malformed: fall back to the trimmed string */
+    }
+    return s;
+  }
+
+  function isWebUrl(url) {
+    return /^https?:\/\//i.test(String(url || "").trim());
+  }
+
+  function escapeAttr(value) {
+    return String(value == null ? "" : value)
+      .replace(/&/g, "&amp;")
+      .replace(/"/g, "&quot;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;");
+  }
+
+  function escapeText(value) {
+    return String(value == null ? "" : value)
+      .replace(/&/g, "&amp;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;");
+  }
+
+  function toNetscapeTime(ms) {
+    var n = typeof ms === "number" && isFinite(ms) && ms > 0 ? Math.floor(ms / 1000) : 0;
+    return String(n);
+  }
+
+  /**
+   * Folder walk for one DL level. Netscape exporters emit <DT><H3>name</H3>
+   * followed by a nested <DL>, but HTML parsers nest those inconsistently
+   * (a <p> inside <DL> reshuffles DT/DL parenting), so instead of relying on
+   * sibling/parent relationships we walk each level in document order: an
+   * Hx heading names the folder for the next nested DL (or stray A) at this
+   * level, and non-DL elements are treated as transparent wrappers.
+   */
+  function joinFolder(path, name) {
+    var clean = String(name || "").trim();
+    if (!clean) return path;
+    return path ? path + "/" + clean : clean;
+  }
+
+  function pushAnchor(anchor, folderPath, out) {
+    var href = (anchor.getAttribute("href") || "").trim();
+    if (!isWebUrl(href)) return;
+    var addRaw = parseInt(anchor.getAttribute("add_date") || "", 10);
+    out.push(
+      sanitizeBookmark({
+        title: (anchor.textContent || "").trim(),
+        url: href,
+        folder: folderPath,
+        added: isFinite(addRaw) && addRaw > 0 ? addRaw * 1000 : 0,
+      })
+    );
+  }
+
+  function walkLevel(node, path, out, state) {
+    var children = node.children;
+    for (var i = 0; i < children.length; i++) {
+      var el = children[i];
+      var tag = el.tagName;
+      if (tag === "DL") {
+        collectLevel(el, joinFolder(path, state.heading), out);
+        state.heading = null;
+      } else if (tag === "A") {
+        pushAnchor(el, joinFolder(path, state.heading), out);
+      } else if (tag === "H2" || tag === "H3" || tag === "H4" || tag === "H5") {
+        var heading = (el.textContent || "").trim();
+        if (heading) state.heading = heading;
+      } else if (el.children && el.children.length) {
+        walkLevel(el, path, out, state);
+      }
+    }
+  }
+
+  function collectLevel(dl, path, out) {
+    walkLevel(dl, path, out, { heading: null });
+  }
+
+  function parseHtml(text) {
+    if (typeof DOMParser === "undefined") {
+      throw new Error("parseHtml requires DOMParser");
+    }
+    var doc = new DOMParser().parseFromString(String(text || ""), "text/html");
+    var rootDl = doc.querySelector("dl");
+    var out = [];
+    if (rootDl) collectLevel(rootDl, "", out);
+    return { version: MODEL_VERSION, bookmarks: out };
+  }
+
+  function buildTree(model) {
+    var root = { folders: Object.create(null), links: [], name: "" };
+    var items = normalizeModel(model).bookmarks;
+    for (var i = 0; i < items.length; i++) {
+      var item = items[i];
+      var node = root;
+      var folder = item.folder.replace(/^\/+|\/+$/g, "");
+      if (folder) {
+        var segs = folder.split("/");
+        for (var j = 0; j < segs.length; j++) {
+          var seg = segs[j] || "";
+          if (!node.folders[seg]) {
+            node.folders[seg] = { folders: Object.create(null), links: [], name: seg };
+          }
+          node = node.folders[seg];
+        }
+      }
+      node.links.push(item);
+    }
+    return root;
+  }
+
+  function renderNode(node, depth, lines) {
+    var pad = new Array(depth + 1).join("    ");
+    for (var i = 0; i < node.links.length; i++) {
+      var b = node.links[i];
+      lines.push(
+        pad +
+          '<DT><A HREF="' +
+          escapeAttr(b.url) +
+          '" ADD_DATE="' +
+          toNetscapeTime(b.added) +
+          '">' +
+          escapeText(b.title) +
+          "</A>"
+      );
+    }
+    var names = Object.keys(node.folders);
+    for (var k = 0; k < names.length; k++) {
+      var folder = node.folders[names[k]];
+      lines.push(
+        pad +
+          '<DT><H3 ADD_DATE="' +
+          toNetscapeTime(Date.now()) +
+          '">' +
+          escapeText(folder.name) +
+          "</H3>"
+      );
+      lines.push(pad + "<DL><p>");
+      renderNode(folder, depth + 1, lines);
+      lines.push(pad + "</DL><p>");
+    }
+  }
+
+  function serializeHtml(model) {
+    var tree = buildTree(model);
+    var lines = [
+      "<!DOCTYPE NETSCAPE-Bookmark-file-1>",
+      "<!-- This is an automatically generated file.",
+      "     It will be read and overwritten.",
+      "     DO NOT EDIT! -->",
+      '<META HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=UTF-8">',
+      "<TITLE>Bookmarks</TITLE>",
+      "<H1>Bookmarks</H1>",
+      "<DL><p>",
+    ];
+    renderNode(tree, 1, lines);
+    lines.push("</DL><p>");
+    return lines.join("\n") + "\n";
+  }
+
+  function indexOfUrl(model, key) {
+    for (var i = 0; i < model.bookmarks.length; i++) {
+      if (urlKey(model.bookmarks[i].url) === key) return i;
+    }
+    return -1;
+  }
+
+  /** Add one bookmark; existing URL wins. Returns {model, added}. */
+  function addBookmark(model, item) {
+    var next = normalizeModel(model);
+    var key = urlKey(item && item.url);
+    if (!key || !isWebUrl(item && item.url)) return { model: next, added: false };
+    if (indexOfUrl(next, key) !== -1) return { model: next, added: false };
+    var clean = sanitizeBookmark(item);
+    if (!clean.url) return { model: next, added: false };
+    next.bookmarks.push(clean);
+    return { model: next, added: true };
+  }
+
+  /** Merge incoming into base by URL; base entries win on collision. */
+  function mergeModels(base, incoming) {
+    var out = normalizeModel(base);
+    var add = normalizeModel(incoming);
+    for (var i = 0; i < add.bookmarks.length; i++) {
+      var item = add.bookmarks[i];
+      if (!item.url || indexOfUrl(out, urlKey(item.url)) !== -1) continue;
+      out.bookmarks.push(item);
+    }
+    return out;
+  }
+
+  function removeBookmark(model, id) {
+    var next = normalizeModel(model);
+    next.bookmarks = next.bookmarks.filter(function (b) {
+      return b.id !== id;
+    });
+    return next;
+  }
+
+  /**
+   * html parse wins for membership/title/folder; the json sidecar donates
+   * tags/note/id for the same URL so rewrites never drop rich fields.
+   */
+  function adoptRichFields(htmlModel, jsonModel) {
+    var out = normalizeModel(htmlModel);
+    if (!isValidModel(jsonModel)) return out;
+    var rich = Object.create(null);
+    for (var i = 0; i < jsonModel.bookmarks.length; i++) {
+      var b = jsonModel.bookmarks[i];
+      var key = urlKey(b.url);
+      if (key && !rich[key]) rich[key] = b;
+    }
+    for (var j = 0; j < out.bookmarks.length; j++) {
+      var item = out.bookmarks[j];
+      var donor = rich[urlKey(item.url)];
+      if (!donor) continue;
+      if (donor.id) item.id = donor.id;
+      if (donor.tags && donor.tags.length) item.tags = donor.tags.slice();
+      if (donor.note) item.note = donor.note;
+    }
+    return out;
+  }
+
+  function modelToJsonText(model) {
+    return JSON.stringify(normalizeModel(model), null, 2);
+  }
+
+  function modelFromJson(text) {
+    var parsed;
+    try {
+      parsed = JSON.parse(String(text || ""));
+    } catch (err) {
+      return { ok: false, model: emptyModel() };
+    }
+    if (!parsed || typeof parsed !== "object" || !Array.isArray(parsed.bookmarks)) {
+      return { ok: false, model: emptyModel() };
+    }
+    return { ok: true, model: normalizeModel(parsed) };
+  }
+
+  return {
+    MODEL_VERSION: MODEL_VERSION,
+    addBookmark: addBookmark,
+    adoptRichFields: adoptRichFields,
+    emptyModel: emptyModel,
+    isWebUrl: isWebUrl,
+    isValidModel: isValidModel,
+    makeId: makeId,
+    mergeModels: mergeModels,
+    modelFromJson: modelFromJson,
+    modelToJsonText: modelToJsonText,
+    normalizeModel: normalizeModel,
+    parseHtml: parseHtml,
+    removeBookmark: removeBookmark,
+    serializeHtml: serializeHtml,
+    urlKey: urlKey,
+  };
+})();
+
+if (typeof module !== "undefined" && module.exports) {
+  module.exports = Bookmarks;
+}

--- a/extension/bookmarksApp.js
+++ b/extension/bookmarksApp.js
@@ -1,0 +1,761 @@
+"use strict";
+
+/**
+ * Bookmark library page wiring. All pure display logic lives in
+ * bookmarksView.js; this file only touches chrome.* and the DOM.
+ */
+
+/* global Bookmarks, BookmarksView, DavflareDav, mergeSettings */
+
+var COPY = {
+  en: {
+    title: "Davflare Bookmarks",
+    brandSub: "Bookmarks",
+    navAll: "All bookmarks",
+    folders: "Folders",
+    tags: "Tags",
+    unfiled: "Unfiled",
+    searchPlaceholder: "Search bookmarks…",
+    allFolders: "All folders",
+    loading: "Loading…",
+    empty: "No bookmarks yet. Right-click any page and choose “Save page to Davflare”, or click Add.",
+    emptyFilter: "Nothing matches the current filter.",
+    add: "Add",
+    import: "Import",
+    export: "Export",
+    drive: "Drive",
+    settings: "Settings",
+    addDialogTitle: "Add bookmark",
+    urlLabel: "URL",
+    titleLabel: "Title",
+    cancel: "Cancel",
+    deleteLabel: "Delete",
+    confirmDelete: "Delete this bookmark?",
+    needConfig: "Configure your instance URL and WebDAV credentials in options first.",
+    openOptions: "Open options",
+    errDisabled: "WebDAV is disabled on this instance (feature switch off).",
+    errNotConfigured: "The server has no WebDAV credentials configured.",
+    errUnauthorized: "Wrong WebDAV username or password. Update them in options.",
+    errNetwork: "Cannot reach the instance. Check the URL in options.",
+    errConflict: "The library changed elsewhere — refreshed. Please retry.",
+    errOther: "The instance returned an unexpected response.",
+    invalidUrl: "Enter a valid http(s) URL.",
+    exists: "This URL is already in the library.",
+    added: "Saved.",
+    deleted: "Deleted.",
+    importDenied: "Import needs the “Read and change your bookmarks” permission.",
+    importDone: "Imported {n} new bookmark(s).",
+    importNone: "No new bookmarks to import.",
+    exported: "Exported bookmarks.html.",
+    syncPrefix: "synced",
+    neverSynced: "never synced",
+    offline: "offline",
+  },
+  zh: {
+    title: "Davflare 书签",
+    brandSub: "书签库",
+    navAll: "所有书签",
+    folders: "分类",
+    tags: "标签",
+    unfiled: "未分类",
+    searchPlaceholder: "搜索书签…",
+    allFolders: "全部分类",
+    loading: "加载中…",
+    empty: "还没有书签。在任意网页右键选择「收藏此页到 Davflare」，或点「添加」。",
+    emptyFilter: "没有符合当前筛选的书签。",
+    add: "添加",
+    import: "导入",
+    export: "导出",
+    drive: "网盘",
+    settings: "设置",
+    addDialogTitle: "添加书签",
+    urlLabel: "地址",
+    titleLabel: "标题",
+    cancel: "取消",
+    deleteLabel: "删除",
+    confirmDelete: "确定删除这个书签？",
+    needConfig: "请先在选项中配置实例地址与 WebDAV 凭据。",
+    openOptions: "打开设置",
+    errDisabled: "该实例已关闭 WebDAV（功能开关）。",
+    errNotConfigured: "服务端未配置 WebDAV 凭据。",
+    errUnauthorized: "WebDAV 用户名或密码错误，请在设置中更新。",
+    errNetwork: "无法连接实例，请在设置中检查地址。",
+    errConflict: "书签库已在别处更新——已刷新，请重试。",
+    errOther: "实例返回了未预期的响应。",
+    invalidUrl: "请填写有效的 http(s) 地址。",
+    exists: "该地址已在书签库中。",
+    added: "已保存。",
+    deleted: "已删除。",
+    importDenied: "导入需要授权「读取和更改您的书签」权限。",
+    importDone: "已导入 {n} 个新书签。",
+    importNone: "没有需要导入的新书签。",
+    exported: "已导出 bookmarks.html。",
+    syncPrefix: "已同步",
+    neverSynced: "从未同步",
+    offline: "未连接",
+  },
+};
+
+var ERROR_KEY = {
+  disabled: "errDisabled",
+  notConfigured: "errNotConfigured",
+  unauthorized: "errUnauthorized",
+  network: "errNetwork",
+  conflict: "errConflict",
+};
+
+var CACHE_KEY = "bookmarksCache";
+var THEME_KEY = "davflare-theme";
+
+var state = {
+  model: Bookmarks.emptyModel(),
+  etag: null,
+  filter: { kind: "all", value: "" },
+  query: "",
+  view: "grid",
+  syncedAt: 0,
+  bytes: 0,
+};
+
+var lang =
+  (navigator.language || "en").toLowerCase().indexOf("zh") === 0 ? "zh" : "en";
+var t = COPY[lang];
+
+function $(id) {
+  return document.getElementById(id);
+}
+
+function fmt(template, values) {
+  return String(template).replace(/\{(\w+)\}/g, function (_, key) {
+    return values && values[key] !== undefined ? values[key] : "";
+  });
+}
+
+function folderLabel(name) {
+  return name === "" ? t.unfiled : name;
+}
+
+function errorText(kind) {
+  var key = ERROR_KEY[kind];
+  return key ? t[key] : t.errOther;
+}
+
+/* ---------- theme ---------- */
+
+function initTheme() {
+  var saved = null;
+  try {
+    saved = localStorage.getItem(THEME_KEY);
+  } catch (err) {
+    saved = null;
+  }
+  var theme = saved === "light" || saved === "dark" ? saved : null;
+  if (!theme) {
+    theme = window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
+  }
+  applyTheme(theme);
+}
+
+function applyTheme(theme) {
+  document.documentElement.dataset.theme = theme;
+  $("themeToggle").textContent = theme === "dark" ? "☀" : "☾";
+}
+
+function toggleTheme() {
+  var next = document.documentElement.dataset.theme === "dark" ? "light" : "dark";
+  applyTheme(next);
+  try {
+    localStorage.setItem(THEME_KEY, next);
+  } catch (err) {
+    /* private mode: theme just won't persist */
+  }
+}
+
+/* ---------- data ---------- */
+
+async function loadConfig() {
+  var sync = await chrome.storage.sync.get(["instanceUrl"]);
+  var local = await chrome.storage.local.get(["davUsername", "davPassword"]);
+  return {
+    instanceUrl: mergeSettings(sync).instanceUrl,
+    username: typeof local.davUsername === "string" ? local.davUsername : "",
+    password: typeof local.davPassword === "string" ? local.davPassword : "",
+  };
+}
+
+function makeClient() {
+  return loadConfig().then(function (cfg) {
+    return { cfg: cfg, client: DavflareDav.createDavClient(cfg) };
+  });
+}
+
+function saveCache() {
+  var payload = {};
+  payload[CACHE_KEY] = {
+    model: state.model,
+    syncedAt: state.syncedAt,
+    bytes: state.bytes,
+  };
+  chrome.storage.local.set(payload);
+}
+
+function renderFromCache() {
+  chrome.storage.local.get([CACHE_KEY], function (stored) {
+    var cache = stored && stored[CACHE_KEY];
+    if (cache && cache.model) {
+      state.model = Bookmarks.normalizeModel(cache.model);
+      state.syncedAt = cache.syncedAt || 0;
+      state.bytes = cache.bytes || 0;
+      renderAll();
+    }
+  });
+}
+
+function computeBytes() {
+  return Bookmarks.serializeHtml(state.model).length + Bookmarks.modelToJsonText(state.model).length;
+}
+
+async function refresh() {
+  hideBanner();
+  $("loading").classList.remove("hidden");
+  var made = await makeClient();
+  try {
+    if (!made.cfg.instanceUrl) {
+      showBanner(t.needConfig, t.openOptions, openOptions);
+      renderAll();
+      return;
+    }
+    var res = await made.client.getBookmarks();
+    if (!res.ok) {
+      showBanner(errorText(res.kind), t.openOptions, openOptions);
+      renderAll();
+      return;
+    }
+    var model = Bookmarks.parseHtml(res.html || "");
+    if (res.jsonText) {
+      var parsed = Bookmarks.modelFromJson(res.jsonText);
+      if (parsed.ok) model = Bookmarks.adoptRichFields(model, parsed.model);
+    }
+    state.model = model;
+    state.etag = res.etag;
+    state.bytes = computeBytes();
+    state.syncedAt = Date.now();
+    saveCache();
+    hideBanner();
+    renderAll();
+  } finally {
+    $("loading").classList.add("hidden");
+  }
+}
+
+async function persist() {
+  var made = await makeClient();
+  if (!made.cfg.instanceUrl) {
+    showBanner(t.needConfig, t.openOptions, openOptions);
+    return false;
+  }
+  var put = await made.client.putBookmarks({
+    html: Bookmarks.serializeHtml(state.model),
+    json: Bookmarks.modelToJsonText(state.model),
+    etag: state.etag,
+  });
+  if (put.ok) {
+    state.bytes = computeBytes();
+    state.syncedAt = Date.now();
+    saveCache();
+    hideBanner();
+    renderAll();
+    return true;
+  }
+  if (put.kind === "conflict") {
+    showBanner(t.errConflict);
+    await refresh();
+    return false;
+  }
+  showBanner(errorText(put.kind), t.openOptions, openOptions);
+  return false;
+}
+
+/* ---------- banner ---------- */
+
+function showBanner(message, actionText, actionFn) {
+  var banner = $("banner");
+  banner.textContent = message || "";
+  if (actionText && actionFn) {
+    var btn = document.createElement("button");
+    btn.className = "ghost";
+    btn.type = "button";
+    btn.textContent = actionText;
+    btn.addEventListener("click", actionFn);
+    banner.appendChild(document.createTextNode(" "));
+    banner.appendChild(btn);
+  }
+  banner.classList.remove("hidden");
+}
+
+function hideBanner() {
+  $("banner").classList.add("hidden");
+}
+
+function openOptions() {
+  chrome.runtime.openOptionsPage();
+}
+
+/* ---------- render ---------- */
+
+function renderAll() {
+  renderNav();
+  renderFolderSelect();
+  renderItems();
+  renderSyncInfo();
+}
+
+function navButton(label, count, active, onClick) {
+  var btn = document.createElement("button");
+  btn.className = "navItem" + (active ? " active" : "");
+  btn.type = "button";
+  var span = document.createElement("span");
+  span.textContent = label;
+  var badge = document.createElement("span");
+  badge.className = "count";
+  badge.textContent = String(count);
+  btn.appendChild(span);
+  btn.appendChild(badge);
+  btn.addEventListener("click", onClick);
+  return btn;
+}
+
+function renderNav() {
+  var all = state.model.bookmarks.length;
+  $("navAllCount").textContent = String(all);
+  $("navAll").classList.toggle("active", state.filter.kind === "all");
+
+  var folderNav = $("folderNav");
+  folderNav.textContent = "";
+  var folders = BookmarksView.folderList(state.model);
+  for (var i = 0; i < folders.length; i++) {
+    (function (entry) {
+      var active = state.filter.kind === "folder" && state.filter.value === entry.name;
+      folderNav.appendChild(
+        navButton(folderLabel(entry.name), entry.count, active, function () {
+          state.filter = { kind: "folder", value: entry.name };
+          renderAll();
+        })
+      );
+    })(folders[i]);
+  }
+  if (!folders.length) {
+    folderNav.appendChild(emptyHint());
+  }
+
+  var tagNav = $("tagNav");
+  tagNav.textContent = "";
+  var tags = BookmarksView.tagList(state.model);
+  for (var j = 0; j < tags.length; j++) {
+    (function (entry) {
+      var active = state.filter.kind === "tag" && state.filter.value === entry.name;
+      tagNav.appendChild(
+        navButton(entry.name, entry.count, active, function () {
+          state.filter = { kind: "tag", value: entry.name };
+          renderAll();
+        })
+      );
+    })(tags[j]);
+  }
+  if (!tags.length) {
+    tagNav.appendChild(emptyHint());
+  }
+}
+
+function emptyHint() {
+  var p = document.createElement("p");
+  p.className = "navEmpty";
+  p.textContent = "—";
+  return p;
+}
+
+function renderFolderSelect() {
+  var select = $("folderSelect");
+  select.textContent = "";
+  var allOption = document.createElement("option");
+  allOption.value = "all";
+  allOption.textContent = t.allFolders;
+  select.appendChild(allOption);
+
+  var folders = BookmarksView.folderList(state.model);
+  for (var i = 0; i < folders.length; i++) {
+    var option = document.createElement("option");
+    option.value = folders[i].name;
+    option.textContent = folderLabel(folders[i].name) + " (" + folders[i].count + ")";
+    select.appendChild(option);
+  }
+  select.value = state.filter.kind === "folder" ? state.filter.value : "all";
+}
+
+function faviconNode(item) {
+  var wrap = document.createElement("span");
+  wrap.className = "favicon";
+  var letter = document.createElement("span");
+  letter.className = "letter";
+  letter.textContent = BookmarksView.fallbackLetter(item);
+  wrap.appendChild(letter);
+  var img = document.createElement("img");
+  img.alt = "";
+  img.width = 20;
+  img.height = 20;
+  img.loading = "lazy";
+  img.src =
+    chrome.runtime.getURL("_favicon/?pageUrl=") + encodeURIComponent(item.url) + "&size=32";
+  img.addEventListener("load", function () {
+    wrap.classList.add("hasIcon");
+  });
+  img.addEventListener("error", function () {
+    img.remove();
+  });
+  wrap.appendChild(img);
+  return wrap;
+}
+
+function deleteButton(item) {
+  var btn = document.createElement("button");
+  btn.className = "del";
+  btn.type = "button";
+  btn.title = t.deleteLabel;
+  btn.setAttribute("aria-label", t.deleteLabel);
+  btn.textContent = "✕";
+  btn.addEventListener("click", function (event) {
+    event.preventDefault();
+    event.stopPropagation();
+    confirmThen(function () {
+      state.model = Bookmarks.removeBookmark(state.model, item.id);
+      persist().then(function (ok) {
+        if (ok) flashStatus(t.deleted);
+      });
+    });
+  });
+  return btn;
+}
+
+function cardNode(item) {
+  var card = document.createElement("article");
+  card.className = "card";
+
+  var link = document.createElement("a");
+  link.className = "cardMain";
+  link.href = item.url;
+  link.target = "_blank";
+  link.rel = "noreferrer noopener";
+
+  link.appendChild(faviconNode(item));
+
+  var title = document.createElement("h3");
+  title.textContent = item.title || BookmarksView.domainOf(item.url) || item.url;
+  link.appendChild(title);
+
+  var domain = document.createElement("p");
+  domain.className = "domain";
+  domain.textContent = BookmarksView.domainOf(item.url) || item.url;
+  link.appendChild(domain);
+
+  var note = item.note ? document.createElement("p") : null;
+  if (note) {
+    note.className = "note";
+    note.textContent = item.note;
+    link.appendChild(note);
+  }
+
+  var meta = document.createElement("footer");
+  meta.className = "cardMeta";
+  var chip = document.createElement("span");
+  chip.className = "chip";
+  chip.textContent = folderLabel(item.folder);
+  meta.appendChild(chip);
+  var tags = Array.isArray(item.tags) ? item.tags : [];
+  for (var i = 0; i < tags.length; i++) {
+    var tag = document.createElement("span");
+    tag.className = "chip tag";
+    tag.textContent = tags[i];
+    meta.appendChild(tag);
+  }
+  var time = document.createElement("time");
+  time.textContent = BookmarksView.formatDate(item.added, lang);
+  meta.appendChild(time);
+  meta.appendChild(deleteButton(item));
+
+  card.appendChild(link);
+  card.appendChild(meta);
+  return card;
+}
+
+function rowNode(item) {
+  var row = document.createElement("a");
+  row.className = "row";
+  row.href = item.url;
+  row.target = "_blank";
+  row.rel = "noreferrer noopener";
+  row.appendChild(faviconNode(item));
+  var title = document.createElement("span");
+  title.className = "rowTitle";
+  title.textContent = item.title || BookmarksView.domainOf(item.url) || item.url;
+  var domain = document.createElement("span");
+  domain.className = "rowDomain";
+  domain.textContent = BookmarksView.domainOf(item.url);
+  var chip = document.createElement("span");
+  chip.className = "chip";
+  chip.textContent = folderLabel(item.folder);
+  var time = document.createElement("time");
+  time.textContent = BookmarksView.formatDate(item.added, lang);
+  row.appendChild(title);
+  row.appendChild(domain);
+  row.appendChild(chip);
+  row.appendChild(time);
+  row.appendChild(deleteButton(item));
+  return row;
+}
+
+function renderItems() {
+  var filter = {
+    query: state.query,
+    folder: state.filter.kind === "folder" ? state.filter.value : null,
+    tag: state.filter.kind === "tag" ? state.filter.value : null,
+  };
+  var items = BookmarksView.filterBookmarks(state.model, filter);
+
+  var cards = $("cards");
+  var rows = $("rows");
+  cards.textContent = "";
+  rows.textContent = "";
+
+  var isGrid = state.view === "grid";
+  cards.classList.toggle("hidden", !isGrid);
+  rows.classList.toggle("hidden", isGrid);
+
+  for (var i = 0; i < items.length; i++) {
+    if (isGrid) cards.appendChild(cardNode(items[i]));
+    else rows.appendChild(rowNode(items[i]));
+  }
+
+  var empty = $("emptyState");
+  if (!items.length) {
+    empty.textContent =
+      state.model.bookmarks.length === 0 ? t.empty : t.emptyFilter;
+    empty.classList.remove("hidden");
+  } else {
+    empty.classList.add("hidden");
+  }
+}
+
+function renderSyncInfo() {
+  var info = $("syncInfo");
+  if (state.syncedAt) {
+    info.textContent =
+      BookmarksView.formatRelative(state.syncedAt, Date.now(), lang) +
+      " · " +
+      BookmarksView.formatBytes(state.bytes);
+  } else {
+    info.textContent = t.neverSynced;
+  }
+}
+
+function flashStatus(message) {
+  var el = $("syncInfo");
+  var before = el.textContent;
+  el.textContent = message;
+  el.classList.add("flash");
+  setTimeout(function () {
+    el.textContent = before;
+    el.classList.remove("flash");
+  }, 2000);
+}
+
+/* ---------- mutations ---------- */
+
+var pendingConfirm = null;
+
+function confirmThen(fn) {
+  pendingConfirm = fn;
+  $("confirmText").textContent = t.confirmDelete;
+  $("confirmDialog").showModal();
+}
+
+async function submitAdd(event) {
+  event.preventDefault();
+  var url = $("addUrl").value.trim();
+  if (!Bookmarks.isWebUrl(url)) {
+    $("addError").textContent = t.invalidUrl;
+    return;
+  }
+  var title = $("addTitleInput").value.trim() || BookmarksView.domainOf(url) || url;
+  var add = Bookmarks.addBookmark(state.model, { title: title, url: url, added: Date.now() });
+  if (!add.added) {
+    $("addError").textContent = t.exists;
+    return;
+  }
+  state.model = add.model;
+  $("addError").textContent = "";
+  $("addDialog").close();
+  $("addUrl").value = "";
+  $("addTitleInput").value = "";
+  var ok = await persist();
+  if (ok) flashStatus(t.added);
+}
+
+async function importChromeBookmarks() {
+  if (typeof chrome === "undefined" || !chrome.permissions || !chrome.bookmarks) {
+    showBanner(t.importDenied);
+    return;
+  }
+  var granted;
+  try {
+    granted = await chrome.permissions.request({ permissions: ["bookmarks"] });
+  } catch (err) {
+    granted = false;
+  }
+  if (!granted) {
+    showBanner(t.importDenied);
+    return;
+  }
+  var tree = await chrome.bookmarks.getTree();
+  var incoming = [];
+  function walk(nodes, folderPath) {
+    for (var i = 0; i < nodes.length; i++) {
+      var node = nodes[i];
+      if (node.url) {
+        if (Bookmarks.isWebUrl(node.url)) {
+          incoming.push({
+            title: node.title || "",
+            url: node.url,
+            folder: folderPath,
+            added: node.dateAdded || 0,
+          });
+        }
+      } else if (Array.isArray(node.children)) {
+        var nextPath = node.title
+          ? (folderPath ? folderPath + "/" : "") + node.title
+          : folderPath;
+        walk(node.children, nextPath);
+      }
+    }
+  }
+  walk(tree || [], "");
+
+  var before = state.model.bookmarks.length;
+  state.model = Bookmarks.mergeModels(state.model, { bookmarks: incoming });
+  var added = state.model.bookmarks.length - before;
+  var ok = await persist();
+  if (ok) flashStatus(fmt(added > 0 ? t.importDone : t.importNone, { n: added }));
+}
+
+function exportHtml() {
+  var blob = new Blob([Bookmarks.serializeHtml(state.model)], { type: "text/html" });
+  var url = URL.createObjectURL(blob);
+  var a = document.createElement("a");
+  a.href = url;
+  a.download = "bookmarks.html";
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+  setTimeout(function () {
+    URL.revokeObjectURL(url);
+  }, 5000);
+  flashStatus(t.exported);
+}
+
+/* ---------- boot ---------- */
+
+function applyCopy() {
+  document.title = t.title;
+  $("brandSub").textContent = t.brandSub;
+  $("navAllText").textContent = t.navAll;
+  $("folderTitle").textContent = t.folders;
+  $("tagTitle").textContent = t.tags;
+  $("search").placeholder = t.searchPlaceholder;
+  $("loading").textContent = t.loading;
+  $("addBtn").textContent = t.add;
+  $("importBtn").textContent = t.import;
+  $("exportBtn").textContent = t.export;
+  $("driveBtn").textContent = t.drive;
+  $("settingsBtn").textContent = t.settings;
+  $("addDialogTitle").textContent = t.addDialogTitle;
+  $("addUrlLabel").textContent = t.urlLabel;
+  $("addTitleLabel").textContent = t.titleLabel;
+  $("addCancel").textContent = t.cancel;
+  $("addSave").textContent = t.add;
+  $("confirmCancel").textContent = t.cancel;
+  $("confirmOk").textContent = t.deleteLabel;
+}
+
+function setView(view) {
+  state.view = view;
+  $("viewGrid").classList.toggle("active", view === "grid");
+  $("viewList").classList.toggle("active", view === "list");
+  renderItems();
+}
+
+function setFilterAll() {
+  state.filter = { kind: "all", value: "" };
+  renderAll();
+}
+
+function wireEvents() {
+  $("navAll").addEventListener("click", setFilterAll);
+  $("search").addEventListener("input", function (event) {
+    state.query = event.target.value;
+    renderItems();
+  });
+  $("folderSelect").addEventListener("change", function (event) {
+    var value = event.target.value;
+    state.filter = value === "all" ? { kind: "all", value: "" } : { kind: "folder", value: value };
+    renderAll();
+  });
+  $("viewGrid").addEventListener("click", function () {
+    setView("grid");
+  });
+  $("viewList").addEventListener("click", function () {
+    setView("list");
+  });
+  $("themeToggle").addEventListener("click", toggleTheme);
+  $("addBtn").addEventListener("click", function () {
+    $("addError").textContent = "";
+    $("addDialog").showModal();
+    $("addUrl").focus();
+  });
+  $("addCancel").addEventListener("click", function () {
+    $("addDialog").close();
+  });
+  $("addForm").addEventListener("submit", submitAdd);
+  $("confirmCancel").addEventListener("click", function () {
+    pendingConfirm = null;
+    $("confirmDialog").close();
+  });
+  $("confirmOk").addEventListener("click", function () {
+    var fn = pendingConfirm;
+    pendingConfirm = null;
+    $("confirmDialog").close();
+    if (fn) fn();
+  });
+  $("importBtn").addEventListener("click", importChromeBookmarks);
+  $("exportBtn").addEventListener("click", exportHtml);
+  $("settingsBtn").addEventListener("click", openOptions);
+  $("driveBtn").addEventListener("click", async function () {
+    var cfg = await loadConfig();
+    if (cfg.instanceUrl) chrome.tabs.create({ url: cfg.instanceUrl });
+    else openOptions();
+  });
+  document.addEventListener("keydown", function (event) {
+    var target = event.target;
+    var typing =
+      target &&
+      (target.tagName === "INPUT" || target.tagName === "TEXTAREA" || target.isContentEditable);
+    if (event.key === "/" && !typing) {
+      event.preventDefault();
+      $("search").focus();
+    }
+  });
+}
+
+applyCopy();
+initTheme();
+wireEvents();
+renderFromCache();
+refresh();

--- a/extension/bookmarksView.js
+++ b/extension/bookmarksView.js
@@ -1,0 +1,160 @@
+"use strict";
+
+/**
+ * Pure view helpers for the bookmark library page. No DOM, no chrome.* —
+ * everything here is unit-testable via the module.exports guard.
+ */
+
+var BookmarksView = (function () {
+  function domainOf(url) {
+    var s = String(url || "").trim();
+    try {
+      var u = new URL(s);
+      if (u.protocol === "http:" || u.protocol === "https:") return u.hostname;
+      return "";
+    } catch (err) {
+      return "";
+    }
+  }
+
+  function folderList(model) {
+    var counts = Object.create(null);
+    var order = [];
+    var items = model && Array.isArray(model.bookmarks) ? model.bookmarks : [];
+    for (var i = 0; i < items.length; i++) {
+      var name = String(items[i].folder || "");
+      if (!counts[name]) {
+        counts[name] = 0;
+        order.push(name);
+      }
+      counts[name] += 1;
+    }
+    order.sort(function (a, b) {
+      if (a === "" && b !== "") return -1;
+      if (b === "" && a !== "") return 1;
+      return a < b ? -1 : a > b ? 1 : 0;
+    });
+    return order.map(function (name) {
+      return { name: name, count: counts[name] };
+    });
+  }
+
+  function tagList(model) {
+    var counts = Object.create(null);
+    var items = model && Array.isArray(model.bookmarks) ? model.bookmarks : [];
+    for (var i = 0; i < items.length; i++) {
+      var tags = Array.isArray(items[i].tags) ? items[i].tags : [];
+      for (var j = 0; j < tags.length; j++) {
+        var tag = String(tags[j] || "").trim();
+        if (!tag) continue;
+        counts[tag] = (counts[tag] || 0) + 1;
+      }
+    }
+    return Object.keys(counts)
+      .map(function (name) {
+        return { name: name, count: counts[name] };
+      })
+      .sort(function (a, b) {
+        if (b.count !== a.count) return b.count - a.count;
+        return a.name < b.name ? -1 : a.name > b.name ? 1 : 0;
+      });
+  }
+
+  function matchesQuery(item, query) {
+    var q = String(query || "").trim().toLowerCase();
+    if (!q) return true;
+    var haystacks = [
+      item.title,
+      item.url,
+      item.note,
+      item.folder,
+      (Array.isArray(item.tags) ? item.tags : []).join(" "),
+      domainOf(item.url),
+    ];
+    for (var i = 0; i < haystacks.length; i++) {
+      if (String(haystacks[i] || "").toLowerCase().indexOf(q) !== -1) return true;
+    }
+    return false;
+  }
+
+  /** opts: {query, folder, tag} — null/undefined filter means "any". */
+  function filterBookmarks(model, opts) {
+    var options = opts || {};
+    var items = model && Array.isArray(model.bookmarks) ? model.bookmarks : [];
+    var out = [];
+    for (var i = 0; i < items.length; i++) {
+      var item = items[i];
+      if (typeof options.folder === "string" && String(item.folder || "") !== options.folder) {
+        continue;
+      }
+      if (options.tag && (item.tags || []).indexOf(options.tag) === -1) continue;
+      if (!matchesQuery(item, options.query)) continue;
+      out.push(item);
+    }
+    return out;
+  }
+
+  function formatBytes(n) {
+    var value = typeof n === "number" && isFinite(n) && n > 0 ? n : 0;
+    if (value < 1024) return value + " B";
+    if (value < 1024 * 1024) return (value / 1024).toFixed(1) + " KB";
+    return (value / (1024 * 1024)).toFixed(2) + " MB";
+  }
+
+  function formatRelative(ms, now, lang) {
+    var target = typeof ms === "number" && isFinite(ms) && ms > 0 ? ms : 0;
+    if (!target) return lang === "zh" ? "从未同步" : "never synced";
+    var seconds = Math.max(0, Math.floor(((now || Date.now()) - target) / 1000));
+    if (seconds < 60) return lang === "zh" ? "刚刚" : "just now";
+    var minutes = Math.floor(seconds / 60);
+    if (minutes < 60) return lang === "zh" ? minutes + " 分钟前" : minutes + "m ago";
+    var hours = Math.floor(minutes / 60);
+    if (hours < 24) return lang === "zh" ? hours + " 小时前" : hours + "h ago";
+    var days = Math.floor(hours / 24);
+    if (days < 30) return lang === "zh" ? days + " 天前" : days + "d ago";
+    var d = new Date(target);
+    var m = d.getMonth() + 1;
+    var day = d.getDate();
+    return (
+      d.getFullYear() +
+      "/" +
+      (m < 10 ? "0" + m : m) +
+      "/" +
+      (day < 10 ? "0" + day : day)
+    );
+  }
+
+  function formatDate(ms, lang) {
+    var target = typeof ms === "number" && isFinite(ms) && ms > 0 ? ms : 0;
+    if (!target) return lang === "zh" ? "未知" : "unknown";
+    var d = new Date(target);
+    var m = d.getMonth() + 1;
+    var day = d.getDate();
+    return (
+      d.getFullYear() +
+      "/" +
+      (m < 10 ? "0" + m : m) +
+      "/" +
+      (day < 10 ? "0" + day : day)
+    );
+  }
+
+  return {
+    domainOf: domainOf,
+    fallbackLetter: function (item) {
+      var t = String((item && item.title) || domainOf(item && item.url) || "").trim();
+      return t ? t.charAt(0).toUpperCase() : "?";
+    },
+    filterBookmarks: filterBookmarks,
+    formatDate: formatDate,
+    formatBytes: formatBytes,
+    formatRelative: formatRelative,
+    folderList: folderList,
+    matchesQuery: matchesQuery,
+    tagList: tagList,
+  };
+})();
+
+if (typeof module !== "undefined" && module.exports) {
+  module.exports = BookmarksView;
+}

--- a/extension/dav.js
+++ b/extension/dav.js
@@ -1,0 +1,165 @@
+"use strict";
+
+/**
+ * Minimal WebDAV client for the Davflare extension.
+ *
+ * Talks Basic auth to the instance's /webdav endpoint (server-side CORS is
+ * open, so page contexts and the service worker can both call it). Error
+ * kinds mirror what the instance can actually return:
+ *   network        — fetch threw or no instance URL
+ *   disabled       — webdav feature flag off (404 before auth)
+ *   notConfigured  — server lacks WEBDAV_USERNAME/PASSWORD (403)
+ *   unauthorized   — wrong credentials (401)
+ *   conflict       — If-Match precondition failed (412)
+ *   httpNNN        — anything else
+ */
+
+var DavflareDav = (function () {
+  var HTML_PATH = "bookmarks.html";
+  var JSON_PATH = "bookmarks.json";
+
+  function mapStatusKind(status) {
+    if (status === 401) return "unauthorized";
+    if (status === 403) return "notConfigured";
+    return "http" + status;
+  }
+
+  function createDavClient(options) {
+    var opts = options || {};
+    var base = String(opts.instanceUrl || "").replace(/\/+$/, "");
+    var root = base + "/webdav";
+    var dir = root + "/bookmarks/";
+    var username = String(opts.username || "");
+    var password = String(opts.password || "");
+    var fetchImpl = opts.fetchImpl || (typeof fetch === "function" ? fetch : null);
+
+    function authHeader() {
+      return "Basic " + btoa(unescape(encodeURIComponent(username + ":" + password)));
+    }
+
+    async function request(method, url, extra) {
+      extra = extra || {};
+      if (!base || !fetchImpl) {
+        return { status: 0, ok: false, kind: "network", text: "", etag: null };
+      }
+      var headers = { Authorization: authHeader() };
+      var keys = Object.keys(extra.headers || {});
+      for (var i = 0; i < keys.length; i++) headers[keys[i]] = extra.headers[keys[i]];
+      try {
+        var res = await fetchImpl(url, {
+          method: method,
+          headers: headers,
+          body: extra.body,
+        });
+        var text = "";
+        if (method === "GET" || method === "PROPFIND") {
+          try {
+            text = await res.text();
+          } catch (err) {
+            text = "";
+          }
+        }
+        var etag = null;
+        try {
+          etag = res.headers.get("etag");
+        } catch (err2) {
+          etag = null;
+        }
+        return {
+          status: res.status,
+          ok: res.status >= 200 && res.status < 300,
+          kind: res.ok ? null : mapStatusKind(res.status),
+          text: text,
+          etag: etag,
+        };
+      } catch (err) {
+        return { status: 0, ok: false, kind: "network", text: "", etag: null };
+      }
+    }
+
+    /** PROPFIND the webdav root; 404 here means the feature flag is off. */
+    async function probe() {
+      var res = await request("PROPFIND", root + "/", { headers: { Depth: "0" } });
+      if (res.ok) return { ok: true };
+      if (res.status === 404) return { ok: false, kind: "disabled" };
+      return { ok: false, kind: res.kind || "network" };
+    }
+
+    async function ensureDir() {
+      var res = await request("MKCOL", dir);
+      if (res.status === 0) return { ok: false, kind: "network" };
+      if (res.ok || res.status === 405) return { ok: true };
+      if (res.status === 404) return { ok: false, kind: "disabled" };
+      return { ok: false, kind: mapStatusKind(res.status) };
+    }
+
+    async function getJsonText() {
+      var res = await request("GET", dir + JSON_PATH);
+      return res.status === 200 ? res.text : null;
+    }
+
+    /**
+     * Load both files. A 404 on the html is ambiguous (missing file vs flag
+     * off), so probe the root to disambiguate before treating it as empty.
+     */
+    async function getBookmarks() {
+      var res = await request("GET", dir + HTML_PATH);
+      if (res.status === 0) return { ok: false, kind: "network" };
+      if (res.status === 404) {
+        var probeRes = await probe();
+        if (!probeRes.ok) return probeRes;
+        return { ok: true, missing: true, html: "", etag: null, jsonText: null };
+      }
+      if (!res.ok) return { ok: false, kind: res.kind };
+      var jsonText = await getJsonText();
+      return {
+        ok: true,
+        missing: false,
+        html: res.text,
+        etag: res.etag,
+        jsonText: jsonText,
+      };
+    }
+
+    /** Write html (with If-Match when we know the etag), then json best-effort. */
+    async function putBookmarks(payload) {
+      payload = payload || {};
+      var mk = await ensureDir();
+      if (!mk.ok) return mk;
+
+      var headers = { "Content-Type": "text/html; charset=utf-8" };
+      if (payload.etag) headers["If-Match"] = payload.etag;
+      var res = await request("PUT", dir + HTML_PATH, {
+        body: String(payload.html || ""),
+        headers: headers,
+      });
+      if (res.status === 0) return { ok: false, kind: "network" };
+      if (res.status === 412) return { ok: false, kind: "conflict" };
+      if (!res.ok) return { ok: false, kind: res.kind };
+
+      var jsonSaved = false;
+      if (typeof payload.json === "string") {
+        var jres = await request("PUT", dir + JSON_PATH, {
+          body: payload.json,
+          headers: { "Content-Type": "application/json; charset=utf-8" },
+        });
+        jsonSaved = jres.ok;
+      }
+      return { ok: true, jsonSaved: jsonSaved };
+    }
+
+    return {
+      ensureDir: ensureDir,
+      getBookmarks: getBookmarks,
+      paths: { root: root, dir: dir, html: dir + HTML_PATH, json: dir + JSON_PATH },
+      probe: probe,
+      putBookmarks: putBookmarks,
+    };
+  }
+
+  return { createDavClient: createDavClient };
+})();
+
+if (typeof module !== "undefined" && module.exports) {
+  module.exports = DavflareDav;
+}

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,8 +1,8 @@
 {
   "manifest_version": 3,
   "name": "Davflare",
-  "version": "1.1.0",
-  "description": "Open your Davflare instance from the toolbar.",
+  "version": "1.2.0",
+  "description": "Open your Davflare drive or bookmark library from the toolbar.",
   "icons": {
     "16": "icons/icon16.png",
     "32": "icons/icon32.png",
@@ -10,7 +10,7 @@
     "128": "icons/icon128.png"
   },
   "action": {
-    "default_title": "Open Davflare",
+    "default_title": "Davflare",
     "default_icon": {
       "16": "icons/icon16.png",
       "32": "icons/icon32.png",
@@ -25,5 +25,7 @@
   "background": {
     "service_worker": "background.js"
   },
-  "permissions": ["storage"]
+  "permissions": ["storage", "activeTab", "contextMenus", "favicon", "notifications"],
+  "optional_permissions": ["bookmarks"],
+  "optional_host_permissions": ["http://*/*", "https://*/*"]
 }

--- a/extension/options.css
+++ b/extension/options.css
@@ -72,7 +72,9 @@ label {
   margin-bottom: 6px;
 }
 
-input[type="url"] {
+input[type="url"],
+input[type="text"],
+input[type="password"] {
   width: 100%;
   border: 1px solid var(--line);
   border-radius: 8px;
@@ -82,10 +84,43 @@ input[type="url"] {
   background: #fff;
 }
 
-input[type="url"]:focus {
+input[type="url"]:focus,
+input[type="text"]:focus,
+input[type="password"]:focus {
   outline: none;
   border-color: var(--orange);
   box-shadow: 0 0 0 4px var(--focus);
+}
+
+.section {
+  margin: 22px 0 0;
+  padding: 0;
+  border: 0;
+}
+
+.section legend {
+  font-weight: 600;
+  font-size: 0.875rem;
+  padding: 0;
+  margin-bottom: 8px;
+}
+
+.section label:not(.radio) {
+  margin-top: 12px;
+}
+
+.radio {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-weight: 400;
+  font-size: 0.875rem;
+  margin: 0 0 6px;
+  cursor: pointer;
+}
+
+.radio input {
+  accent-color: var(--orange);
 }
 
 .actions {
@@ -93,6 +128,7 @@ input[type="url"]:focus {
   align-items: center;
   gap: 14px;
   margin-top: 22px;
+  flex-wrap: wrap;
 }
 
 button {
@@ -109,6 +145,16 @@ button {
 
 button:hover {
   background: var(--orange-dark);
+}
+
+button.ghost {
+  background: transparent;
+  color: var(--orange-dark);
+  border: 1px solid var(--orange);
+}
+
+button.ghost:hover {
+  background: var(--focus);
 }
 
 button:focus-visible {

--- a/extension/options.html
+++ b/extension/options.html
@@ -31,13 +31,54 @@
           Paste the Pages or custom-domain URL of your own Davflare instance.
         </p>
 
+        <fieldset class="section">
+          <legend id="modeLabel">Default toolbar action</legend>
+          <label class="radio" for="modeDrive">
+            <input type="radio" id="modeDrive" name="toolbarMode" value="drive" />
+            <span id="modeDriveText">Open drive</span>
+          </label>
+          <label class="radio" for="modeBookmarks">
+            <input type="radio" id="modeBookmarks" name="toolbarMode" value="bookmarks" />
+            <span id="modeBookmarksText">Open bookmark library</span>
+          </label>
+          <p class="hint" id="modeHint">Right-click the toolbar icon to switch anytime.</p>
+        </fieldset>
+
+        <fieldset class="section">
+          <legend id="davLabel">WebDAV credentials</legend>
+          <label for="davUser" id="userLabel">Username</label>
+          <input
+            id="davUser"
+            name="davUser"
+            type="text"
+            autocomplete="off"
+            spellcheck="false"
+            autocapitalize="off"
+          />
+          <label for="davPass" id="passLabel">Password</label>
+          <input
+            id="davPass"
+            name="davPass"
+            type="password"
+            autocomplete="new-password"
+            spellcheck="false"
+          />
+          <p class="hint" id="davHint">
+            Stored only on this device. Same values as your deployment's
+            WEBDAV_USERNAME / WEBDAV_PASSWORD.
+          </p>
+        </fieldset>
+
         <div class="actions">
           <button type="submit" id="save">Save</button>
+          <button type="button" id="testConn" class="ghost">Test connection</button>
           <p id="status" class="status" role="status"></p>
         </div>
+        <p id="probeStatus" class="status" role="status"></p>
       </form>
     </main>
     <script src="url.js"></script>
+    <script src="dav.js"></script>
     <script src="options.js"></script>
   </body>
 </html>

--- a/extension/options.js
+++ b/extension/options.js
@@ -6,34 +6,81 @@ var COPY = {
     tagline: "Open the drive you deployed. No built-in host.",
     urlLabel: "Instance URL",
     urlHint: "Paste the Pages or custom-domain URL of your own Davflare instance.",
+    modeLabel: "Default toolbar action",
+    modeDrive: "Open drive",
+    modeBookmarks: "Open bookmark library",
+    modeHint: "Right-click the toolbar icon to switch anytime.",
+    davLabel: "WebDAV credentials",
+    userLabel: "Username",
+    passLabel: "Password",
+    davHint:
+      "Stored only on this device. Same values as your deployment's WEBDAV_USERNAME / WEBDAV_PASSWORD.",
     save: "Save",
+    testConn: "Test connection",
+    testing: "Testing…",
     saved: "Saved.",
+    savedNoGrant:
+      "Saved, but access to this site was not granted — bookmark features will not work.",
     cleared: "Saved. Toolbar click will open this page until you add a URL.",
     invalid: "Enter an http(s) URL, or leave the field empty.",
+    probeOk: "Connected. WebDAV is enabled.",
+    probeDisabled: "WebDAV is disabled on this instance (feature switch off).",
+    probeNotConfigured: "The server has no WebDAV credentials configured.",
+    probeUnauthorized: "Wrong WebDAV username or password.",
+    probeNetwork: "Cannot reach the instance. Check the URL.",
+    probeOther: "The instance returned an unexpected response.",
   },
   zh: {
     title: "Davflare 选项",
     tagline: "打开你自己部署的网盘。扩展不内置任何站点。",
     urlLabel: "实例地址",
     urlHint: "粘贴你自己的 Pages 或自定义域名。",
+    modeLabel: "工具栏默认行为",
+    modeDrive: "打开网盘",
+    modeBookmarks: "打开书签库",
+    modeHint: "随时可右键点击工具栏图标快速切换。",
+    davLabel: "WebDAV 凭据",
+    userLabel: "用户名",
+    passLabel: "密码",
+    davHint: "仅保存在本设备。与你部署时配置的 WEBDAV_USERNAME / WEBDAV_PASSWORD 一致。",
     save: "保存",
+    testConn: "测试连接",
+    testing: "测试中…",
     saved: "已保存。",
+    savedNoGrant: "已保存，但未授权访问该站点，书签功能将不可用。",
     cleared: "已保存。未填写地址时，工具栏点击会打开本页。",
     invalid: "请填写 http(s) 地址，或留空。",
+    probeOk: "连接成功，WebDAV 已开启。",
+    probeDisabled: "该实例已关闭 WebDAV（功能开关）。",
+    probeNotConfigured: "服务端未配置 WebDAV 凭据。",
+    probeUnauthorized: "WebDAV 用户名或密码错误。",
+    probeNetwork: "无法连接实例，请检查地址。",
+    probeOther: "实例返回了未预期的响应。",
   },
 };
 
-function storageArea() {
-  if (typeof chrome !== "undefined" && chrome.storage && chrome.storage.sync) {
-    return chrome.storage.sync;
+var PROBE_COPY = {
+  disabled: "probeDisabled",
+  notConfigured: "probeNotConfigured",
+  unauthorized: "probeUnauthorized",
+  network: "probeNetwork",
+};
+
+function chromeArea(name, seed) {
+  if (typeof chrome !== "undefined" && chrome.storage && chrome.storage[name]) {
+    return chrome.storage[name];
   }
-  var memory = { instanceUrl: "" };
+  var memory = Object.assign({}, seed);
   return {
     get: function (keys, cb) {
-      cb({ instanceUrl: memory.instanceUrl });
+      var out = {};
+      (Array.isArray(keys) ? keys : []).forEach(function (key) {
+        out[key] = memory[key];
+      });
+      cb(out);
     },
     set: function (values, cb) {
-      if (typeof values.instanceUrl === "string") memory.instanceUrl = values.instanceUrl;
+      Object.assign(memory, values);
       if (cb) cb();
     },
   };
@@ -47,24 +94,77 @@ function applyCopy() {
   document.getElementById("tagline").textContent = t.tagline;
   document.getElementById("urlLabel").textContent = t.urlLabel;
   document.getElementById("urlHint").textContent = t.urlHint;
+  document.getElementById("modeLabel").textContent = t.modeLabel;
+  document.getElementById("modeDriveText").textContent = t.modeDrive;
+  document.getElementById("modeBookmarksText").textContent = t.modeBookmarks;
+  document.getElementById("modeHint").textContent = t.modeHint;
+  document.getElementById("davLabel").textContent = t.davLabel;
+  document.getElementById("userLabel").textContent = t.userLabel;
+  document.getElementById("passLabel").textContent = t.passLabel;
+  document.getElementById("davHint").textContent = t.davHint;
   document.getElementById("save").textContent = t.save;
+  document.getElementById("testConn").textContent = t.testConn;
   return t;
 }
 
 var strings = applyCopy();
-var store = storageArea();
+var syncStore = chromeArea("sync", { instanceUrl: "", toolbarMode: "drive" });
+var localStore = chromeArea("local", { davUsername: "", davPassword: "" });
 var form = document.getElementById("form");
 var urlInput = document.getElementById("instanceUrl");
+var modeDrive = document.getElementById("modeDrive");
+var modeBookmarks = document.getElementById("modeBookmarks");
+var userInput = document.getElementById("davUser");
+var passInput = document.getElementById("davPass");
 var statusEl = document.getElementById("status");
+var probeEl = document.getElementById("probeStatus");
 
 function setStatus(message, kind) {
   statusEl.textContent = message || "";
   statusEl.className = "status" + (kind ? " " + kind : "");
 }
 
-store.get(["instanceUrl"], function (stored) {
-  urlInput.value = mergeSettings(stored).instanceUrl;
-});
+function setProbe(message, kind) {
+  probeEl.textContent = message || "";
+  probeEl.className = "status" + (kind ? " " + kind : "");
+}
+
+function loadSettings() {
+  syncStore.get(["instanceUrl", "toolbarMode"], function (stored) {
+    var merged = mergeSettings(stored);
+    urlInput.value = merged.instanceUrl;
+    (merged.toolbarMode === "bookmarks" ? modeBookmarks : modeDrive).checked = true;
+  });
+  localStore.get(["davUsername", "davPassword"], function (stored) {
+    userInput.value = typeof stored.davUsername === "string" ? stored.davUsername : "";
+    passInput.value = typeof stored.davPassword === "string" ? stored.davPassword : "";
+  });
+}
+
+function selectedMode() {
+  return modeBookmarks.checked ? "bookmarks" : "drive";
+}
+
+async function ensureOriginPermission(instanceUrl) {
+  if (!instanceUrl || typeof chrome === "undefined" || !chrome.permissions) {
+    return { granted: true, skipped: true };
+  }
+  var origin;
+  try {
+    origin = new URL(instanceUrl).origin + "/*";
+  } catch (err) {
+    return { granted: true, skipped: true };
+  }
+  try {
+    if (await chrome.permissions.contains({ origins: [origin] })) {
+      return { granted: true };
+    }
+    var granted = await chrome.permissions.request({ origins: [origin] });
+    return { granted: Boolean(granted) };
+  } catch (err) {
+    return { granted: false };
+  }
+}
 
 form.addEventListener("submit", function (event) {
   event.preventDefault();
@@ -75,9 +175,43 @@ form.addEventListener("submit", function (event) {
     urlInput.focus();
     return;
   }
-  var next = { instanceUrl: normalized };
-  store.set(next, function () {
-    urlInput.value = next.instanceUrl;
-    setStatus(next.instanceUrl ? strings.saved : strings.cleared, "ok");
-  });
+  syncStore.set(
+    { instanceUrl: normalized, toolbarMode: selectedMode() },
+    function () {
+      localStore.set(
+        { davUsername: userInput.value.trim(), davPassword: passInput.value },
+        async function () {
+          urlInput.value = normalized;
+          var perm = await ensureOriginPermission(normalized);
+          if (!normalized) setStatus(strings.cleared, "ok");
+          else if (perm.granted) setStatus(strings.saved, "ok");
+          else setStatus(strings.savedNoGrant, "err");
+        }
+      );
+    }
+  );
 });
+
+document.getElementById("testConn").addEventListener("click", async function () {
+  var url = normalizeInstanceUrl(urlInput.value);
+  if (!url) {
+    setStatus(strings.invalid, "err");
+    urlInput.focus();
+    return;
+  }
+  setProbe(strings.testing);
+  var client = DavflareDav.createDavClient({
+    instanceUrl: url,
+    username: userInput.value.trim(),
+    password: passInput.value,
+  });
+  var res = await client.probe();
+  if (res.ok) {
+    setProbe(strings.probeOk, "ok");
+    return;
+  }
+  var key = PROBE_COPY[res.kind];
+  setProbe(key ? strings[key] : strings.probeOther, "err");
+});
+
+loadSettings();

--- a/extension/url.js
+++ b/extension/url.js
@@ -7,7 +7,10 @@
 
 var DEFAULT_SETTINGS = {
   instanceUrl: "",
+  toolbarMode: "drive",
 };
+
+var TOOLBAR_MODES = ["drive", "bookmarks"];
 
 var DEFAULT_NTP = "chrome://new-tab-page/";
 
@@ -15,6 +18,7 @@ function mergeSettings(stored) {
   var src = stored && typeof stored === "object" ? stored : {};
   return {
     instanceUrl: typeof src.instanceUrl === "string" ? src.instanceUrl : "",
+    toolbarMode: src.toolbarMode === "bookmarks" ? "bookmarks" : "drive",
   };
 }
 
@@ -51,6 +55,7 @@ function normalizeInstanceUrl(raw) {
 
 function resolveToolbarTarget(settings) {
   var merged = mergeSettings(settings);
+  if (merged.toolbarMode === "bookmarks") return { action: "bookmarks" };
   var url = normalizeInstanceUrl(merged.instanceUrl);
   if (url) return { action: "open", url: url };
   return { action: "options" };
@@ -66,6 +71,7 @@ if (typeof module !== "undefined" && module.exports) {
   module.exports = {
     DEFAULT_NTP: DEFAULT_NTP,
     DEFAULT_SETTINGS: DEFAULT_SETTINGS,
+    TOOLBAR_MODES: TOOLBAR_MODES,
     mergeSettings: mergeSettings,
     normalizeInstanceUrl: normalizeInstanceUrl,
     resolveNewTabTarget: resolveNewTabTarget,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1900,112 +1900,6 @@
         "win32"
       ]
     },
-    "node_modules/@testing-library/dom": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.2.0.tgz",
-      "integrity": "sha512-CytIvb6tVOADRngTHGWNxH8LPgO/3hi/BdCEHOf7Qd2GvZVClhVP0Wo/QHzWhpki49Bk0b4VT6xpt3fx8HTSIw==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "@babel/code-frame": "^7.10.4",
-        "@babel/runtime": "^7.12.5",
-        "@types/aria-query": "^5.0.1",
-        "aria-query": "5.3.0",
-        "chalk": "^4.1.0",
-        "dom-accessibility-api": "^0.5.9",
-        "lz-string": "^1.5.0",
-        "pretty-format": "^27.0.2"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@testing-library/dom/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/@testing-library/dom/node_modules/aria-query": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
-      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "dequal": "^2.0.3"
-      }
-    },
-    "node_modules/@testing-library/dom/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/@testing-library/dom/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/@testing-library/dom/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
-      "peer": true
-    },
-    "node_modules/@testing-library/dom/node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
-      "peer": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@testing-library/dom/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/@testing-library/jest-dom": {
       "version": "6.9.1",
       "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
@@ -3070,16 +2964,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
-      }
-    },
-    "node_modules/dequal": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
-      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
-      "dev": true,
-      "peer": true,
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/dijkstrajs": {

--- a/src/app/__tests__/extension.test.ts
+++ b/src/app/__tests__/extension.test.ts
@@ -20,14 +20,16 @@ const packageScript = path.join(repoRoot, "scripts/package-extension.sh");
 const {
   DEFAULT_NTP,
   DEFAULT_SETTINGS,
+  TOOLBAR_MODES,
   mergeSettings,
   normalizeInstanceUrl,
   resolveNewTabTarget,
   resolveToolbarTarget,
 } = nodeRequire("../../../extension/url.js") as {
   DEFAULT_NTP: string;
-  DEFAULT_SETTINGS: { instanceUrl: string };
-  mergeSettings: (stored: unknown) => { instanceUrl: string };
+  DEFAULT_SETTINGS: { instanceUrl: string; toolbarMode: string };
+  TOOLBAR_MODES: string[];
+  mergeSettings: (stored: unknown) => { instanceUrl: string; toolbarMode: string };
   normalizeInstanceUrl: (raw: unknown) => string;
   resolveNewTabTarget: (settings: unknown) => { action: string; url?: string };
   resolveToolbarTarget: (settings: unknown) => { action: string; url?: string };
@@ -59,13 +61,20 @@ describe("Davflare Chrome extension / default package", () => {
     fs.readFileSync(path.join(extDir, "manifest.json"), "utf8")
   ) as Record<string, unknown>;
 
-  test("is Manifest V3 with action, options, and storage — no NTP override", () => {
+  test("is Manifest V3 with action, options, and bookmarks permissions — no NTP override", () => {
     expect(manifest.manifest_version).toBe(3);
     expect(manifest.action).toBeTruthy();
     expect((manifest.options_ui as { page: string }).page).toBe("options.html");
-    expect(manifest.permissions).toEqual(["storage"]);
+    expect(manifest.permissions).toEqual([
+      "storage",
+      "activeTab",
+      "contextMenus",
+      "favicon",
+      "notifications",
+    ]);
+    expect(manifest.optional_permissions).toEqual(["bookmarks"]);
     expect(manifest.host_permissions).toBeUndefined();
-    expect(manifest.optional_host_permissions).toBeUndefined();
+    expect(manifest.optional_host_permissions).toEqual(["http://*/*", "https://*/*"]);
     expect(manifest.chrome_url_overrides).toBeUndefined();
     expect(Object.prototype.hasOwnProperty.call(manifest, "chrome_url_overrides")).toBe(
       false
@@ -103,18 +112,28 @@ describe("Davflare Chrome extension / default package", () => {
 });
 
 describe("Davflare Chrome extension / settings defaults", () => {
-  test("instance URL is empty and leftover newTab flags are ignored", () => {
-    expect(DEFAULT_SETTINGS).toEqual({ instanceUrl: "" });
-    expect(mergeSettings(undefined)).toEqual({ instanceUrl: "" });
-    expect(mergeSettings({})).toEqual({ instanceUrl: "" });
+  test("instance URL is empty, mode defaults to drive, and leftover flags are ignored", () => {
+    expect(DEFAULT_SETTINGS).toEqual({ instanceUrl: "", toolbarMode: "drive" });
+    expect(TOOLBAR_MODES).toEqual(["drive", "bookmarks"]);
+    expect(mergeSettings(undefined)).toEqual({ instanceUrl: "", toolbarMode: "drive" });
+    expect(mergeSettings({})).toEqual({ instanceUrl: "", toolbarMode: "drive" });
     expect(mergeSettings({ newTab: true, instanceUrl: 1 })).toEqual({
       instanceUrl: "",
+      toolbarMode: "drive",
     });
     expect(
       mergeSettings({ newTab: true, instanceUrl: "https://drive.example" })
     ).toEqual({
       instanceUrl: "https://drive.example",
+      toolbarMode: "drive",
     });
+  });
+
+  test("only the two known toolbar modes are accepted", () => {
+    expect(mergeSettings({ toolbarMode: "bookmarks" }).toolbarMode).toBe("bookmarks");
+    expect(mergeSettings({ toolbarMode: "drive" }).toolbarMode).toBe("drive");
+    expect(mergeSettings({ toolbarMode: "newtab" }).toolbarMode).toBe("drive");
+    expect(mergeSettings({ toolbarMode: 42 }).toolbarMode).toBe("drive");
   });
 });
 
@@ -142,6 +161,16 @@ describe("Davflare Chrome extension / toolbar URL helper", () => {
       url: "http://localhost:8788",
     });
     expect(normalizeInstanceUrl("drive.example")).toBe("https://drive.example");
+  });
+
+  test("bookmark mode routes to the library page even before a URL is configured", () => {
+    expect(resolveToolbarTarget({ toolbarMode: "bookmarks" })).toEqual({
+      action: "bookmarks",
+    });
+    expect(
+      resolveToolbarTarget({ instanceUrl: "https://drive.example", toolbarMode: "bookmarks" })
+    ).toEqual({ action: "bookmarks" });
+    expect(resolveToolbarTarget({ toolbarMode: "drive" })).toEqual({ action: "options" });
   });
 });
 
@@ -176,7 +205,7 @@ describe("Davflare Chrome extension / release zips", () => {
     fs.rmSync(tmp, { recursive: true, force: true });
   });
 
-  test("default zip has no chrome_url_overrides and no newtab files", () => {
+  test("default zip has no chrome_url_overrides and ships the bookmark library", () => {
     const manifest = unzipManifest(defaultZip);
     const names = unzipList(defaultZip);
     expect(manifest.chrome_url_overrides).toBeUndefined();
@@ -188,6 +217,12 @@ describe("Davflare Chrome extension / release zips", () => {
     expect(names).toContain("manifest.json");
     expect(names).toContain("options.html");
     expect(names).toContain("background.js");
+    expect(names).toContain("bookmarks.html");
+    expect(names).toContain("bookmarks.css");
+    expect(names).toContain("bookmarksApp.js");
+    expect(names).toContain("bookmarksView.js");
+    expect(names).toContain("bookmarks.js");
+    expect(names).toContain("dav.js");
   });
 
   test("newtab zip includes chrome_url_overrides and newtab files", () => {

--- a/src/app/__tests__/extensionBookmarks.test.ts
+++ b/src/app/__tests__/extensionBookmarks.test.ts
@@ -1,0 +1,240 @@
+import { createRequire } from "module";
+
+const nodeRequire = createRequire(import.meta.url);
+
+type BookmarkRow = Record<string, unknown>;
+type BookmarkModel = { version: number; bookmarks: BookmarkRow[] };
+
+const Bookmarks = nodeRequire("../../../extension/bookmarks.js") as {
+  MODEL_VERSION: number;
+  addBookmark: (
+    model: unknown,
+    item: { title?: string; url?: string; folder?: string; tags?: string[]; note?: string; added?: number }
+  ) => { model: BookmarkModel; added: boolean };
+  adoptRichFields: (htmlModel: unknown, jsonModel: unknown) => BookmarkModel;
+  emptyModel: () => BookmarkModel;
+  isWebUrl: (url: unknown) => boolean;
+  isValidModel: (value: unknown) => boolean;
+  mergeModels: (base: unknown, incoming: unknown) => BookmarkModel;
+  modelFromJson: (text: string) => { ok: boolean; model: BookmarkModel };
+  modelToJsonText: (model: unknown) => string;
+  normalizeModel: (raw: unknown) => BookmarkModel;
+  parseHtml: (text: string) => BookmarkModel;
+  removeBookmark: (model: unknown, id: string) => BookmarkModel;
+  serializeHtml: (model: unknown) => string;
+  urlKey: (url: unknown) => string;
+};
+
+const CHROME_EXPORT = `<!DOCTYPE NETSCAPE-Bookmark-file-1>
+<META HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=UTF-8">
+<TITLE>Bookmarks</TITLE>
+<H1>Bookmarks</H1>
+<DL><p>
+    <DT><A HREF="https://root.example/" ADD_DATE="1690000900">Root Link</A>
+    <DT><H3 ADD_DATE="1690000000" PERSONAL_TOOLBAR_FOLDER="true">书签栏</H3>
+    <DL><p>
+        <DT><A HREF="https://example.com/" ADD_DATE="1690000100">Example</A>
+        <DT><A HREF="https://example.org/?q=1&amp;x=2" ADD_DATE="1690000200">A &amp; B</A>
+        <DT><A HREF="javascript:void(0)">bad</A>
+        <DT><H3 ADD_DATE="1690000300">Dev</H3>
+        <DL><p>
+            <DT><H3 ADD_DATE="1690000400">Rust</H3>
+            <DL><p>
+                <DT><A HREF="https://rust-lang.org" ADD_DATE="1690000500">Rust</A>
+            </DL><p>
+        </DL><p>
+    </DL><p>
+</DL><p>
+`;
+
+describe("extension/bookmarks.js parseHtml", () => {
+  test("flattens chrome-style exports into folder paths and epoch ms", () => {
+    const model = Bookmarks.parseHtml(CHROME_EXPORT);
+    expect(model.bookmarks).toHaveLength(4);
+    expect(model.bookmarks[0]).toMatchObject({
+      title: "Root Link",
+      url: "https://root.example/",
+      folder: "",
+      added: 1690000900000,
+    });
+    expect(model.bookmarks[1]).toMatchObject({
+      title: "Example",
+      url: "https://example.com/",
+      folder: "书签栏",
+      added: 1690000100000,
+    });
+    expect(model.bookmarks[2]).toMatchObject({
+      title: "A & B",
+      url: "https://example.org/?q=1&x=2",
+      folder: "书签栏",
+    });
+    expect(model.bookmarks[3]).toMatchObject({
+      title: "Rust",
+      url: "https://rust-lang.org",
+      folder: "书签栏/Dev/Rust",
+    });
+  });
+
+  test("keeps only http(s) links and tags every parsed bookmark as untagged", () => {
+    const model = Bookmarks.parseHtml(CHROME_EXPORT);
+    for (const item of model.bookmarks) {
+      expect(String(item.url)).toMatch(/^https?:\/\//);
+      expect(item.tags).toEqual([]);
+    }
+  });
+
+  test("root-level links land in the unfiled folder", () => {
+    const html = `<H1>Bookmarks</H1><DL><p><DT><A HREF="https://a.example" ADD_DATE="1">A</A></DL><p>`;
+    const model = Bookmarks.parseHtml(html);
+    expect(model.bookmarks[0].folder).toBe("");
+  });
+
+  test("empty or garbage input yields an empty model instead of throwing", () => {
+    expect(Bookmarks.parseHtml("")).toEqual({ version: 1, bookmarks: [] });
+    expect(Bookmarks.parseHtml("<p>not a bookmark file</p>")).toEqual({
+      version: 1,
+      bookmarks: [],
+    });
+  });
+});
+
+describe("extension/bookmarks.js serializeHtml", () => {
+  test("emits a Netscape header and escapes attributes and text", () => {
+    const html = Bookmarks.serializeHtml({
+      bookmarks: [
+        { id: "b1", title: 'He said "<hi>" & left', url: "https://a.com/?x=1&y=2", added: 1690000100123 },
+      ],
+    });
+    expect(html).toContain("<!DOCTYPE NETSCAPE-Bookmark-file-1>");
+    expect(html).toContain('<META HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=UTF-8">');
+    expect(html).toContain('HREF="https://a.com/?x=1&amp;y=2"');
+    expect(html).toContain('He said "&lt;hi&gt;" &amp; left');
+    expect(html).toContain('ADD_DATE="1690000100"');
+  });
+
+  test("round-trips urls, titles, and folders at second precision", () => {
+    const model = {
+      bookmarks: [
+        { id: "b1", title: "Root", url: "https://root.example", added: 1690000100123 },
+        { id: "b2", title: "Nested", url: "https://deep.example", folder: "书签栏/Dev", added: 1690000200000 },
+      ],
+    };
+    const parsed = Bookmarks.parseHtml(Bookmarks.serializeHtml(model));
+    expect(parsed.bookmarks).toHaveLength(2);
+    const byUrl = new Map(parsed.bookmarks.map((b) => [b.url, b]));
+    const root = byUrl.get("https://root.example") as Record<string, unknown>;
+    const deep = byUrl.get("https://deep.example") as Record<string, unknown>;
+    expect(root.title).toBe("Root");
+    expect(root.folder).toBe("");
+    expect(root.added).toBe(Math.floor(1690000100123 / 1000) * 1000);
+    expect(deep.folder).toBe("书签栏/Dev");
+  });
+
+  test("a serialized empty model still parses to an empty model", () => {
+    const parsed = Bookmarks.parseHtml(Bookmarks.serializeHtml(Bookmarks.emptyModel()));
+    expect(parsed.bookmarks).toHaveLength(0);
+  });
+});
+
+describe("extension/bookmarks.js urlKey", () => {
+  test("ignores fragments and normalizes the root trailing slash", () => {
+    expect(Bookmarks.urlKey("https://a.com/x#frag")).toBe(Bookmarks.urlKey("https://a.com/x"));
+    expect(Bookmarks.urlKey("http://a.com")).toBe(Bookmarks.urlKey("http://a.com/"));
+    expect(Bookmarks.urlKey("https://a.com/x")).not.toBe(Bookmarks.urlKey("https://a.com/y"));
+  });
+});
+
+describe("extension/bookmarks.js addBookmark / merge / remove", () => {
+  test("adds a valid page once and rejects duplicates and non-http urls", () => {
+    let model = Bookmarks.emptyModel();
+    const first = Bookmarks.addBookmark(model, { title: "A", url: "https://a.com", added: 1 });
+    expect(first.added).toBe(true);
+    model = first.model;
+    expect(Bookmarks.addBookmark(model, { title: "A2", url: "https://a.com#top" }).added).toBe(
+      false
+    );
+    expect(Bookmarks.addBookmark(model, { title: "JS", url: "javascript:alert(1)" }).added).toBe(
+      false
+    );
+    expect(model.bookmarks).toHaveLength(1);
+    expect(String(model.bookmarks[0].id)).toMatch(/^bm-[0-9a-z]+-[0-9a-z]+$/);
+  });
+
+  test("mergeModels keeps the base entry on URL collisions and appends the rest", () => {
+    const base = {
+      bookmarks: [{ id: "b1", title: "Keep", url: "https://a.com", tags: ["x"] }],
+    };
+    const incoming = {
+      bookmarks: [
+        { id: "b2", title: "Drop", url: "https://a.com/" },
+        { id: "b3", title: "New", url: "https://b.com" },
+      ],
+    };
+    const merged = Bookmarks.mergeModels(base, incoming);
+    expect(merged.bookmarks).toHaveLength(2);
+    expect(merged.bookmarks[0]).toMatchObject({ title: "Keep", tags: ["x"] });
+    expect(merged.bookmarks[1]).toMatchObject({ title: "New" });
+  });
+
+  test("removeBookmark drops only the matching id", () => {
+    const model = Bookmarks.normalizeModel({
+      bookmarks: [
+        { id: "b1", url: "https://a.com" },
+        { id: "b2", url: "https://b.com" },
+      ],
+    });
+    const next = Bookmarks.removeBookmark(model, "b1");
+    expect(next.bookmarks.map((b) => b.id)).toEqual(["b2"]);
+  });
+});
+
+describe("extension/bookmarks.js json sidecar", () => {
+  test("adoptRichFields re-attaches tags, note, and id by URL without importing json-only rows", () => {
+    const htmlModel = Bookmarks.parseHtml(
+      `<DL><p><DT><A HREF="https://a.com" ADD_DATE="1">A</A></DL><p>`
+    );
+    const jsonModel = Bookmarks.normalizeModel({
+      bookmarks: [
+        { id: "stable-1", url: "https://a.com/", tags: ["dev", "rust"], note: "docs" },
+        { id: "gone", url: "https://only-in-json.example", tags: ["ghost"] },
+      ],
+    });
+    const merged = Bookmarks.adoptRichFields(htmlModel, jsonModel);
+    expect(merged.bookmarks).toHaveLength(1);
+    expect(merged.bookmarks[0]).toMatchObject({
+      id: "stable-1",
+      tags: ["dev", "rust"],
+      note: "docs",
+    });
+  });
+
+  test("modelToJsonText / modelFromJson round-trip and reject garbage", () => {
+    const model = Bookmarks.normalizeModel({
+      bookmarks: [{ id: "b1", url: "https://a.com", title: "A", tags: ["t"] }],
+    });
+    const text = Bookmarks.modelToJsonText(model);
+    const back = Bookmarks.modelFromJson(text);
+    expect(back.ok).toBe(true);
+    expect(back.model.bookmarks[0]).toMatchObject({ id: "b1", tags: ["t"] });
+
+    expect(Bookmarks.modelFromJson("not json").ok).toBe(false);
+    expect(Bookmarks.modelFromJson('{"nope":1}').ok).toBe(false);
+    expect(Bookmarks.modelFromJson("").ok).toBe(false);
+  });
+
+  test("normalizeModel sanitizes junk rows and duplicate ids", () => {
+    const model = Bookmarks.normalizeModel({
+      bookmarks: [
+        { url: "https://a.com", tags: ["x", "x", "", 42] },
+        { url: "" },
+        null,
+      ],
+    });
+    expect(model.bookmarks).toHaveLength(1);
+    expect(model.bookmarks[0].tags).toEqual(["x"]);
+    expect(Bookmarks.isValidModel(model)).toBe(true);
+    expect(Bookmarks.isValidModel({ bookmarks: [] })).toBe(false);
+    expect(Bookmarks.isWebUrl("https://a.com")).toBe(true);
+    expect(Bookmarks.isWebUrl("chrome://settings")).toBe(false);
+  });
+});

--- a/src/app/__tests__/extensionBookmarksView.test.ts
+++ b/src/app/__tests__/extensionBookmarksView.test.ts
@@ -1,0 +1,133 @@
+import { createRequire } from "module";
+
+const nodeRequire = createRequire(import.meta.url);
+
+const BookmarksView = nodeRequire("../../../extension/bookmarksView.js") as {
+  domainOf: (url: unknown) => string;
+  fallbackLetter: (item: unknown) => string;
+  filterBookmarks: (
+    model: unknown,
+    opts?: { query?: string; folder?: string | null; tag?: string | null }
+  ) => Array<Record<string, unknown>>;
+  formatDate: (ms: number, lang?: string) => string;
+  formatBytes: (n: number) => string;
+  formatRelative: (ms: number, now: number, lang?: string) => string;
+  folderList: (model: unknown) => Array<{ name: string; count: number }>;
+  tagList: (model: unknown) => Array<{ name: string; count: number }>;
+};
+
+function modelWith(bookmarks: Array<Record<string, unknown>>) {
+  return { version: 1, bookmarks };
+}
+
+describe("extension/bookmarksView.js basics", () => {
+  test("domainOf keeps only http(s) hosts", () => {
+    expect(BookmarksView.domainOf("https://a.example/x")).toBe("a.example");
+    expect(BookmarksView.domainOf("http://b.example:8080/")).toBe("b.example");
+    expect(BookmarksView.domainOf("chrome://settings")).toBe("");
+    expect(BookmarksView.domainOf("not a url")).toBe("");
+    expect(BookmarksView.domainOf(null)).toBe("");
+  });
+
+  test("fallbackLetter prefers the title, then domain, then a placeholder", () => {
+    expect(BookmarksView.fallbackLetter({ title: "github home", url: "https://x.io" })).toBe("G");
+    expect(BookmarksView.fallbackLetter({ title: "", url: "https://docs.io" })).toBe("D");
+    expect(BookmarksView.fallbackLetter({ title: "", url: "" })).toBe("?");
+  });
+
+  test("formatBytes spans B / KB / MB", () => {
+    expect(BookmarksView.formatBytes(0)).toBe("0 B");
+    expect(BookmarksView.formatBytes(512)).toBe("512 B");
+    expect(BookmarksView.formatBytes(2048)).toBe("2.0 KB");
+    expect(BookmarksView.formatBytes(5 * 1024 * 1024)).toBe("5.00 MB");
+  });
+
+  test("formatRelative handles never / just now / minutes / hours / days in both languages", () => {
+    const now = Date.UTC(2026, 8, 5, 12, 0, 0);
+    expect(BookmarksView.formatRelative(0, now, "en")).toBe("never synced");
+    expect(BookmarksView.formatRelative(0, now, "zh")).toBe("从未同步");
+    expect(BookmarksView.formatRelative(now - 30_000, now, "zh")).toBe("刚刚");
+    expect(BookmarksView.formatRelative(now - 5 * 60_000, now, "en")).toBe("5m ago");
+    expect(BookmarksView.formatRelative(now - 3 * 3_600_000, now, "zh")).toBe("3 小时前");
+    expect(BookmarksView.formatRelative(now - 2 * 86_400_000, now, "en")).toBe("2d ago");
+    expect(BookmarksView.formatRelative(now - 40 * 86_400_000, now, "en")).toBe(
+      "2026/07/27"
+    );
+  });
+
+  test("formatDate renders yyyy/mm/dd or a placeholder", () => {
+    expect(BookmarksView.formatDate(Date.UTC(2026, 7, 24), "en")).toBe("2026/08/24");
+    expect(BookmarksView.formatDate(0, "zh")).toBe("未知");
+  });
+});
+
+describe("extension/bookmarksView.js folderList / tagList", () => {
+  test("folders keep unfiled first, then alphabetical, with counts", () => {
+    const folders = BookmarksView.folderList(
+      modelWith([
+        { folder: "Dev" },
+        { folder: "" },
+        { folder: "Dev" },
+        { folder: "Art" },
+      ])
+    );
+    expect(folders).toEqual([
+      { name: "", count: 1 },
+      { name: "Art", count: 1 },
+      { name: "Dev", count: 2 },
+    ]);
+  });
+
+  test("tags aggregate counts and sort by count desc then name", () => {
+    const tags = BookmarksView.tagList(
+      modelWith([
+        { tags: ["dev", "rust"] },
+        { tags: ["dev"] },
+        { tags: ["aigc"] },
+      ])
+    );
+    expect(tags).toEqual([
+      { name: "dev", count: 2 },
+      { name: "aigc", count: 1 },
+      { name: "rust", count: 1 },
+    ]);
+  });
+});
+
+describe("extension/bookmarksView.js filterBookmarks", () => {
+  const model = modelWith([
+    { id: "1", title: "Rust book", url: "https://doc.rust-lang.org", folder: "Dev", tags: ["rust", "docs"], note: "" },
+    { id: "2", title: "腾讯云", url: "https://cloud.tencent.com", folder: "Work", tags: ["infra"], note: "控制台" },
+    { id: "3", title: "Hoppscotch", url: "https://hoppscotch.io", folder: "Dev", tags: ["api"], note: "" },
+  ]);
+
+  test("matches the query against title, url, note, tags, and domain", () => {
+    const q = (query: string) =>
+      BookmarksView.filterBookmarks(model, { query }).map((b) => b.id);
+    expect(q("rust")).toEqual(["1"]);
+    expect(q("tencent")).toEqual(["2"]);
+    expect(q("控制台")).toEqual(["2"]);
+    expect(q("infra")).toEqual(["2"]);
+    expect(q("HOPPS")).toEqual(["3"]);
+    expect(q("no-such-thing")).toEqual([]);
+    expect(q("")).toHaveLength(3);
+  });
+
+  test("folder and tag filters narrow the list and combine with the query", () => {
+    const folder = BookmarksView.filterBookmarks(model, { folder: "Dev" });
+    expect(folder.map((b) => b.id)).toEqual(["1", "3"]);
+
+    const tag = BookmarksView.filterBookmarks(model, { tag: "rust" });
+    expect(tag.map((b) => b.id)).toEqual(["1"]);
+
+    const combined = BookmarksView.filterBookmarks(model, {
+      query: "book",
+      folder: "Dev",
+      tag: "rust",
+    });
+    expect(combined.map((b) => b.id)).toEqual(["1"]);
+
+    const miss = BookmarksView.filterBookmarks(model, { folder: "Dev", tag: "infra" });
+    expect(miss).toEqual([]);
+  });
+});

--- a/src/app/__tests__/extensionDav.test.ts
+++ b/src/app/__tests__/extensionDav.test.ts
@@ -1,0 +1,242 @@
+import { createRequire } from "module";
+
+const nodeRequire = createRequire(import.meta.url);
+
+const DavflareDav = nodeRequire("../../../extension/dav.js") as {
+  createDavClient: (options: Record<string, unknown>) => {
+    ensureDir: () => Promise<Resolved>;
+    getBookmarks: () => Promise<Resolved>;
+    paths: { root: string; dir: string; html: string; json: string };
+    probe: () => Promise<Resolved>;
+    putBookmarks: (payload: Record<string, unknown>) => Promise<Resolved>;
+  };
+};
+
+type Resolved = { ok: boolean; kind?: string; [key: string]: unknown };
+
+type MockReply = {
+  status: number;
+  body?: string;
+  etag?: string;
+};
+
+type MockCall = { url: string; init: RequestInit };
+
+function fetchMock(
+  handler: (url: string, init: RequestInit) => MockReply | Promise<MockReply>
+): { fetch: typeof fetch; calls: MockCall[] } {
+  const calls: MockCall[] = [];
+  const fn = async (url: unknown, init?: RequestInit): Promise<unknown> => {
+    calls.push({ url: String(url), init: init || {} });
+    const reply = await handler(String(url), init || {});
+    return {
+      status: reply.status,
+      ok: reply.status >= 200 && reply.status < 300,
+      text: async () => reply.body ?? "",
+      headers: {
+        get: (name: string) =>
+          name.toLowerCase() === "etag" ? reply.etag ?? null : null,
+      },
+    };
+  };
+  return { fetch: fn as unknown as typeof fetch, calls };
+}
+
+function clientWith(
+  overrides: Record<string, unknown>,
+  handler: (url: string, init: RequestInit) => MockReply | Promise<MockReply>
+) {
+  const mock = fetchMock(handler);
+  const client = DavflareDav.createDavClient({
+    instanceUrl: "https://drive.example",
+    username: "walter",
+    password: "s3cret",
+    fetchImpl: mock.fetch,
+    ...overrides,
+  });
+  return { client, calls: mock.calls };
+}
+
+const ROOT = "https://drive.example/webdav";
+const DIR = ROOT + "/bookmarks/";
+
+describe("extension/dav.js request basics", () => {
+  test("sends Basic auth to the /webdav endpoints", async () => {
+    const { client, calls } = clientWith({}, () => ({ status: 207 }));
+    await client.probe();
+    expect(calls).toHaveLength(1);
+    expect(calls[0].url).toBe(ROOT + "/");
+    const headers = calls[0].init.headers as Record<string, string>;
+    expect(headers.Authorization).toBe("Basic " + btoa("walter:s3cret"));
+    expect(headers.Depth).toBe("0");
+    expect(calls[0].init.method).toBe("PROPFIND");
+    expect(client.paths.dir).toBe(DIR);
+  });
+
+  test("non-ASCII credentials are utf-8 encoded into the auth header", async () => {
+    const { client, calls } = clientWith(
+      { username: "秋日", password: "密码" },
+      () => ({ status: 207 })
+    );
+    await client.probe();
+    const headers = calls[0].init.headers as Record<string, string>;
+    expect(headers.Authorization).toBe(
+      "Basic " + btoa(unescape(encodeURIComponent("秋日:密码")))
+    );
+  });
+
+  test("a missing instance URL or fetch means network kind, never a throw", async () => {
+    const noUrl = DavflareDav.createDavClient({
+      username: "u",
+      password: "p",
+      fetchImpl: fetchMock(() => ({ status: 207 })).fetch,
+    });
+    expect(await noUrl.probe()).toEqual({ ok: false, kind: "network" });
+
+    const { client } = clientWith(
+      {
+        fetchImpl: (() => {
+          throw new Error("boom");
+        }) as unknown as typeof fetch,
+      },
+      () => ({ status: 200 })
+    );
+    expect(await client.getBookmarks()).toEqual({ ok: false, kind: "network" });
+  });
+});
+
+describe("extension/dav.js probe", () => {
+  test("maps 207/404/401/403 to ok, disabled, unauthorized, notConfigured", async () => {
+    const ok = clientWith({}, () => ({ status: 207 }));
+    expect((await ok.client.probe()).ok).toBe(true);
+
+    const disabled = clientWith({}, () => ({ status: 404, body: "Not Found" }));
+    expect(await disabled.client.probe()).toEqual({ ok: false, kind: "disabled" });
+
+    const unauthorized = clientWith({}, () => ({ status: 401 }));
+    expect(await unauthorized.client.probe()).toEqual({ ok: false, kind: "unauthorized" });
+
+    const notConfigured = clientWith({}, () => ({ status: 403 }));
+    expect(await notConfigured.client.probe()).toEqual({
+      ok: false,
+      kind: "notConfigured",
+    });
+  });
+});
+
+describe("extension/dav.js getBookmarks", () => {
+  test("fetches html then json and returns both with the etag", async () => {
+    const { client, calls } = clientWith({}, (url) =>
+      url.endsWith("bookmarks.html")
+        ? { status: 200, body: "<DL><p></DL><p>", etag: '"abc123"' }
+        : { status: 200, body: '{"bookmarks":[]}' }
+    );
+    const res = await client.getBookmarks();
+    expect(res.ok).toBe(true);
+    expect(res).toMatchObject({
+      missing: false,
+      html: "<DL><p></DL><p>",
+      etag: '"abc123"',
+      jsonText: '{"bookmarks":[]}',
+    });
+    expect(calls.map((c) => c.url)).toEqual([DIR + "bookmarks.html", DIR + "bookmarks.json"]);
+  });
+
+  test("a 404 on the file with a healthy probe means first run, not a disabled flag", async () => {
+    const { client, calls } = clientWith({}, (_url, init) => {
+      const method = (init.method as string) || "GET";
+      if (method === "PROPFIND") return { status: 207 };
+      return { status: 404, body: "Not Found" };
+    });
+    const res = await client.getBookmarks();
+    expect(res).toMatchObject({ ok: true, missing: true, html: "" });
+    expect(calls[1].init.method).toBe("PROPFIND");
+  });
+
+  test("a 404 everywhere means the webdav flag is off", async () => {
+    const { client } = clientWith({}, () => ({ status: 404, body: "Not Found" }));
+    expect(await client.getBookmarks()).toEqual({ ok: false, kind: "disabled" });
+  });
+
+  test("auth failures surface as unauthorized / notConfigured", async () => {
+    const unauthorized = clientWith({}, () => ({ status: 401 }));
+    expect(await unauthorized.client.getBookmarks()).toEqual({
+      ok: false,
+      kind: "unauthorized",
+    });
+    const notConfigured = clientWith({}, () => ({ status: 403 }));
+    expect(await notConfigured.client.getBookmarks()).toEqual({
+      ok: false,
+      kind: "notConfigured",
+    });
+  });
+});
+
+describe("extension/dav.js putBookmarks", () => {
+  test("creates the folder (tolerating 405), puts html with If-Match, then json", async () => {
+    const { client, calls } = clientWith({}, (url, init) => {
+      const method = (init.method as string) || "";
+      if (method === "MKCOL") return { status: 405 };
+      if (url.endsWith("bookmarks.json")) return { status: 204 };
+      return { status: 204 };
+    });
+    const res = await client.putBookmarks({
+      html: "<DL><p></DL><p>",
+      json: '{"bookmarks":[]}',
+      etag: '"etag-1"',
+    });
+    expect(res).toEqual({ ok: true, jsonSaved: true });
+
+    const methods = calls.map((c) => (c.init.method as string) + " " + c.url);
+    expect(methods).toEqual([
+      "MKCOL " + DIR,
+      "PUT " + DIR + "bookmarks.html",
+      "PUT " + DIR + "bookmarks.json",
+    ]);
+    const htmlPut = calls[1].init.headers as Record<string, string>;
+    expect(htmlPut["If-Match"]).toBe('"etag-1"');
+    expect(htmlPut["Content-Type"]).toContain("text/html");
+    expect(calls[1].init.body).toBe("<DL><p></DL><p>");
+  });
+
+  test("no etag means no If-Match precondition", async () => {
+    const { client, calls } = clientWith({}, () => ({ status: 201 }));
+    await client.putBookmarks({ html: "x" });
+    const headers = calls[1].init.headers as Record<string, string>;
+    expect(headers["If-Match"]).toBeUndefined();
+  });
+
+  test("a 412 precondition failure maps to conflict without touching json", async () => {
+    const { client, calls } = clientWith({}, (_url, init) => {
+      if ((init.method as string) === "MKCOL") return { status: 405 };
+      return { status: 412 };
+    });
+    expect(await client.putBookmarks({ html: "x", json: "{}" })).toEqual({
+      ok: false,
+      kind: "conflict",
+    });
+    expect(calls).toHaveLength(2);
+  });
+
+  test("a failing json write is best-effort and still reports success", async () => {
+    const { client } = clientWith({}, (url) =>
+      url.endsWith("bookmarks.json") ? { status: 500 } : { status: 204 }
+    );
+    expect(await client.putBookmarks({ html: "x", json: "{}" })).toEqual({
+      ok: true,
+      jsonSaved: false,
+    });
+  });
+
+  test("a disabled webdav flag blocks the write before any PUT", async () => {
+    const { client, calls } = clientWith({}, (_url, init) => {
+      if ((init.method as string) === "MKCOL") return { status: 404 };
+      return { status: 204 };
+    });
+    expect(await client.putBookmarks({ html: "x" })).toEqual({
+      ok: false,
+      kind: "disabled",
+    });
+    expect(calls).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## 概要（薄书签 P2 · PR1/3 核心）

对齐既定拍板：工具栏双模式（网盘照旧 / 书签库，Options 设默认 + 图标右键快速切换）、页面右键一键收藏、Netscape `bookmarks.html`（权威可导入）+ `bookmarks.json`（旁路富字段）双写、凭据仅存 `chrome.storage.local`。

### 新增
- `extension/bookmarks.js`：Netscape 编解码（按 DL 层级文档序遍历，兼容 `<DL><p>` 解析怪癖）、URL 去重合并、`adoptRichFields` 保 json 富字段不丢
- `extension/dav.js`：Basic auth WebDAV 客户端——双写 PUT（html 带 If-Match、412 冲突映射、json best-effort）、MKCOL、探测；404=开关关 / 401=凭据错 / 403=未配置 / 412=冲突 / 0=网络 错误分类
- `extension/url.js`：`toolbarMode`（drive|bookmarks，默认 drive），向后兼容
- `extension/bookmarks{,App,View}.{js,html,css}`：HamHome 风格书签库页——侧栏（所有书签/分类/标签 + 计数）、搜索、网格/列表切换、明暗主题（跟随系统可记忆）、favicon（MV3 内置 _favicon）、本地缓存先渲染后刷新、导入（可选授权）/导出、存储占用 + 同步时间
- `extension/background.js`：双模式路由（书签页已开则聚焦复用）、右键「收藏此页」（activeTab 读标题/URL → 合并 → 双写 → badge/通知反馈）、action 右键切换默认模式
- options：默认模式、WebDAV 用户名/密码（local）、测试连接（三类错误文案）、保存实例时 `chrome.permissions.request` 按需授权

### manifest 1.2.0
- `permissions`: storage, **activeTab, contextMenus, favicon, notifications**
- `optional_permissions`: **bookmarks**（仅导入时授权）
- `optional_host_permissions`: http(s)（WebDAV fetch 按需授权）
- 仍无 popup、无 `chrome_url_overrides`；默认 zip / newtab zip 策略不变

### 测试
- 新增 `extensionBookmarks/extensionDav/extensionBookmarksView` 3 套件 47 例（createRequire 直测 + fetch mock）
- `extension.test.ts` manifest/settings/zip 断言同步更新
- 全量 792 测试通过，typecheck / 覆盖率棘轮 / 打包脚本（两 zip）验证通过

### 后续
- PR2/3：标签系统、本地增强搜索（拼音/模糊/过滤）、工作区、Tab 分组（本地规则引擎）、网页快照（存 WebDAV）

明确不做：AI（摘要/自动标签/分组/翻译/向量）、接管新标签页、独立 API、服务端改动。