### PR TITLE
feat: 扩展书签导入导出改为文件（JSON/HTML）+ 收编 HamHome 一级入口

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -1,8 +1,26 @@
 # FlareDrive 回归测试清单
 
-> 最近一轮：2026-09-06 0a-9/0a-10（扩展设置并入主页 + 首次使用强制配置 + 删除 newtab 变体；书签库 UI 打磨 #57）
-> 前几轮：2026-09-05 0a-8（扩展网盘视图去 iframe，原生挂载 Web 端 React App）、2026-08-30 第三轮四批（Sites 管理面板 + MCP 深化 + davflare-cli）、2026-08-29 第六批（缺陷修复 + B5/B9/C9 收尾 + i18n 第二阶段收编 + 界面美化 + 单测/e2e 落地）、第五批（A9 i18n 第一阶段 + scripts/api-e2e.sh 回归套件沉淀）、第四批（多选拖拽/面包屑下拉/图标扩展）、第三批（目录分享/回收站清理/搜索高亮/动效 11 项）、第二批（目录级 API 等）、首批（暗色模式等）
+> 最近一轮：2026-09-06 0a-11（扩展书签导入导出改为文件 + 收编 HamHome 一级入口，issue #65）
+> 前几轮：2026-09-06 0a-10（扩展设置并入主页 + 首次使用强制配置 + 删除 newtab 变体；书签库 UI 打磨 #57）、2026-09-05 0a-8（扩展网盘视图去 iframe，原生挂载 Web 端 React App）、2026-08-30 第三轮四批（Sites 管理面板 + MCP 深化 + davflare-cli）、2026-08-29 第六批（缺陷修复 + B5/B9/C9 收尾 + i18n 第二阶段收编 + 界面美化 + 单测/e2e 落地）、第五批（A9 i18n 第一阶段 + scripts/api-e2e.sh 回归套件沉淀）、第四批（多选拖拽/面包屑下拉/图标扩展）、第三批（目录分享/回收站清理/搜索高亮/动效 11 项）、第二批（目录级 API 等）、首批（暗色模式等）
 > 约束：所有测试数据操作仅在自己创建的目录内进行，测试后清理。
+
+## 0a-11. 扩展书签导入导出改为文件 + 收编 HamHome 入口（issue #65，2026-09-06）
+
+「导入」从 Chrome bookmarks API 改为文件优先（JSON/HTML），导出补 JSON 完整备份，HamHome 独立一级入口收进导入对话框。
+
+### 改动
+| 项 | 内容 |
+|----|------|
+| 导入对话框 | 「⋯ 更多 → 导入」改为弹导入面板：主按钮「选择文件…（JSON / HTML）」走系统文件选择器（点不动问题闭环）；「从浏览器书签导入」（原一级行为，仍走 bookmarks 可选权限）与「从本实例 HamHomeSync 目录导入」（原独立 HamHome 一级按钮）收编为面板内次要选项；空态按钮从三收二（添加 / 导入） |
+| 格式识别 | `Bookmarks.sniffJsonImport` 按条目字段嗅探 JSON 归属（Davflare: folder/note/added/id；HamHome: categoryId/description/createdAt，裸数组也算 HamHome），`Bookmarks.importBackup` 统一入口吃 Davflare JSON / HamHome JSON（含内联 categories）/ Netscape HTML；`HamHome.importFrom` 支持直接传已解析对象 |
+| 导出对话框 | 「⋯ 更多 → 导出」弹导出面板：HTML（Netscape，浏览器可再导入）+ JSON（完整备份 davflare-bookmarks.json，含 folder/tags/note）；下载逻辑抽 `downloadText` 共用 |
+| 去重与文案 | 导入一律按 URL 合并去重（`mergeModels`），成功提示新增条数；解析失败/文件无书签分别有明确文案（importInvalid / importEmpty，显示在面板内） |
+
+### 待手动回归（Chrome 加载扩展）
+1. 「⋯ 更多 → 导入」弹面板；选 HamHome 导出的 meta.json（或含 categories 的合并 JSON）→ 提示导入条数，文件夹路径正确；选浏览器导出的 HTML → 导入成功。
+2. 重复导入同一文件 → 提示「没有需要导入的新书签」；选无关文件（乱码 JSON/无书签 HTML）→ 面板内明确报错。
+3. 「⋯ 更多 → 导出」分别下载 bookmarks.html 与 davflare-bookmarks.json；HTML 可被 Chrome 书签管理器再导入；JSON 重新导入后标签/备注/文件夹不丢。
+4. 侧栏「⋯ 更多」只剩导入/导出两项；空态只剩「添加 / 导入」；全 UI 无一级 HamHome 入口；导入面板内两个次要选项可用。
 
 ## 0a-10. 扩展书签库 UI 打磨（issue #57，借鉴 HamHome 观感；2026-09-06）
 

