### PR TITLE
feat: 扩展薄书签 P2/3——网页快照（存 WebDAV）

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,22 +216,35 @@ In the drive UI, **Sites** (`#/sites`) lists each slug with stats, one-click zip
 
 ## Extension
 
-A Chrome Manifest V3 helper that opens **your** Davflare instance. It is not on the Chrome Web Store.
+A Chrome Manifest V3 helper with two toolbar modes — open **your** Davflare drive, or a full bookmark library backed by your instance’s WebDAV. It is not on the Chrome Web Store.
 
 - Options: paste the URL of the Pages / custom-domain host you deployed. The field starts empty — there is no built-in site.
-- Toolbar click opens that URL. If it is unset, the toolbar opens Options instead.
+- **Toolbar modes:** *drive* (default, click opens your instance) or *bookmarks* (click opens the bookmark library page). Pick the default in Options; right-click the toolbar icon to switch anytime.
+- **Save this page** appears in the page context menu — it merges the current tab’s title + URL into your WebDAV bookmark file.
+- WebDAV credentials (same values as your deployment’s `WEBDAV_USERNAME` / `WEBDAV_PASSWORD`) are stored **only** in `chrome.storage.local`; they never sync to a Google account. Saving an instance URL asks for per-site host permission (optional permissions — nothing is pre-granted).
 - The **default** package does **not** change Chrome’s new tab. Chrome treats a new-tab override as permanent for as long as `chrome_url_overrides` is in the loaded manifest — an in-extension toggle cannot undo that.
 
 Two zips on the same GitHub Release:
 
 | Zip | What it does |
 | --- | --- |
