### PR TITLE
fix(扩展): 嵌套书签目录逐级 MKCOL（#60）

### DIFF
--- a/extension/dav.js
+++ b/extension/dav.js
@@ -89,12 +89,28 @@ var DavflareDav = (function () {
       return { ok: false, kind: res.kind || "network" };
     }
 
+    /**
+     * MKCOL the bookmark basePath segment-by-segment (issue #60).
+     * Nested paths like a/b/c need parents created first; a single MKCOL
+     * of the leaf returns 409 when an intermediate collection is missing.
+     * 405 = collection already exists (treated as success).
+     */
     async function ensureDir() {
-      var res = await request("MKCOL", dir);
-      if (res.status === 0) return { ok: false, kind: "network" };
-      if (res.ok || res.status === 405) return { ok: true };
-      if (res.status === 404) return { ok: false, kind: "disabled" };
-      return { ok: false, kind: mapStatusKind(res.status) };
+      var parts = basePath.split("/");
+      var prefix = "";
+      for (var i = 0; i < parts.length; i++) {
+        var seg = parts[i];
+        if (!seg || seg === "." || seg === "..") {
+          return { ok: false, kind: "http400" };
+        }
+        prefix += seg + "/";
+        var res = await request("MKCOL", root + "/" + prefix);
+        if (res.status === 0) return { ok: false, kind: "network" };
+        if (res.ok || res.status === 405) continue;
+        if (res.status === 404) return { ok: false, kind: "disabled" };
+        return { ok: false, kind: mapStatusKind(res.status) };
+      }
+      return { ok: true };
     }
 
     /**

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Davflare",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "Open your Davflare drive or bookmark library from the toolbar.",
   "icons": {
     "16": "icons/icon16.png",

--- a/src/app/__tests__/extensionDav.test.ts
+++ b/src/app/__tests__/extensionDav.test.ts
@@ -141,6 +141,89 @@ describe("extension/dav.js basePath (issue #54)", () => {
   });
 });
 
+describe("extension/dav.js ensureDir nested basePath (issue #60)", () => {
+  test("MKCOLs each basePath segment in order (a/ then a/b/)", async () => {
+    const { client, calls } = clientWith({ basePath: "a/b" }, (_url, init) => {
+      if ((init.method as string) === "MKCOL") return { status: 201 };
+      return { status: 204 };
+    });
+    expect(await client.ensureDir()).toEqual({ ok: true });
+    expect(calls.map((c) => (c.init.method as string) + " " + c.url)).toEqual([
+      "MKCOL " + ROOT + "/a/",
+      "MKCOL " + ROOT + "/a/b/",
+    ]);
+  });
+
+  test("treats 405 on an intermediate segment as already-exists and continues", async () => {
+    const { client, calls } = clientWith({ basePath: "qa/bookmarks" }, (url, init) => {
+      if ((init.method as string) === "MKCOL") {
+        // parent already there; create the leaf
+        if (url.endsWith("/qa/")) return { status: 405 };
+        return { status: 201 };
+      }
+      return { status: 204 };
+    });
+    expect(await client.ensureDir()).toEqual({ ok: true });
+    expect(calls.map((c) => (c.init.method as string) + " " + c.url)).toEqual([
+      "MKCOL " + ROOT + "/qa/",
+      "MKCOL " + ROOT + "/qa/bookmarks/",
+    ]);
+  });
+
+  test("putBookmarks MKCOLs nested basePath before PUT", async () => {
+    const nestedDir = ROOT + "/_pm_qa/bookmarks/";
+    const { client, calls } = clientWith({ basePath: "_pm_qa/bookmarks" }, (_url, init) => {
+      if ((init.method as string) === "MKCOL") return { status: 201 };
+      return { status: 204 };
+    });
+    expect(
+      await client.putBookmarks({ html: "<DL><p></DL><p>", json: '{"bookmarks":[]}' })
+    ).toEqual({ ok: true, jsonSaved: true });
+    expect(calls.map((c) => (c.init.method as string) + " " + c.url)).toEqual([
+      "MKCOL " + ROOT + "/_pm_qa/",
+      "MKCOL " + nestedDir,
+      "PUT " + nestedDir + "bookmarks.html",
+      "PUT " + nestedDir + "bookmarks.json",
+    ]);
+  });
+
+  test("putFile under nested basePath MKCOLs basePath segments then file parents", async () => {
+    const nestedDir = ROOT + "/a/b/";
+    const { client, calls } = clientWith({ basePath: "a/b" }, (_url, init) => {
+      if ((init.method as string) === "MKCOL") return { status: 201 };
+      return { status: 201 };
+    });
+    expect(
+      await client.putFile("snapshots/s1.html", "<html></html>", "text/html; charset=utf-8")
+    ).toEqual({ ok: true });
+    expect(calls.map((c) => (c.init.method as string) + " " + c.url)).toEqual([
+      "MKCOL " + ROOT + "/a/",
+      "MKCOL " + nestedDir,
+      "MKCOL " + nestedDir + "snapshots/",
+      "PUT " + nestedDir + "snapshots/s1.html",
+    ]);
+  });
+
+  test("a single MKCOL of a nested leaf would 409 — segmented create avoids it", async () => {
+    // Simulate a strict server: MKCOL fails with 409 when any parent is missing.
+    const created = new Set<string>();
+    const { client, calls } = clientWith({ basePath: "a/b/c" }, (url, init) => {
+      if ((init.method as string) !== "MKCOL") return { status: 204 };
+      const path = url.slice(ROOT.length); // e.g. /a/ or /a/b/
+      const parent = path.replace(/[^/]+\/$/, "");
+      if (parent !== "/" && !created.has(parent)) return { status: 409 };
+      created.add(path);
+      return { status: 201 };
+    });
+    expect(await client.ensureDir()).toEqual({ ok: true });
+    expect(calls.filter((c) => c.init.method === "MKCOL").map((c) => c.url)).toEqual([
+      ROOT + "/a/",
+      ROOT + "/a/b/",
+      ROOT + "/a/b/c/",
+    ]);
+  });
+});
+
 describe("extension/dav.js probe", () => {
   test("maps 207/404/401/403 to ok, disabled, unauthorized, notConfigured", async () => {
     const ok = clientWith({}, () => ({ status: 207 }));


### PR DESCRIPTION
## Summary
- `extension/dav.js` `ensureDir()` now MKCOLs each `basePath` segment in order (e.g. `a/` then `a/b/`), so nested bookmark directories no longer fail with 409 / “unexpected response”.
- Unit tests in `extensionDav.test.ts` cover segmented create, 405-on-parent continue, `putBookmarks` / `putFile` under nested paths, and a strict 409-without-parent server simulation.
- Bump extension manifest to **1.2.3** for the release zip/tag after merge.

Fixes #60

## Test plan
- [x] `tsc --noEmit`
- [x] `vitest run src/app/__tests__/extensionDav.test.ts` (26 passed)
- [ ] CI green
- [ ] After merge: tag `extension-v1.2.3`; QA retest nested Bookmark directory save (e.g. `_pm_qa_.../bookmarks`)