--- a/extension/bookmarks.css
+++ b/extension/bookmarks.css
@@ -861,6 +861,19 @@ dialog textarea {
   cursor: not-allowed;
 }
 
+/* import / export dialog sections (issue #65) */
+.dlgSection {
+  margin-top: 16px;
+  border: none;
+  padding: 0;
+}
+
+.dlgSection legend {
+  font-weight: 600;
+  font-size: 0.8125rem;
+  padding: 0;
+}
+
 /* ---------- drive view (embedded instance) ---------- */
 
 #viewDrive {

--- a/extension/bookmarks.html
+++ b/extension/bookmarks.html
@@ -47,7 +47,6 @@
               <button id="moreBtn" class="ghost menuToggle" type="button" aria-haspopup="true" aria-expanded="false">⋯ <span id="moreText">More</span></button>
               <div id="moreMenu" class="popMenu" role="menu">
                 <button id="importBtn" class="menuItem" type="button">Import</button>
-                <button id="hhImportBtn" class="menuItem" type="button">HamHome</button>
                 <button id="exportBtn" class="menuItem" type="button">Export</button>
               </div>
             </div>
@@ -211,6 +210,42 @@
         <menu>
           <button id="addCancel" class="ghost" type="button">Cancel</button>
           <button id="addSave" class="primary" type="submit">Add</button>
+        </menu>
+      </form>
+    </dialog>
+
+    <dialog id="importDialog">
+      <form id="importForm" novalidate>
+        <h2 id="importDialogTitle">Import bookmarks</h2>
+        <p id="importDesc" class="dialogSubtitle"></p>
+        <input id="importFile" type="file" accept=".json,.htm,.html,application/json,text/html" hidden />
+        <div class="snapActions" id="importFileRow">
+          <button id="importPick" class="primary" type="button"></button>
+        </div>
+        <fieldset class="dlgSection">
+          <legend id="importAltLegend"></legend>
+          <div class="snapActions">
+            <button id="importBrowserBtn" class="ghost" type="button"></button>
+            <button id="importHamHomeBtn" class="ghost" type="button"></button>
+          </div>
+        </fieldset>
+        <p id="importStatus" class="status err"></p>
+        <menu>
+          <button id="importCancel" class="ghost" type="button">Cancel</button>
+        </menu>
+      </form>
+    </dialog>
+
+    <dialog id="exportDialog">
+      <form id="exportForm" novalidate>
+        <h2 id="exportDialogTitle">Export bookmarks</h2>
+        <p id="exportDesc" class="dialogSubtitle"></p>
+        <div class="snapActions">
+          <button id="exportHtmlBtn" class="primary" type="button"></button>
+          <button id="exportJsonBtn" class="primary" type="button"></button>
+        </div>
+        <menu>
+          <button id="exportCancel" class="ghost" type="button">Cancel</button>
         </menu>
       </form>
     </dialog>