-| `davflare-extension.zip` | Toolbar + options only. Load this unless you want Davflare as the new tab. |
+| `davflare-extension.zip` | Toolbar + options + bookmark library. Load this unless you want Davflare as the new tab. |
 | `davflare-extension-newtab.zip` | Same as default, plus a New Tab override that opens your instance. Separate download; do not expect this behavior from the default zip. |
 
 **Load unpacked (default, no new tab):** Chrome → `chrome://extensions` → Developer mode → Load unpacked → select the `extension/` folder in this repo.
 
 **Release zips:** download from [GitHub Releases](https://github.com/fanchenggang/Davflare/releases), unzip, then load unpacked. A tag (`v*` / `extension-*`) or **Actions → Release extension** attaches both zips.
+
+## Bookmarks (thin bookmarks P2)
+
+The extension’s bookmark library keeps your bookmarks **on your own WebDAV** — no third-party service, no AI. Requires the WebDAV feature switch to be on for your instance.
+
+- **Storage layout** (under your instance’s `/webdav/bookmarks/`): `bookmarks.html` is the authoritative Netscape bookmark file that Chrome/Edge can import directly; `bookmarks.json` is a sidecar carrying tags and notes that the HTML format cannot hold; `workspaces.json`, `tabGroups.json`, and `snapshots.json` hold the features below. Writes go through with `If-Match` (a 412 conflict is surfaced, never silently overwritten).
+- **Library page:** sidebar with folder/tag counts, keyword search over title/URL/tags/notes with **pinyin support** (full spelling and initials, thanks to a bundled compact dictionary), time-range filter, grid/list views, light/dark theme, import from Chrome bookmarks (optional `bookmarks` permission, merge by URL) and export to `bookmarks.html`.
+- **Workspaces:** save the current window — page order, pinned state, native tab-group metadata — and restore all or selected pages into a new window (duplicate URLs skipped, pinned/group state restored).
+- **Tab groups:** local rule engine (domain suffix / URL / title / regex, AND-combined) that groups the current window into native tab groups with custom title/color/collapse/priority; unmatched tabs can fall back to root-domain grouping. Rules sync via `tabGroups.json`.
+- **Snapshots:** capture the current page as a single self-contained HTML file (images best-effort inlined where CORS allows; scripts/iframes stripped; 8 MB cap) onto `bookmarks/snapshots/`. View, download, update, or delete from the bookmark editor. Cross-origin assets without CORS headers cannot be inlined (browser security), and restricted pages such as `chrome://` cannot be captured.
+- **Errors never fail silently:** a disabled WebDAV switch (404), missing server credentials (403), wrong credentials (401), and edit conflicts (412) each get a distinct message with a shortcut to Options.
 
 ## Image host
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -214,22 +214,35 @@ Cursor（`mcp.json`）：
 
 ## 扩展
 
-Chrome Manifest V3 辅助扩展，用来打开**你自己部署的** Davflare。不在 Chrome 网上应用店上架。
+Chrome Manifest V3 辅助扩展，双模式工具栏：打开**你自己部署的** Davflare 网盘，或打开由实例 WebDAV 支撑的书签库。不在 Chrome 网上应用店上架。
 
 - 选项页：粘贴你部署的 Pages / 自定义域名。默认空白，没有内置站点。
-- 点击工具栏图标打开该地址。未填写时改为打开选项页。
+- **工具栏双模式**：*网盘*（默认，点击打开实例）或 *书签*（点击打开书签库页）。在选项页设置默认模式，随时右键工具栏图标快速切换。
+- 页面右键菜单有「收藏此页」——把当前标签页的标题 + URL 合并进你 WebDAV 上的书签文件。
+- WebDAV 凭据（与部署时的 `WEBDAV_USERNAME` / `WEBDAV_PASSWORD` 一致）**仅**保存在 `chrome.storage.local`，不会同步到 Google 账号。保存实例地址时会按需申请该站点的 host 权限（可选权限，不预授权任何域名）。
 - **默认包不会改 Chrome 新标签页。** 只要已加载的 `manifest.json` 里有 `chrome_url_overrides`，Chrome 就会把新标签页当成被覆盖；扩展里再开关也无法恢复。
 
 同一 GitHub Release 附两个 zip：
 
 | Zip | 作用 |
 | --- | --- |
-| `davflare-extension.zip` | 仅工具栏 + 选项。不想改新标签页就装这个。 |
+| `davflare-extension.zip` | 工具栏 + 选项 + 书签库。不想改新标签页就装这个。 |
 | `davflare-extension-newtab.zip` | 默认包之外另加新标签页覆盖，打开你的实例。需单独下载；不要指望默认 zip 提供该行为。 |
 
 **加载未打包扩展（默认，不改新标签页）：** Chrome → `chrome://extensions` → 开发者模式 → 加载已解压的扩展程序 → 选本仓库的 `extension/` 目录。
 
 **Release zip：** 从 [GitHub Releases](https://github.com/fanchenggang/Davflare/releases) 下载后解压再按上面的方式加载。打 tag（`v*` / `extension-*`）或在 **Actions → Release extension** 里运行工作流会附上两个 zip。
+
+## 薄书签（P2）
+
+扩展的书签库把书签存在**你自己的 WebDAV 上**——不依赖第三方服务，不含任何 AI。要求实例的 WebDAV 功能开关已打开。
+
+- **存储布局**（实例 `/webdav/bookmarks/` 下）：`bookmarks.html` 是权威的 Netscape 书签文件，可直接用 Chrome/Edge「导入书签」；`bookmarks.json` 是旁路文件，承载 HTML 格式放不下的标签与备注；`workspaces.json`、`tabGroups.json`、`snapshots.json` 分别对应下面几个功能。写入带 `If-Match`，出现 412 冲突会明确提示重试，绝不静默覆盖。
+- **书签库页**：侧栏分类/标签计数；搜索覆盖标题/URL/标签/备注，**支持拼音**（全拼与首字母，内置精简字典）；时间范围筛选；网格/列表视图；明暗主题；从 Chrome 书签导入（可选 `bookmarks` 权限，按 URL 合并）与导出 `bookmarks.html`。
+- **工作区**：把当前窗口存为工作区——页面顺序、固定状态、原生标签组元数据——之后可全部或勾选恢复到新窗口（URL 去重，还原固定与分组）。
+- **Tab 分组**：本地规则引擎（域名后缀 / URL / 标题 / 正则，多条件 AND），一键把当前窗口收进原生标签组，可自定义标题/颜色/折叠/优先级；未命中可按根域名兜底。规则经 `tabGroups.json` 同步。
+- **快照**：把页面捕获为单文件 HTML（CORS 允许的图片尽力内联；剥离 script/iframe；8 MB 上限）存到 `bookmarks/snapshots/`，在书签编辑里查看、下载、更新、删除。无 CORS 头的跨域资源无法内联（浏览器安全限制），`chrome://` 等受限页无法捕获。
+- **错误不静默**：WebDAV 开关关闭（404）、服务端未配置凭据（403）、凭据错误（401）、编辑冲突（412）各有独立文案，并提供打开设置的入口。
 
 ## 图床
 

--- a/extension/bookmarks.css
+++ b/extension/bookmarks.css
@@ -662,6 +662,33 @@ dialog textarea {
   margin-top: 10px;
 }
 
+#snapSection {
+  margin-top: 16px;
+}
+
+#snapSection legend {
+  font-weight: 600;
+  font-size: 0.8125rem;
+  padding: 0;
+}
+
+.snapActions {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  margin-top: 8px;
+}
+
+.snapActions button {
+  font-size: 0.8125rem;
+  padding: 5px 12px;
+}
+
+.snapActions button:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
 /* ---------- workspaces ---------- */
 
 .wsList {

--- a/extension/bookmarks.html
+++ b/extension/bookmarks.html
@@ -121,6 +121,18 @@
         <input id="tagInput" type="text" spellcheck="false" placeholder="dev, docs" />
         <label for="noteInput" id="noteInputLabel">Note</label>
         <textarea id="noteInput" rows="3" spellcheck="false"></textarea>
+
+        <fieldset class="section" id="snapSection">
+          <legend id="snapLegend">Snapshot</legend>
+          <p id="snapInfo" class="status"></p>
+          <div class="snapActions">
+            <button id="snapCapture" class="primary" type="button">Capture</button>
+            <button id="snapView" class="ghost" type="button" disabled>View</button>
+            <button id="snapDownload" class="ghost" type="button" disabled>Download</button>
+            <button id="snapDelete" class="ghost" type="button" disabled>Delete</button>
+          </div>
+        </fieldset>
+
         <menu>
           <button id="tagCancel" class="ghost" type="button">Cancel</button>
           <button id="tagSave" class="primary" type="submit">Save</button>
@@ -193,6 +205,7 @@
     <script src="bookmarksView.js"></script>
     <script src="workspaces.js"></script>
     <script src="tabRules.js"></script>
+    <script src="snapshots.js"></script>
     <script src="bookmarksApp.js"></script>
   </body>
 </html>

--- a/extension/bookmarksApp.js
+++ b/extension/bookmarksApp.js
@@ -91,6 +91,20 @@ var COPY = {
     groupCurrentWindow: "Group current window",
     fallbackText: "Group the rest by domain",
     invalidName: "Enter a name.",
+    snapLegend: "Snapshot",
+    snapCapture: "Capture",
+    snapUpdate: "Re-capture",
+    snapView: "View",
+    snapDownload: "Download",
+    snapDelete: "Delete",
+    snapNone: "No snapshot yet. Captures the page as a single HTML file onto your WebDAV.",
+    snapCapturing: "Capturing…",
+    snapSaved: "Snapshot saved.",
+    snapCaptureFail: "Could not capture this page (restricted or failed to load).",
+    snapTooLarge: "Snapshot exceeds 8 MB and was not saved.",
+    snapMissing: "Snapshot file is missing on the server.",
+    snapConfirmDelete: "Delete this snapshot from WebDAV?",
+    snapDeleted: "Snapshot deleted.",
   },
   zh: {
     title: "Davflare 书签",
@@ -174,6 +188,20 @@ var COPY = {
     groupCurrentWindow: "按规则分组当前窗口",
     fallbackText: "未命中的按域名分组",
     invalidName: "请填写名称。",
+    snapLegend: "快照",
+    snapCapture: "生成快照",
+    snapUpdate: "更新快照",
+    snapView: "查看",
+    snapDownload: "下载",
+    snapDelete: "删除",
+    snapNone: "还没有快照。会把页面捕获为单文件 HTML 存到你的 WebDAV。",
+    snapCapturing: "捕获中…",
+    snapSaved: "快照已保存。",
+    snapCaptureFail: "无法捕获该页面（受限页面或加载失败）。",
+    snapTooLarge: "快照超过 8 MB，未保存。",
+    snapMissing: "服务器上的快照文件已缺失。",
+    snapConfirmDelete: "确定从 WebDAV 删除这个快照？",
+    snapDeleted: "快照已删除。",
   },
 };
 
@@ -208,11 +236,14 @@ var appState = {
   tabRules: { version: 1, fallbackDomain: true, rules: [] },
   rulesEtag: null,
   wsSelected: {},
+  snapshots: { version: 1, snapshots: [] },
+  snapshotsEtag: null,
 };
 
 var editingBookmarkId = null;
 var editingRuleId = null;
 var editingWsId = null;
+var tagDialogBookmark = null;
 var pendingConfirm = null;
 
 var lang =
@@ -1176,15 +1207,262 @@ async function submitRule(event) {
   if (await persistTabRules()) renderTabRules();
 }
 
+/* ---------- snapshots ---------- */
+
+var SNAP_FILE = "snapshots.json";
+var SNAPSHOT_MAX_BYTES = 8 * 1024 * 1024;
+
+/**
+ * Runs inside the captured page (MAIN world): best-effort inlines CORS-readable
+ * images as data URLs, strips scripts/iframes, returns the serialized HTML.
+ * Must stay fully self-contained — it is serialized, not closure-called.
+ */
+var PAGE_CAPTURE_FUNC = function () {
+  return (async function () {
+    var imgs = Array.prototype.slice.call(document.images || []).slice(0, 50);
+    await Promise.all(
+      imgs.map(function (img) {
+        if (!img || !img.src || img.src.indexOf("data:") === 0) return Promise.resolve();
+        return fetch(img.src, { mode: "cors", credentials: "omit" })
+          .then(function (res) {
+            return res.ok ? res.blob() : null;
+          })
+          .then(function (blob) {
+            if (!blob || blob.size > 2 * 1024 * 1024) return;
+            return new Promise(function (resolve) {
+              var reader = new FileReader();
+              reader.onload = function () {
+                img.src = String(reader.result);
+                resolve();
+              };
+              reader.onerror = function () {
+                resolve();
+              };
+              reader.readAsDataURL(blob);
+            });
+          })
+          .catch(function () {});
+      })
+    );
+    var root = document.documentElement ? document.documentElement.cloneNode(true) : null;
+    if (!root) return "";
+    var junk = root.querySelectorAll("script, iframe, noscript");
+    for (var i = 0; i < junk.length; i++) {
+      if (junk[i].parentNode) junk[i].parentNode.removeChild(junk[i]);
+    }
+    return "<!DOCTYPE html>" + root.outerHTML;
+  })();
+};
+
+function waitForTabComplete(tabId, timeoutMs) {
+  return new Promise(function (resolve, reject) {
+    var settled = false;
+    var listener = function (id, info) {
+      if (id === tabId && info && info.status === "complete") {
+        cleanup();
+        resolve();
+      }
+    };
+    function cleanup() {
+      if (settled) return;
+      settled = true;
+      try {
+        chrome.tabs.onUpdated.removeListener(listener);
+      } catch (err) {
+        /* listener already gone */
+      }
+    }
+    chrome.tabs.onUpdated.addListener(listener);
+    setTimeout(function () {
+      cleanup();
+      reject(new Error("snapshot tab timeout"));
+    }, timeoutMs);
+    chrome.tabs
+      .get(tabId)
+      .then(function (tab) {
+        if (tab && tab.status === "complete") {
+          cleanup();
+          resolve();
+        }
+      })
+      .catch(function () {});
+  });
+}
+
+function setSnapStatus(message) {
+  $("snapInfo").textContent = message || "";
+}
+
+async function loadSnapshots() {
+  var made = await makeClient();
+  if (!made.cfg.instanceUrl) return;
+  var res = await made.client.getFile(SNAP_FILE);
+  if (!res.ok) return;
+  appState.snapshotsEtag = res.etag;
+  var parsed = null;
+  if (res.text) {
+    try {
+      parsed = JSON.parse(res.text);
+    } catch (err) {
+      parsed = null;
+    }
+  }
+  appState.snapshots = Snapshots.normalize(parsed);
+}
+
+async function persistSnapshots() {
+  var made = await makeClient();
+  var put = await made.client.putFile(
+    SNAP_FILE,
+    JSON.stringify(appState.snapshots, null, 2),
+    "application/json; charset=utf-8",
+    appState.snapshotsEtag
+  );
+  if (put.ok) return true;
+  if (put.kind === "conflict") await loadSnapshots();
+  return false;
+}
+
+function renderSnapSection() {
+  var bookmark = tagDialogBookmark;
+  if (!bookmark) return;
+  var entry = Snapshots.findByBookmarkId(appState.snapshots, bookmark.id);
+  $("snapCapture").textContent = entry ? t.snapUpdate : t.snapCapture;
+  $("snapView").disabled = !entry;
+  $("snapDownload").disabled = !entry;
+  $("snapDelete").disabled = !entry;
+  if (entry) {
+    setSnapStatus(
+      BookmarksView.formatRelative(entry.capturedAt, Date.now(), lang) +
+        " · " +
+        BookmarksView.formatBytes(entry.size)
+    );
+  } else {
+    setSnapStatus(t.snapNone);
+  }
+}
+
+async function captureSnapshotFor(bookmark) {
+  if (!bookmark || !chrome.scripting) {
+    setSnapStatus(t.snapCaptureFail);
+    return;
+  }
+  setSnapStatus(t.snapCapturing);
+  await loadSnapshots();
+
+  var tab = await chrome.tabs.create({ url: bookmark.url, active: false });
+  var html = "";
+  try {
+    await waitForTabComplete(tab.id, 25000);
+    var results = await chrome.scripting.executeScript({
+      target: { tabId: tab.id },
+      world: "MAIN",
+      func: PAGE_CAPTURE_FUNC,
+    });
+    html =
+      results && results[0] && typeof results[0].result === "string"
+        ? results[0].result
+        : "";
+  } catch (err) {
+    setSnapStatus(t.snapCaptureFail);
+    return;
+  } finally {
+    chrome.tabs.remove(tab.id);
+  }
+  if (!html) {
+    setSnapStatus(t.snapCaptureFail);
+    return;
+  }
+  if (html.length > SNAPSHOT_MAX_BYTES) {
+    setSnapStatus(t.snapTooLarge);
+    return;
+  }
+
+  var made = await makeClient();
+  var id = Snapshots.makeId();
+  var put = await made.client.putFile(Snapshots.fileName(id), html, "text/html; charset=utf-8");
+  if (!put.ok) {
+    setSnapStatus(errorText(put.kind));
+    return;
+  }
+  appState.snapshots = Snapshots.upsert(appState.snapshots, {
+    id: id,
+    bookmarkId: bookmark.id,
+    url: bookmark.url,
+    title: bookmark.title,
+    capturedAt: Date.now(),
+    size: html.length,
+  });
+  var ok = await persistSnapshots();
+  setSnapStatus(ok ? t.snapSaved : t.errConflict);
+  renderSnapSection();
+}
+
+async function fetchSnapshotHtml(entry) {
+  var made = await makeClient();
+  var file = await made.client.getFile(Snapshots.fileName(entry.id));
+  if (!file.ok) {
+    setSnapStatus(errorText(file.kind));
+    return null;
+  }
+  if (file.missing) {
+    setSnapStatus(t.snapMissing);
+    return null;
+  }
+  return String(file.text || "");
+}
+
+async function viewSnapshot(entry) {
+  var html = await fetchSnapshotHtml(entry);
+  if (html === null) return;
+  var blob = new Blob([html], { type: "text/html" });
+  var url = URL.createObjectURL(blob);
+  chrome.tabs.create({ url: url });
+  setTimeout(function () {
+    URL.revokeObjectURL(url);
+  }, 5 * 60 * 1000);
+}
+
+async function downloadSnapshot(entry) {
+  var html = await fetchSnapshotHtml(entry);
+  if (html === null) return;
+  var blob = new Blob([html], { type: "text/html" });
+  var url = URL.createObjectURL(blob);
+  var a = document.createElement("a");
+  a.href = url;
+  a.download = entry.id + ".html";
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+  setTimeout(function () {
+    URL.revokeObjectURL(url);
+  }, 5000);
+}
+
+async function deleteSnapshot(entry) {
+  var made = await makeClient();
+  var del = await made.client.deleteFile(Snapshots.fileName(entry.id));
+  if (!del.ok) {
+    setSnapStatus(errorText(del.kind));
+    return;
+  }
+  appState.snapshots = Snapshots.remove(appState.snapshots, entry.id);
+  var ok = await persistSnapshots();
+  if (ok) setSnapStatus(t.snapDeleted);
+  renderSnapSection();
+}
+
 /* ---------- tag / note editing ---------- */
 
 function openTagDialog(item) {
   editingBookmarkId = item.id;
+  tagDialogBookmark = item;
   $("tagTarget").textContent = item.title || BookmarksView.domainOf(item.url) || item.url;
   $("tagInput").value = (Array.isArray(item.tags) ? item.tags : []).join(", ");
   $("noteInput").value = item.note || "";
   $("tagDialog").showModal();
   $("tagInput").focus();
+  loadSnapshots().then(renderSnapSection);
 }
 
 async function submitTagForm(event) {
@@ -1413,6 +1691,10 @@ function applyCopy() {
   $("applyGroupsBtn").textContent = t.groupCurrentWindow;
   $("ruleAddBtn").textContent = t.ruleAdd;
   $("fallbackText").textContent = t.fallbackText;
+  $("snapLegend").textContent = t.snapLegend;
+  $("snapView").textContent = t.snapView;
+  $("snapDownload").textContent = t.snapDownload;
+  $("snapDelete").textContent = t.snapDelete;
 }
 
 function setView(view) {
@@ -1471,6 +1753,30 @@ function wireEvents() {
     $("tagDialog").close();
   });
   $("tagForm").addEventListener("submit", submitTagForm);
+  $("snapCapture").addEventListener("click", function () {
+    captureSnapshotFor(tagDialogBookmark);
+  });
+  $("snapView").addEventListener("click", function () {
+    var entry =
+      tagDialogBookmark &&
+      Snapshots.findByBookmarkId(appState.snapshots, tagDialogBookmark.id);
+    if (entry) viewSnapshot(entry);
+  });
+  $("snapDownload").addEventListener("click", function () {
+    var entry =
+      tagDialogBookmark &&
+      Snapshots.findByBookmarkId(appState.snapshots, tagDialogBookmark.id);
+    if (entry) downloadSnapshot(entry);
+  });
+  $("snapDelete").addEventListener("click", function () {
+    var entry =
+      tagDialogBookmark &&
+      Snapshots.findByBookmarkId(appState.snapshots, tagDialogBookmark.id);
+    if (!entry) return;
+    confirmThen(t.snapConfirmDelete, function () {
+      deleteSnapshot(entry);
+    });
+  });
   $("wsNameCancel").addEventListener("click", function () {
     openWsNameDialog.pendingPages = null;
     $("wsNameDialog").close();

--- a/extension/bookmarksApp.js
+++ b/extension/bookmarksApp.js
@@ -1379,11 +1379,15 @@ async function captureSnapshotFor(bookmark) {
   }
 
   var made = await makeClient();
+  var previous = Snapshots.findByBookmarkId(appState.snapshots, bookmark.id);
   var id = Snapshots.makeId();
   var put = await made.client.putFile(Snapshots.fileName(id), html, "text/html; charset=utf-8");
   if (!put.ok) {
     setSnapStatus(errorText(put.kind));
     return;
+  }
+  if (previous && previous.id && previous.id !== id) {
+    await made.client.deleteFile(Snapshots.fileName(previous.id));
   }
   appState.snapshots = Snapshots.upsert(appState.snapshots, {
     id: id,

--- a/extension/dav.js
+++ b/extension/dav.js
@@ -130,6 +130,14 @@ var DavflareDav = (function () {
       return { ok: true };
     }
 
+    /** DELETE one file under bookmarks/; a missing file counts as deleted. */
+    async function deleteFile(fileName) {
+      var res = await request("DELETE", dir + fileName);
+      if (res.status === 0) return { ok: false, kind: "network" };
+      if (res.ok || res.status === 404) return { ok: true };
+      return { ok: false, kind: mapStatusKind(res.status) };
+    }
+
     async function getBookmarks() {
       var html = await getFile(HTML_PATH);
       if (!html.ok) return html;
@@ -171,6 +179,7 @@ var DavflareDav = (function () {
     }
 
     return {
+      deleteFile: deleteFile,
       ensureDir: ensureDir,
       getFile: getFile,
       getBookmarks: getBookmarks,

--- a/extension/dav.js
+++ b/extension/dav.js
@@ -93,6 +93,32 @@ var DavflareDav = (function () {
       return { ok: false, kind: mapStatusKind(res.status) };
     }
 
+    /**
+     * MKCOL bookmarks/ plus every intermediate folder in fileName
+     * (e.g. snapshots/ for snapshots/<id>.html). Server PUT returns 409
+     * when a parent collection is missing.
+     */
+    async function ensureParentDirs(fileName) {
+      var mk = await ensureDir();
+      if (!mk.ok) return mk;
+      var parts = String(fileName || "").split("/");
+      if (parts.length < 2) return { ok: true };
+      var prefix = "";
+      for (var i = 0; i < parts.length - 1; i++) {
+        var seg = parts[i];
+        if (!seg || seg === "." || seg === "..") {
+          return { ok: false, kind: "http400" };
+        }
+        prefix += seg + "/";
+        var res = await request("MKCOL", dir + prefix);
+        if (res.status === 0) return { ok: false, kind: "network" };
+        if (res.ok || res.status === 405) continue;
+        if (res.status === 404) return { ok: false, kind: "disabled" };
+        return { ok: false, kind: mapStatusKind(res.status) };
+      }
+      return { ok: true };
+    }
+
     async function getJsonText() {
       var res = await request("GET", dir + JSON_PATH);
       return res.status === 200 ? res.text : null;
@@ -116,7 +142,7 @@ var DavflareDav = (function () {
 
     /** PUT one file under bookmarks/; sends If-Match when an etag is given. */
     async function putFile(fileName, body, contentType, etag) {
-      var mk = await ensureDir();
+      var mk = await ensureParentDirs(fileName);
       if (!mk.ok) return mk;
       var headers = { "Content-Type": contentType };
       if (etag) headers["If-Match"] = etag;

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -32,7 +32,8 @@
     "favicon",
     "notifications",
     "tabs",
-    "tabGroups"
+    "tabGroups",
+    "scripting"
   ],
   "optional_permissions": ["bookmarks"],
   "optional_host_permissions": ["http://*/*", "https://*/*"]

--- a/extension/snapshots.js
+++ b/extension/snapshots.js
@@ -1,0 +1,108 @@
+"use strict";
+
+/**
+ * Snapshot index for the bookmark library. A snapshot is a captured HTML
+ * file stored on the user's WebDAV under bookmarks/snapshots/<id>.html;
+ * this module is the pure index (snapshots.json) — capture and I/O live in
+ * the page layer / dav.js.
+ */
+
+var Snapshots = (function () {
+  var MODEL_VERSION = 1;
+  var idCounter = 0;
+
+  function makeId() {
+    idCounter += 1;
+    return "snap-" + Date.now().toString(36) + "-" + idCounter.toString(36);
+  }
+
+  function asString(value) {
+    return typeof value === "string" ? value : "";
+  }
+
+  function sanitizeEntry(raw) {
+    var src = raw && typeof raw === "object" ? raw : {};
+    return {
+      id: asString(src.id),
+      bookmarkId: asString(src.bookmarkId),
+      url: asString(src.url),
+      title: asString(src.title),
+      capturedAt:
+        typeof src.capturedAt === "number" && isFinite(src.capturedAt) ? src.capturedAt : 0,
+      size: typeof src.size === "number" && isFinite(src.size) ? Math.max(0, Math.floor(src.size)) : 0,
+    };
+  }
+
+  function isValidEntry(entry) {
+    return Boolean(entry.id && entry.url);
+  }
+
+  function normalize(raw) {
+    if (!raw || typeof raw !== "object" || !Array.isArray(raw.snapshots)) {
+      return { version: MODEL_VERSION, snapshots: [] };
+    }
+    var clean = [];
+    for (var i = 0; i < raw.snapshots.length; i++) {
+      if (!raw.snapshots[i] || typeof raw.snapshots[i] !== "object") continue;
+      var entry = sanitizeEntry(raw.snapshots[i]);
+      if (isValidEntry(entry)) clean.push(entry);
+    }
+    return { version: MODEL_VERSION, snapshots: clean };
+  }
+
+  function fileName(id) {
+    return "snapshots/" + encodeURIComponent(id) + ".html";
+  }
+
+  function findByBookmarkId(model, bookmarkId) {
+    var list = normalize(model).snapshots;
+    for (var i = 0; i < list.length; i++) {
+      if (list[i].bookmarkId === bookmarkId) return list[i];
+    }
+    return null;
+  }
+
+  /** Adds or replaces the entry for one bookmark (a bookmark has at most one snapshot). */
+  function upsert(list, entry) {
+    var model = normalize(list);
+    var clean = sanitizeEntry(entry);
+    if (!isValidEntry(clean)) return model;
+    var out = [];
+    var replaced = false;
+    for (var i = 0; i < model.snapshots.length; i++) {
+      var current = model.snapshots[i];
+      if (clean.bookmarkId && current.bookmarkId === clean.bookmarkId) continue;
+      if (current.id === clean.id) {
+        out.push(clean);
+        replaced = true;
+      } else {
+        out.push(current);
+      }
+    }
+    if (!replaced) out.push(clean);
+    return { version: MODEL_VERSION, snapshots: out };
+  }
+
+  function remove(list, id) {
+    var model = normalize(list);
+    return {
+      version: MODEL_VERSION,
+      snapshots: model.snapshots.filter(function (entry) {
+        return entry.id !== id;
+      }),
+    };
+  }
+
+  return {
+    findByBookmarkId: findByBookmarkId,
+    fileName: fileName,
+    makeId: makeId,
+    normalize: normalize,
+    remove: remove,
+    upsert: upsert,
+  };
+})();
+
+if (typeof module !== "undefined" && module.exports) {
+  module.exports = Snapshots;
+}

--- a/src/app/__tests__/extension.test.ts
+++ b/src/app/__tests__/extension.test.ts
@@ -73,6 +73,7 @@ describe("Davflare Chrome extension / default package", () => {
       "notifications",
       "tabs",
       "tabGroups",
+      "scripting",
     ]);
     expect(manifest.optional_permissions).toEqual(["bookmarks"]);
     expect(manifest.host_permissions).toBeUndefined();
@@ -229,6 +230,7 @@ describe("Davflare Chrome extension / release zips", () => {
     expect(names).toContain("tabRules.js");
     expect(names).toContain("pinyin.js");
     expect(names).toContain("pinyinDict.js");
+    expect(names).toContain("snapshots.js");
   });
 
   test("newtab zip includes chrome_url_overrides and newtab files", () => {

--- a/src/app/__tests__/extensionDav.test.ts
+++ b/src/app/__tests__/extensionDav.test.ts
@@ -4,6 +4,7 @@ const nodeRequire = createRequire(import.meta.url);
 
 const DavflareDav = nodeRequire("../../../extension/dav.js") as {
   createDavClient: (options: Record<string, unknown>) => {
+    deleteFile: (fileName: string) => Promise<Resolved>;
     ensureDir: () => Promise<Resolved>;
     getBookmarks: () => Promise<Resolved>;
     getFile: (fileName: string) => Promise<Resolved>;
@@ -293,5 +294,27 @@ describe("extension/dav.js generic getFile / putFile", () => {
       ok: true,
     });
     expect((calls[1].init.headers as Record<string, string>)["If-Match"]).toBeUndefined();
+  });
+});
+
+describe("extension/dav.js deleteFile", () => {
+  test("maps 204/404 to ok and other statuses to kinds", async () => {
+    const gone = clientWith({}, () => ({ status: 204 }));
+    expect(await gone.client.deleteFile("snapshots/snap-1.html")).toEqual({ ok: true });
+
+    const missing = clientWith({}, () => ({ status: 404 }));
+    expect(await missing.client.deleteFile("snapshots/snap-1.html")).toEqual({ ok: true });
+
+    const denied = clientWith({}, () => ({ status: 401 }));
+    expect(await denied.client.deleteFile("snapshots/snap-1.html")).toEqual({
+      ok: false,
+      kind: "unauthorized",
+    });
+
+    const offline = clientWith({}, () => ({ status: 0 }));
+    expect(await offline.client.deleteFile("snapshots/snap-1.html")).toEqual({
+      ok: false,
+      kind: "network",
+    });
   });
 });

--- a/src/app/__tests__/extensionDav.test.ts
+++ b/src/app/__tests__/extensionDav.test.ts
@@ -177,7 +177,7 @@ describe("extension/dav.js getBookmarks", () => {
 
 describe("extension/dav.js putBookmarks", () => {
   test("creates the folder (tolerating 405), puts html with If-Match, then json", async () => {
-    const { client, calls } = clientWith({}, (url, init) => {
+    const { client, calls } = clientWith({}, (url: string, init) => {
       const method = (init.method as string) || "";
       if (method === "MKCOL") return { status: 405 };
       if (url.endsWith("bookmarks.json")) return { status: 204 };
@@ -271,7 +271,7 @@ describe("extension/dav.js generic getFile / putFile", () => {
   });
 
   test("putFile sends If-Match with the etag and maps 412 to conflict", async () => {
-    const { client, calls } = clientWith({}, (url, init) => {
+    const { client, calls } = clientWith({}, (url: string, init) => {
       if ((init.method as string) === "MKCOL") return { status: 201 };
       if (url.endsWith("tabGroups.json") && (init.headers as Record<string, string>)["If-Match"]) {
         return { status: 412 };
@@ -294,6 +294,21 @@ describe("extension/dav.js generic getFile / putFile", () => {
       ok: true,
     });
     expect((calls[1].init.headers as Record<string, string>)["If-Match"]).toBeUndefined();
+  });
+
+  test("putFile MKCOLs nested parent folders before PUT", async () => {
+    const { client, calls } = clientWith({}, (_url, init) => {
+      if ((init.method as string) === "MKCOL") return { status: 201 };
+      return { status: 201 };
+    });
+    expect(
+      await client.putFile("snapshots/snap-1.html", "<html></html>", "text/html; charset=utf-8")
+    ).toEqual({ ok: true });
+    expect(calls.map((c) => c.init.method + " " + c.url)).toEqual([
+      "MKCOL " + DIR,
+      "MKCOL " + DIR + "snapshots/",
+      "PUT " + DIR + "snapshots/snap-1.html",
+    ]);
   });
 });
 

--- a/src/app/__tests__/extensionSnapshots.test.ts
+++ b/src/app/__tests__/extensionSnapshots.test.ts
@@ -1,0 +1,67 @@
+import { createRequire } from "module";
+
+const nodeRequire = createRequire(import.meta.url);
+
+const Snapshots = nodeRequire("../../../extension/snapshots.js") as {
+  fileName: (id: string) => string;
+  findByBookmarkId: (model: unknown, bookmarkId: string) => Record<string, unknown> | null;
+  makeId: () => string;
+  normalize: (raw: unknown) => { snapshots: Array<Record<string, unknown>> };
+  remove: (list: unknown, id: string) => { snapshots: Array<Record<string, unknown>> };
+  upsert: (list: unknown, entry: Record<string, unknown>) => { snapshots: Array<Record<string, unknown>> };
+};
+
+const entry = (over: Record<string, unknown>) => ({
+  id: "snap-1",
+  bookmarkId: "bm-1",
+  url: "https://a.dev",
+  title: "A",
+  capturedAt: 1690000000000,
+  size: 1234,
+  ...over,
+});
+
+describe("extension/snapshots.js index", () => {
+  test("normalizes junk rows and requires id + url", () => {
+    expect(Snapshots.normalize(null)).toEqual({ version: 1, snapshots: [] });
+    const model = Snapshots.normalize({
+      snapshots: [
+        entry({}),
+        entry({ id: "", url: "https://a.dev" }),
+        entry({ id: "snap-2", url: "" }),
+        null,
+        { id: "snap-3", url: "https://b.dev", size: -5, capturedAt: "x" },
+      ],
+    });
+    expect(model.snapshots).toHaveLength(2);
+    expect(model.snapshots[0]).toMatchObject({ id: "snap-1", size: 1234 });
+    expect(model.snapshots[1]).toMatchObject({ id: "snap-3", size: 0, capturedAt: 0 });
+  });
+
+  test("upsert keeps at most one snapshot per bookmark and replaces by id", () => {
+    let model = Snapshots.normalize({ snapshots: [entry({})] });
+    model = Snapshots.upsert(model, entry({ id: "snap-9" }));
+    expect(model.snapshots).toHaveLength(1);
+    expect(model.snapshots[0].id).toBe("snap-9");
+
+    model = Snapshots.upsert(
+      model,
+      entry({ id: "snap-10", bookmarkId: "bm-2", url: "https://b.dev" })
+    );
+    expect(model.snapshots).toHaveLength(2);
+
+    // a fresh snapshot for bm-1 replaces the old entry entirely
+    model = Snapshots.upsert(model, entry({}));
+    expect(model.snapshots).toHaveLength(2);
+    expect(model.snapshots.map((s) => s.bookmarkId)).toEqual(["bm-2", "bm-1"]);
+  });
+
+  test("findByBookmarkId / remove / fileName", () => {
+    const model = Snapshots.normalize({ snapshots: [entry({})] });
+    expect(Snapshots.findByBookmarkId(model, "bm-1")).toMatchObject({ id: "snap-1" });
+    expect(Snapshots.findByBookmarkId(model, "bm-x")).toBeNull();
+    expect(Snapshots.remove(model, "snap-1").snapshots).toHaveLength(0);
+    expect(Snapshots.fileName("snap-1")).toBe("snapshots/snap-1.html");
+    expect(typeof Snapshots.makeId()).toBe("string");
+  });
+});


### PR DESCRIPTION
## 概要（薄书签 P2 · PR3/3，叠加在 #50 之上）

SingleFile 风格的网页快照（v1 仅 HTML，best-effort 保真度），数据存用户自己的 WebDAV。

### 新增
- **捕获管线**：编辑书签对话框点「生成快照」→ 后台标签页打开书签 URL → 等待加载完成 → `chrome.scripting`（MAIN world）注入采集 `outerHTML`；CORS 可读的图片 best-effort 内联为 data-URL（≤2MB/张），剥离 script/iframe/noscript；8MB 上限防误存
- **存储**：正文 PUT `bookmarks/snapshots/<id>.html`，索引 `bookmarks/snapshots.json`（一书签至多一份，重新捕获按 bookmarkId 替换），全部走既有 Basic auth + If-Match 语义
- **管理**：查看（扩展内 fetch 带 Basic auth → blob URL 新标签打开，无需手输凭据）、下载、删除（DELETE，404 视为已删除）；显示捕获时间与体积
- **dav.js**：新增通用 `deleteFile`

### manifest
- `permissions` 追加 **scripting**（注入捕获）

### 测试
- 新增 `extensionSnapshots` 套件（索引 normalize/upsert/findByBookmarkId/fileName）+ dav deleteFile 用例
- 全量 **821 测试**、typecheck、覆盖率棘轮全绿

### 已知限制（文档将注明）
- 跨域且无 CORS 头的图片/样式无法内联（浏览器安全限制），离线还原为尽力而为；受限页（chrome:// 等）无法捕获，提示明确错误