--- a/extension/bookmarks.js
+++ b/extension/bookmarks.js
@@ -329,6 +329,70 @@ var Bookmarks = (function () {
     return out;
   }
 
+  /**
+   * Issue #65: tell a Davflare backup JSON from a HamHome backup JSON before
+   * parsing. Both wrap a bookmarks array, but only Davflare entries carry
+   * folder/note/added while HamHome uses categoryId/description/createdAt —
+   * feeding HamHome data through modelFromJson would silently drop those
+   * fields. Bare arrays are HamHome's shape; version field alone decides for
+   * entries with no distinguishing keys (or an empty list).
+   * Returns {flavor: "davflare"|"hamhome", parsed} or null when the text is
+   * not a bookmark JSON at all.
+   */
+  function sniffJsonImport(text) {
+    var parsed;
+    try {
+      parsed = JSON.parse(String(text || ""));
+    } catch (err) {
+      return null;
+    }
+    if (!parsed || typeof parsed !== "object") return null;
+    var items = Array.isArray(parsed) ? parsed : parsed.bookmarks;
+    if (!Array.isArray(items)) return null;
+    for (var i = 0; i < items.length; i++) {
+      var item = items[i];
+      if (!item || typeof item !== "object") continue;
+      if ("categoryId" in item || "description" in item || "createdAt" in item) {
+        return { flavor: "hamhome", parsed: parsed };
+      }
+      if ("folder" in item || "note" in item || "added" in item || "id" in item) {
+        return { flavor: "davflare", parsed: parsed };
+      }
+    }
+    return { flavor: "davflare", parsed: parsed };
+  }
+
+  /**
+   * Parse one imported backup file into a model. Accepts Davflare JSON,
+   * HamHome JSON (meta.json shape, optionally with inline `categories`) and
+   * Netscape HTML; hamhome is injected because it loads after this file in
+   * the page. Returns {ok, model} or {ok: false, reason: "invalid"|"empty"}.
+   */
+  function importBackup(text, hamhome) {
+    var trimmed = String(text || "").replace(/^\uFEFF/, "").trim();
+    var model;
+    if (trimmed.charAt(0) === "{" || trimmed.charAt(0) === "[") {
+      var sniff = sniffJsonImport(trimmed);
+      if (!sniff) return { ok: false, reason: "invalid" };
+      if (sniff.flavor === "hamhome") {
+        var hh = hamhome.importFrom(
+          sniff.parsed,
+          sniff.parsed && !Array.isArray(sniff.parsed) ? sniff.parsed.categories : null
+        );
+        if (!hh.ok) return { ok: false, reason: "invalid" };
+        model = hh.model;
+      } else {
+        var parsed = modelFromJson(trimmed);
+        if (!parsed.ok) return { ok: false, reason: "invalid" };
+        model = parsed.model;
+      }
+    } else {
+      model = parseHtml(trimmed);
+    }
+    if (!model.bookmarks.length) return { ok: false, reason: "empty" };
+    return { ok: true, model: model };
+  }
+
   function modelToJsonText(model) {
     return JSON.stringify(normalizeModel(model), null, 2);
   }
@@ -351,6 +415,7 @@ var Bookmarks = (function () {
     addBookmark: addBookmark,
     adoptRichFields: adoptRichFields,
     emptyModel: emptyModel,
+    importBackup: importBackup,
     isWebUrl: isWebUrl,
     isValidModel: isValidModel,
     makeId: makeId,
@@ -361,6 +426,7 @@ var Bookmarks = (function () {
     parseHtml: parseHtml,
     removeBookmark: removeBookmark,
     serializeHtml: serializeHtml,
+    sniffJsonImport: sniffJsonImport,
     updateBookmark: updateBookmark,
     urlKey: urlKey,
   };

--- a/extension/bookmarksApp.js
+++ b/extension/bookmarksApp.js
@@ -6,7 +6,7 @@
  * pinyin.js; this file only touches chrome.* and the DOM.
  */
 
-/* global Bookmarks, BookmarksView, DavflareDav, Workspaces, TabRules, PinyinIndex, mergeSettings */
+/* global Bookmarks, BookmarksView, DavflareDav, Workspaces, TabRules, PinyinIndex, HamHome, mergeSettings */
 
 var COPY = {
   en: {
@@ -32,12 +32,25 @@ var COPY = {
     add: "Add",
     save: "Save",
     import: "Import",
-    hhImport: "HamHome",
     hhNotFound: "No bookmarks/meta.json found under /HamHomeSync/ on this instance.",
     hhInvalid: "HamHome data could not be parsed.",
     hhImported: "Imported {n} bookmark(s) from HamHome.",
     hhNone: "Nothing new to import from HamHome.",
     export: "Export",
+    importDialogTitle: "Import bookmarks",
+    importDesc:
+      "Pick a Davflare / HamHome JSON backup or a bookmarks HTML exported from your browser.",
+    importPick: "Choose file… (JSON / HTML)",
+    importAltLegend: "Other ways to import",
+    importBrowser: "From browser bookmarks",
+    importHamHomeSync: "From this instance's HamHomeSync folder",
+    importInvalid: "Could not parse this file as a bookmark backup.",
+    importEmpty: "No bookmarks found in this file.",
+    exportDialogTitle: "Export bookmarks",
+    exportDesc: "HTML can be re-imported by browsers; JSON keeps folders, tags and notes.",
+    exportHtmlAction: "HTML (browser-importable)",
+    exportJsonAction: "JSON (full backup)",
+    exportedJson: "Exported davflare-bookmarks.json.",
     drive: "Drive",
     driveReload: "Reload",
     driveOpenExternal: "Open in new tab",
@@ -80,9 +93,7 @@ var COPY = {
     probeOther: "The instance returned an unexpected response.",
     moreLabel: "More",
     emptyTitle: "Your library is empty",
-    emptyDesc: "Save your go-to pages, or import from your browser or HamHome.",
-    emptyImportBrowser: "Import browser bookmarks",
-    emptyImportHamHome: "Import from HamHome",
+    emptyDesc: "Save your go-to pages, or import a backup file.",
     clearFilter: "Clear filters",
     emptyFolderTitle: "No bookmarks in this folder yet",
     emptyTagTitle: "No bookmarks with this tag yet",
@@ -173,12 +184,24 @@ var COPY = {
     add: "添加",
     save: "保存",
     import: "导入",
-    hhImport: "HamHome",
     hhNotFound: "实例 /HamHomeSync/bookmarks/ 下没有 meta.json。",
     hhInvalid: "HamHome 数据无法解析。",
     hhImported: "已从 HamHome 导入 {n} 个书签。",
     hhNone: "HamHome 没有可导入的新书签。",
     export: "导出",
+    importDialogTitle: "导入书签",
+    importDesc: "选择 Davflare / HamHome 的 JSON 备份，或浏览器导出的书签 HTML 文件。",
+    importPick: "选择文件…（JSON / HTML）",
+    importAltLegend: "其他导入方式",
+    importBrowser: "从浏览器书签导入",
+    importHamHomeSync: "从本实例 HamHomeSync 目录导入",
+    importInvalid: "无法把这个文件解析成书签备份。",
+    importEmpty: "文件里没有找到可导入的书签。",
+    exportDialogTitle: "导出书签",
+    exportDesc: "HTML 可被浏览器重新导入；JSON 包含文件夹、标签与备注等完整信息。",
+    exportHtmlAction: "HTML（浏览器可导入）",
+    exportJsonAction: "JSON（完整备份）",
+    exportedJson: "已导出 davflare-bookmarks.json。",
     drive: "网盘",
     driveReload: "刷新",
     driveOpenExternal: "新标签页打开",
@@ -218,9 +241,7 @@ var COPY = {
     probeOther: "实例返回了未预期的响应。",
     moreLabel: "更多",
     emptyTitle: "书签库还是空的",
-    emptyDesc: "把常用页面存进来，或从浏览器 / HamHome 导入。",
-    emptyImportBrowser: "导入浏览器书签",
-    emptyImportHamHome: "从 HamHome 迁入",
+    emptyDesc: "把常用页面存进来，或导入一份备份文件。",
     clearFilter: "清除筛选",
     emptyFolderTitle: "该分类下还没有书签",
     emptyTagTitle: "该标签下还没有书签",
@@ -1093,8 +1114,7 @@ function renderItems() {
         desc: t.emptyDesc,
         actions: [
           { label: t.add, kind: "primary", onClick: openAddDialog },
-          { label: t.emptyImportBrowser, kind: "ghost", onClick: importChromeBookmarks },
-          { label: t.emptyImportHamHome, kind: "ghost", onClick: importHamHome },
+          { label: t.import, kind: "ghost", onClick: openImportDialog },
         ],
       });
     } else if (state.filter.kind === "folder") {
@@ -1996,19 +2016,74 @@ async function importHamHome() {
   if (ok) flashStatus(fmt(added > 0 ? t.hhImported : t.hhNone, { n: added }));
 }
 
-function exportHtml() {
-  var blob = new Blob([Bookmarks.serializeHtml(state.model)], { type: "text/html" });
+function downloadText(filename, mime, text) {
+  var blob = new Blob([text], { type: mime });
   var url = URL.createObjectURL(blob);
   var a = document.createElement("a");
   a.href = url;
-  a.download = "bookmarks.html";
+  a.download = filename;
   document.body.appendChild(a);
   a.click();
   a.remove();
   setTimeout(function () {
     URL.revokeObjectURL(url);
   }, 5000);
+}
+
+function exportHtml() {
+  downloadText("bookmarks.html", "text/html", Bookmarks.serializeHtml(state.model));
   flashStatus(t.exported);
+}
+
+function exportJson() {
+  downloadText(
+    "davflare-bookmarks.json",
+    "application/json",
+    Bookmarks.modelToJsonText(state.model)
+  );
+  flashStatus(t.exportedJson);
+}
+
+/* ---------- import dialog (issue #65) ---------- */
+
+function openImportDialog() {
+  $("importStatus").textContent = "";
+  $("importFile").value = "";
+  $("importDialog").showModal();
+}
+
+function openExportDialog() {
+  $("exportDialog").showModal();
+}
+
+/**
+ * File import (issue #65): read the picked backup file, merge it into the
+ * library by URL and report the count. JSON (Davflare or HamHome shape) and
+ * Netscape HTML are both accepted; detection lives in Bookmarks.importBackup.
+ */
+async function onImportFilePicked(event) {
+  var file = event.target.files && event.target.files[0];
+  event.target.value = "";
+  if (!file) return;
+  $("importStatus").textContent = "";
+  var text;
+  try {
+    text = await file.text();
+  } catch (err) {
+    $("importStatus").textContent = t.importInvalid;
+    return;
+  }
+  var res = Bookmarks.importBackup(text, HamHome);
+  if (!res.ok) {
+    $("importStatus").textContent = res.reason === "empty" ? t.importEmpty : t.importInvalid;
+    return;
+  }
+  var before = state.model.bookmarks.length;
+  state.model = Bookmarks.mergeModels(state.model, res.model);
+  var added = state.model.bookmarks.length - before;
+  $("importDialog").close();
+  var ok = await persist();
+  if (ok) flashStatus(fmt(added > 0 ? t.importDone : t.importNone, { n: added }));
 }
 
 /* ---------- dialogs ---------- */
@@ -2101,8 +2176,19 @@ function applyCopy() {
   $("loading").textContent = t.loading;
   $("addBtn").textContent = t.add;
   $("importBtn").textContent = t.import;
-  $("hhImportBtn").textContent = t.hhImport;
   $("exportBtn").textContent = t.export;
+  $("importDialogTitle").textContent = t.importDialogTitle;
+  $("importDesc").textContent = t.importDesc;
+  $("importPick").textContent = t.importPick;
+  $("importAltLegend").textContent = t.importAltLegend;
+  $("importBrowserBtn").textContent = t.importBrowser;
+  $("importHamHomeBtn").textContent = t.importHamHomeSync;
+  $("importCancel").textContent = t.cancel;
+  $("exportDialogTitle").textContent = t.exportDialogTitle;
+  $("exportDesc").textContent = t.exportDesc;
+  $("exportHtmlBtn").textContent = t.exportHtmlAction;
+  $("exportJsonBtn").textContent = t.exportJsonAction;
+  $("exportCancel").textContent = t.cancel;
   $("driveBtn").textContent = t.drive;
   $("settingsBtn").textContent = t.settings;
   $("moreText").textContent = t.moreLabel;
@@ -2284,9 +2370,34 @@ function wireEvents() {
     $("confirmDialog").close();
     if (fn) fn();
   });
-  $("importBtn").addEventListener("click", importChromeBookmarks);
-  $("hhImportBtn").addEventListener("click", importHamHome);
-  $("exportBtn").addEventListener("click", exportHtml);
+  $("importBtn").addEventListener("click", openImportDialog);
+  $("exportBtn").addEventListener("click", openExportDialog);
+  $("importPick").addEventListener("click", function () {
+    $("importFile").click();
+  });
+  $("importFile").addEventListener("change", onImportFilePicked);
+  $("importBrowserBtn").addEventListener("click", function () {
+    $("importDialog").close();
+    importChromeBookmarks();
+  });
+  $("importHamHomeBtn").addEventListener("click", function () {
+    $("importDialog").close();
+    importHamHome();
+  });
+  $("importCancel").addEventListener("click", function () {
+    $("importDialog").close();
+  });
+  $("exportHtmlBtn").addEventListener("click", function () {
+    $("exportDialog").close();
+    exportHtml();
+  });
+  $("exportJsonBtn").addEventListener("click", function () {
+    $("exportDialog").close();
+    exportJson();
+  });
+  $("exportCancel").addEventListener("click", function () {
+    $("exportDialog").close();
+  });
   $("settingsBtn").addEventListener("click", openSettings);
   $("saveWindowBtn").addEventListener("click", saveCurrentWindow);
   $("driveBtn").addEventListener("click", function () {

--- a/extension/hamhome.js
+++ b/extension/hamhome.js
@@ -17,7 +17,9 @@
 var HamHome = (function () {
   var MODEL_VERSION = 1;
 
+  /** Accepts an already-parsed object too (file import hands one over). */
   function parseJson(text) {
+    if (text && typeof text === "object") return text;
     try {
       return JSON.parse(String(text || ""));
     } catch (err) {

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Davflare",
-  "version": "1.2.3",
+  "version": "1.3.0",
   "description": "Open your Davflare drive or bookmark library from the toolbar.",
   "icons": {
     "16": "icons/icon16.png",

--- a/src/app/__tests__/extensionImportExport.test.ts
+++ b/src/app/__tests__/extensionImportExport.test.ts
@@ -1,0 +1,188 @@
+import { createRequire } from "module";
+
+const nodeRequire = createRequire(import.meta.url);
+
+type BookmarkRow = Record<string, unknown>;
+type BookmarkModel = { version: number; bookmarks: BookmarkRow[] };
+type ImportResult =
+  | { ok: true; model: BookmarkModel }
+  | { ok: false; reason: "invalid" | "empty" };
+
+const Bookmarks = nodeRequire("../../../extension/bookmarks.js") as {
+  importBackup: (text: string, hamhome: unknown) => ImportResult;
+  modelToJsonText: (model: unknown) => string;
+  normalizeModel: (raw: unknown) => BookmarkModel;
+  parseHtml: (text: string) => BookmarkModel;
+  sniffJsonImport: (
+    text: string
+  ) => { flavor: "davflare" | "hamhome"; parsed: unknown } | null;
+  urlKey: (url: unknown) => string;
+};
+
+const HamHome = nodeRequire("../../../extension/hamhome.js") as {
+  importFrom: (
+    meta: unknown,
+    categories: unknown
+  ) => { ok: boolean; model: BookmarkModel };
+};
+
+const DAVFLARE_JSON = JSON.stringify({
+  version: 1,
+  bookmarks: [
+    {
+      id: "bm-1",
+      title: "Docs",
+      url: "https://docs.example/",
+      folder: "Dev/Rust",
+      tags: ["dev"],
+      note: "handbook",
+      added: 1690000100000,
+    },
+  ],
+});
+
+const HAMHOME_JSON = JSON.stringify({
+  bookmarks: [
+    {
+      title: "Docs",
+      url: "https://docs.example/",
+      categoryId: "c1",
+      tags: ["dev"],
+      description: "handbook",
+      createdAt: 1690000100000,
+    },
+    {
+      title: "Deleted",
+      url: "https://gone.example/",
+      categoryId: "c2",
+      isDeleted: true,
+    },
+  ],
+  categories: [
+    { id: "c1", name: "Rust", parentId: "root" },
+    { id: "root", name: "Dev", parentId: null },
+  ],
+});
+
+describe("extension/bookmarks.js sniffJsonImport (issue #65)", () => {
+  test("detects Davflare and HamHome shapes", () => {
+    expect(Bookmarks.sniffJsonImport(DAVFLARE_JSON)?.flavor).toBe("davflare");
+    expect(Bookmarks.sniffJsonImport(HAMHOME_JSON)?.flavor).toBe("hamhome");
+    expect(
+      Bookmarks.sniffJsonImport('[{"url":"https://a.com","createdAt":1,"description":"x"}]')
+        ?.flavor
+    ).toBe("hamhome");
+  });
+
+  test("defaults plain or empty bookmark arrays to Davflare", () => {
+    expect(Bookmarks.sniffJsonImport('{"bookmarks":[{"url":"https://a.com"}]}')?.flavor).toBe(
+      "davflare"
+    );
+    expect(Bookmarks.sniffJsonImport('{"bookmarks":[]}')?.flavor).toBe("davflare");
+  });
+
+  test("rejects non-bookmark JSON", () => {
+    expect(Bookmarks.sniffJsonImport("not json")).toBeNull();
+    expect(Bookmarks.sniffJsonImport("<DL><p></DL><p>")).toBeNull();
+    expect(Bookmarks.sniffJsonImport('{"nope":1}')).toBeNull();
+  });
+});
+
+describe("extension/bookmarks.js importBackup (issue #65)", () => {
+  test("parses Davflare JSON with rich fields intact", () => {
+    const res = Bookmarks.importBackup(DAVFLARE_JSON, HamHome);
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.model.bookmarks[0]).toMatchObject({
+      id: "bm-1",
+      folder: "Dev/Rust",
+      tags: ["dev"],
+      note: "handbook",
+      added: 1690000100000,
+    });
+  });
+
+  test("parses HamHome JSON with inline categories, skipping deleted rows", () => {
+    const res = Bookmarks.importBackup(HAMHOME_JSON, HamHome);
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.model.bookmarks).toHaveLength(1);
+    expect(res.model.bookmarks[0]).toMatchObject({
+      title: "Docs",
+      url: "https://docs.example/",
+      folder: "Dev/Rust",
+      note: "handbook",
+      tags: ["dev"],
+      added: 1690000100000,
+    });
+  });
+
+  test("parses HamHome bare array without categories as unfiled", () => {
+    const res = Bookmarks.importBackup(
+      '[{"title":"A","url":"https://a.com","categoryId":"zz"}]',
+      HamHome
+    );
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.model.bookmarks[0]).toMatchObject({ url: "https://a.com", folder: "" });
+  });
+
+  test("parses Netscape HTML with folder paths", () => {
+    const res = Bookmarks.importBackup(
+      '<DL><p><DT><H3>Dev</H3><DL><p><DT><A HREF="https://a.com" ADD_DATE="1690000100">A</A></DL><p></DL><p>',
+      HamHome
+    );
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.model.bookmarks).toHaveLength(1);
+    expect(res.model.bookmarks[0]).toMatchObject({ url: "https://a.com", folder: "Dev" });
+  });
+
+  test("round-trips its own JSON export", () => {
+    const model = Bookmarks.normalizeModel({
+      bookmarks: [{ id: "b1", url: "https://a.com", title: "A", tags: ["t"] }],
+    });
+    const res = Bookmarks.importBackup(Bookmarks.modelToJsonText(model), HamHome);
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.model.bookmarks[0]).toMatchObject({ id: "b1", tags: ["t"] });
+    expect(Bookmarks.urlKey(res.model.bookmarks[0].url as string)).toBe(
+      Bookmarks.urlKey("https://a.com")
+    );
+  });
+
+  test("reports empty for files without bookmarks", () => {
+    expect(Bookmarks.importBackup("<p>hello world</p>", HamHome)).toMatchObject({
+      ok: false,
+      reason: "empty",
+    });
+    expect(Bookmarks.importBackup('{"bookmarks":[]}', HamHome)).toMatchObject({
+      ok: false,
+      reason: "empty",
+    });
+  });
+
+  test("reports invalid for broken JSON", () => {
+    expect(Bookmarks.importBackup("{oops", HamHome)).toMatchObject({
+      ok: false,
+      reason: "invalid",
+    });
+    expect(Bookmarks.importBackup('{"nope":1}', HamHome)).toMatchObject({
+      ok: false,
+      reason: "invalid",
+    });
+  });
+});
+
+describe("extension/hamhome.js object input (issue #65)", () => {
+  test("importFrom accepts already-parsed meta and categories", () => {
+    const res = HamHome.importFrom(
+      {
+        bookmarks: [{ title: "A", url: "https://a.com/", categoryId: "c1" }],
+      },
+      { categories: [{ id: "c1", name: "Docs", parentId: "" }] }
+    );
+    expect(res.ok).toBe(true);
+    expect(res.model.bookmarks[0]).toMatchObject({ url: "https://a.com/", folder: "Docs" });
+  });
+});


### PR DESCRIPTION
Closes #65

## 背景

#65 产品走查发现：「导入」直接走 Chrome `bookmarks` 可选权限，权限未授予时只显示 banner，看起来像点不动；侧栏「更多」里有独立的「HamHome」一级入口；「导出」只有 Netscape HTML。

## 改动

- **导入对话框**：「⋯ 更多 → 导入」弹出导入面板，主入口为系统文件选择器（JSON / HTML）；「从浏览器书签导入」「从本实例 HamHomeSync 目录导入」收为面板内次要选项。删除独立 `HamHome` 一级菜单项与空态「从 HamHome 迁入」按钮，空态收敛为「添加 / 导入」两按钮。
- **格式识别**（`Bookmarks.sniffJsonImport` + `Bookmarks.importBackup`）：
  - Davflare JSON（`{version, bookmarks:[{id,title,url,folder,tags,note,added}]}`）
  - HamHome JSON（meta.json 形态：裸数组或 `{bookmarks:[…]}`，支持内联 `categories`，沿用 `hamhome.js` 字段映射，跳过 `isDeleted` 行）
  - Netscape HTML（Chrome/Firefox/Edge 导出）
  - 按条目字段嗅探归属（`folder/note/added/id` vs `categoryId/description/createdAt`），避免 HamHome 数据误走 `modelFromJson` 丢掉 folder/note/added
- **导出对话框**：Netscape HTML（浏览器可再导入）+ Davflare JSON 完整备份（`davflare-bookmarks.json`，含 folder/tags/note，可再导入）。
- **合并策略**：一律按 URL 合并去重（`mergeModels`），成功提示新增条数；解析失败 / 文件无书签在面板内分别给明确文案。
- `HamHome.importFrom` 支持直接传已解析对象（文件导入场景）。
- manifest 升至 1.3.0（便于合并后打 release tag）。

## 测试

- 新增 `src/app/__tests__/extensionImportExport.test.ts`（11 例）：格式嗅探、三类文件导入、HamHome 内联 categories 路径解析、自产 JSON 往返、空文件/损坏文件文案。
- 全量 `npm test`：76 套件 / 856 用例全绿。
- 手动回归清单见 TESTING.md 0a-11。

## 验收对照（#65）

- [x] 点「导入」必有反应：弹导入方式面板
- [x] HamHome 导出的 JSON / 浏览器导出的 HTML 能导入书签库
- [x] 导出 JSON + HTML 各一份可下载
- [x] UI 无单独「HamHome」菜单项/空态按钮