### PR TITLE
fix(扩展): 大库下右键收藏反馈与弹窗/库页性能 (#68 #69)

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -4,6 +4,7 @@ importScripts("url.js", "bookmarks.js", "dav.js");
 
 var MENU_SAVE = "davflare-save-page";
 var MENU_MODE = "davflare-toggle-mode";
+var CACHE_KEY = "bookmarksCache";
 
 var MESSAGES = {
   en: {
@@ -12,6 +13,7 @@ var MESSAGES = {
     saveOk: "Bookmark saved to your library.",
     saveExists: "This page is already in your library.",
     skipPage: "Only http(s) pages can be saved.",
+    needConfig: "Configure your instance URL and WebDAV credentials in settings first.",
     modeTitle: "Default home view switched",
     modeDrive: "The home page will open your drive.",
     modeBookmarks: "The home page will open your bookmark library.",
@@ -22,6 +24,7 @@ var MESSAGES = {
     saveOk: "已收藏到书签库。",
     saveExists: "该页面已在书签库中。",
     skipPage: "只能收藏 http(s) 页面。",
+    needConfig: "请先在设置里配置实例地址与 WebDAV 凭据。",
     modeTitle: "主页默认视图已切换",
     modeDrive: "插件主页将打开网盘。",
     modeBookmarks: "插件主页将打开书签库。",
@@ -39,6 +42,10 @@ var ERROR_COPY = {
     zh: "WebDAV 用户名或密码错误，请在书签库的设置里检查。",
   },
   network: { en: "Cannot reach the instance.", zh: "无法连接实例。" },
+  timeout: {
+    en: "The instance timed out (large library or slow network). Try again.",
+    zh: "实例响应超时（库较大或网络慢），请重试。",
+  },
   conflict: {
     en: "The library changed elsewhere. Please retry.",
     zh: "书签库已在别处更新，请重试。",
@@ -55,24 +62,40 @@ function t() {
 
 function errorText(kind) {
   var known = ERROR_COPY[kind];
-  return known ? known[pickLang()] : "HTTP " + kind;
+  if (known) return known[pickLang()];
+  if (kind && String(kind).indexOf("http") === 0) {
+    var code = String(kind).slice(4);
+    return pickLang() === "zh"
+      ? "实例返回了未预期的响应（HTTP " + code + "）。"
+      : "Unexpected response from the instance (HTTP " + code + ").";
+  }
+  return pickLang() === "zh"
+    ? "实例返回了未预期的响应。"
+    : "Unexpected response from the instance.";
 }
 
 function flashBadge(text) {
-  chrome.action.setBadgeText({ text: text });
-  setTimeout(function () {
-    chrome.action.setBadgeText({ text: "" });
-  }, 2500);
+  try {
+    chrome.action.setBadgeBackgroundColor({ color: text === "!" ? "#c62828" : "#2e7d32" });
+    chrome.action.setBadgeText({ text: text });
+    setTimeout(function () {
+      chrome.action.setBadgeText({ text: "" });
+    }, 2500);
+  } catch (err) {
+    /* badge is best-effort */
+  }
 }
 
 function notify(title, message) {
   try {
     chrome.notifications.create(
+      "davflare-save-" + String(Date.now()),
       {
         type: "basic",
-        iconUrl: "icons/icon128.png",
+        iconUrl: chrome.runtime.getURL("icons/icon128.png"),
         title: title,
         message: message,
+        priority: 2,
       },
       function () {
         void chrome.runtime.lastError;
@@ -81,6 +104,16 @@ function notify(title, message) {
   } catch (err) {
     /* notifications are best-effort feedback */
   }
+}
+
+function failFeedback(message) {
+  flashBadge("!");
+  notify(t().errTitle, message);
+}
+
+function okFeedback(message) {
+  flashBadge("✓");
+  notify(t().appTitle, message);
 }
 
 async function loadConfig() {
@@ -95,6 +128,36 @@ async function loadConfig() {
   };
 }
 
+async function readBookmarksCache() {
+  var stored = await chrome.storage.local.get([CACHE_KEY]);
+  var cache = stored && stored[CACHE_KEY];
+  if (!cache || !cache.model) return null;
+  return cache;
+}
+
+async function writeBookmarksCache(model, etag) {
+  var normalized = Bookmarks.normalizeModel(model);
+  var payload = {};
+  payload[CACHE_KEY] = {
+    model: normalized,
+    etag: etag || null,
+    syncedAt: Date.now(),
+    bytes:
+      Bookmarks.serializeHtml(normalized).length +
+      Bookmarks.modelToJsonText(normalized).length,
+  };
+  await chrome.storage.local.set(payload);
+}
+
+function parseRemoteLibrary(res) {
+  var model = Bookmarks.parseHtml(res.html || "");
+  if (res.jsonText) {
+    var parsed = Bookmarks.modelFromJson(res.jsonText);
+    if (parsed.ok) model = Bookmarks.adoptRichFields(model, parsed.model);
+  }
+  return model;
+}
+
 async function toggleDefaultMode() {
   var stored = await chrome.storage.sync.get(["toolbarMode"]);
   var next = mergeSettings(stored).toolbarMode === "bookmarks" ? "drive" : "bookmarks";
@@ -103,32 +166,77 @@ async function toggleDefaultMode() {
   notify(copy.modeTitle, next === "bookmarks" ? copy.modeBookmarks : copy.modeDrive);
 }
 
+/**
+ * Context-menu / fallback quick-save (#68).
+ *
+ * MV3 service workers are killed if the click listener does not return the
+ * async work as a Promise — previously savePage was fire-and-forget, so a
+ * large-library GET could be aborted mid-flight with no notification and no
+ * write. We also prefer the local bookmarksCache (+ etag) so the common path
+ * does not wait on a full Netscape re-download before PUT.
+ */
 async function savePage(tab) {
   var copy = t();
+  flashBadge("…");
   var url = (tab && tab.url) || "";
   var title = (tab && tab.title) || "";
   if (!Bookmarks.isWebUrl(url)) {
-    flashBadge("!");
-    notify(copy.errTitle, copy.skipPage);
-    return;
-  }
-  var client = DavflareDav.createDavClient(await loadConfig());
-  var res = await client.getBookmarks();
-  if (!res.ok) {
-    flashBadge("!");
-    notify(copy.errTitle, errorText(res.kind));
+    failFeedback(copy.skipPage);
     return;
   }
 
-  var model = Bookmarks.parseHtml(res.html || "");
-  if (res.jsonText) {
-    var parsed = Bookmarks.modelFromJson(res.jsonText);
-    if (parsed.ok) model = Bookmarks.adoptRichFields(model, parsed.model);
+  var cfg = await loadConfig();
+  if (!cfg.instanceUrl) {
+    failFeedback(copy.needConfig);
+    return;
   }
+
+  var client = DavflareDav.createDavClient(cfg);
+  var cache = await readBookmarksCache();
+  var cachedModel = cache && cache.model ? Bookmarks.normalizeModel(cache.model) : null;
+  var cachedEtag = cache && cache.etag ? cache.etag : null;
+
+  if (cachedModel) {
+    var early = Bookmarks.addBookmark(cachedModel, {
+      title: title,
+      url: url,
+      added: Date.now(),
+    });
+    if (!early.added) {
+      okFeedback(copy.saveExists);
+      return;
+    }
+
+    // Fast path: PUT against the cached etag (If-Match). Conflict → re-GET.
+    if (cachedEtag) {
+      var putCached = await client.putBookmarks({
+        html: Bookmarks.serializeHtml(early.model),
+        json: Bookmarks.modelToJsonText(early.model),
+        etag: cachedEtag,
+      });
+      if (putCached.ok) {
+        await writeBookmarksCache(early.model, putCached.etag || null);
+        okFeedback(copy.saveOk);
+        return;
+      }
+      if (putCached.kind !== "conflict") {
+        failFeedback(errorText(putCached.kind));
+        return;
+      }
+    }
+  }
+
+  var res = await client.getBookmarks();
+  if (!res.ok) {
+    failFeedback(errorText(res.kind));
+    return;
+  }
+
+  var model = parseRemoteLibrary(res);
   var add = Bookmarks.addBookmark(model, { title: title, url: url, added: Date.now() });
   if (!add.added) {
-    flashBadge("✓");
-    notify(copy.appTitle, copy.saveExists);
+    await writeBookmarksCache(model, res.etag || null);
+    okFeedback(copy.saveExists);
     return;
   }
 
@@ -138,12 +246,11 @@ async function savePage(tab) {
     etag: res.etag,
   });
   if (!put.ok) {
-    flashBadge("!");
-    notify(copy.errTitle, errorText(put.kind));
+    failFeedback(errorText(put.kind));
     return;
   }
-  flashBadge("✓");
-  notify(copy.appTitle, copy.saveOk);
+  await writeBookmarksCache(add.model, put.etag || null);
+  okFeedback(copy.saveOk);
 }
 
 // 工具栏左键点击由 popup.html（收藏弹窗）接管；右键菜单保留一键收藏与主页默认视图切换。
@@ -168,13 +275,12 @@ async function quickSaveCurrentPage() {
 }
 
 chrome.commands.onCommand.addListener(function (command) {
-  if (command === "save-current-page") quickSaveCurrentPage();
+  if (command === "save-current-page") return quickSaveCurrentPage();
 });
 
 /* ---------- omnibox (#62 P1): "df <query>" searches the cached library ---------- */
 
 var OMNI_LIMIT = 6;
-var CACHE_KEY = "bookmarksCache";
 
 function xmlEscape(text) {
   return String(text == null ? "" : text)
@@ -185,8 +291,7 @@ function xmlEscape(text) {
 }
 
 async function cachedBookmarksModel() {
-  var stored = await chrome.storage.local.get([CACHE_KEY]);
-  var cache = stored && stored[CACHE_KEY];
+  var cache = await readBookmarksCache();
   return cache && cache.model ? cache.model : { bookmarks: [] };
 }
 
@@ -258,36 +363,42 @@ chrome.omnibox.onInputEntered.addListener(async function (text, disposition) {
   }
 });
 
+// Return the Promise so MV3 keeps the service worker alive until save finishes (#68).
 chrome.contextMenus.onClicked.addListener(function (info, tab) {
   if (info.menuItemId === MENU_MODE) {
-    toggleDefaultMode();
-    return;
+    return toggleDefaultMode();
   }
   if (info.menuItemId === MENU_SAVE) {
-    savePage(tab);
+    return savePage(tab);
   }
 });
 
-chrome.runtime.onInstalled.addListener(function () {
+function ensureContextMenus() {
   var zh = pickLang() === "zh";
-  chrome.contextMenus.create(
-    {
-      id: MENU_SAVE,
-      title: zh ? "收藏此页到 Davflare" : "Save page to Davflare",
-      contexts: ["page"],
-    },
-    function () {
-      void chrome.runtime.lastError;
-    }
-  );
-  chrome.contextMenus.create(
-    {
-      id: MENU_MODE,
-      title: zh ? "切换插件主页默认视图" : "Switch default home view",
-      contexts: ["action"],
-    },
-    function () {
-      void chrome.runtime.lastError;
-    }
-  );
-});
+  chrome.contextMenus.removeAll(function () {
+    void chrome.runtime.lastError;
+    chrome.contextMenus.create(
+      {
+        id: MENU_SAVE,
+        title: zh ? "收藏此页到 Davflare" : "Save page to Davflare",
+        contexts: ["page"],
+      },
+      function () {
+        void chrome.runtime.lastError;
+      }
+    );
+    chrome.contextMenus.create(
+      {
+        id: MENU_MODE,
+        title: zh ? "切换插件主页默认视图" : "Switch default home view",
+        contexts: ["action"],
+      },
+      function () {
+        void chrome.runtime.lastError;
+      }
+    );
+  });
+}
+
+chrome.runtime.onInstalled.addListener(ensureContextMenus);
+chrome.runtime.onStartup.addListener(ensureContextMenus);

--- a/extension/bookmarksApp.js
+++ b/extension/bookmarksApp.js
@@ -107,7 +107,9 @@ var COPY = {
     errUnauthorized: "Wrong WebDAV username or password. Update them in settings.",
     errNetwork: "Cannot reach the instance. Check the URL in settings.",
     errConflict: "Changed elsewhere — reloaded the remote copy. Please retry.",
+    errTimeout: "The instance timed out (large library or slow network). Try again.",
     errOther: "The instance returned an unexpected response.",
+    retry: "Retry",
     invalidUrl: "Enter a valid http(s) URL.",
     exists: "This URL is already in the library.",
     added: "Saved.",
@@ -255,7 +257,9 @@ var COPY = {
     errUnauthorized: "WebDAV 用户名或密码错误，请在设置中更新。",
     errNetwork: "无法连接实例，请在设置中检查地址。",
     errConflict: "内容已在别处更新——已重新加载远端，请重试。",
+    errTimeout: "实例响应超时（库较大或网络慢），请重试。",
     errOther: "实例返回了未预期的响应。",
+    retry: "重试",
     invalidUrl: "请填写有效的 http(s) 地址。",
     exists: "该地址已在书签库中。",
     added: "已保存。",
@@ -317,6 +321,7 @@ var ERROR_KEY = {
   notConfigured: "errNotConfigured",
   unauthorized: "errUnauthorized",
   network: "errNetwork",
+  timeout: "errTimeout",
   conflict: "errConflict",
 };
 
@@ -378,7 +383,14 @@ function folderLabel(name) {
 
 function errorText(kind) {
   var key = ERROR_KEY[kind];
-  return key ? t[key] : t.errOther;
+  if (key) return t[key];
+  if (kind && String(kind).indexOf("http") === 0) {
+    var code = String(kind).slice(4);
+    return lang === "zh"
+      ? "实例返回了未预期的响应（HTTP " + code + "）。"
+      : "Unexpected response from the instance (HTTP " + code + ").";
+  }
+  return t.errOther;
 }
 
 /* ---------- theme ---------- */
@@ -436,6 +448,7 @@ function saveCache() {
   var payload = {};
   payload[CACHE_KEY] = {
     model: state.model,
+    etag: state.etag || null,
     syncedAt: state.syncedAt,
     bytes: state.bytes,
   };
@@ -447,6 +460,7 @@ function renderFromCache() {
     var cache = stored && stored[CACHE_KEY];
     if (cache && cache.model) {
       state.model = Bookmarks.normalizeModel(cache.model);
+      state.etag = cache.etag || null;
       state.syncedAt = cache.syncedAt || 0;
       state.bytes = cache.bytes || 0;
       renderAll();
@@ -456,6 +470,22 @@ function renderFromCache() {
 
 function computeBytes() {
   return Bookmarks.serializeHtml(state.model).length + Bookmarks.modelToJsonText(state.model).length;
+}
+
+function showLibraryError(kind) {
+  // Auth/config problems → settings; everything else → retry (#69).
+  if (
+    kind === "unauthorized" ||
+    kind === "notConfigured" ||
+    kind === "disabled" ||
+    kind === "network"
+  ) {
+    showBanner(errorText(kind), t.openSettings, openSettings);
+  } else {
+    showBanner(errorText(kind), t.retry, function () {
+      refresh();
+    });
+  }
 }
 
 async function refresh() {
@@ -468,9 +498,15 @@ async function refresh() {
       renderAll();
       return;
     }
-    var res = await made.client.getBookmarks();
+    var getOpts = state.etag ? { ifNoneMatch: state.etag } : {};
+    var res = await made.client.getBookmarks(getOpts);
     if (!res.ok) {
-      showBanner(errorText(res.kind), t.openSettings, openSettings);
+      showLibraryError(res.kind);
+      renderAll();
+      return;
+    }
+    if (res.notModified) {
+      hideBanner();
       renderAll();
       return;
     }
@@ -485,6 +521,9 @@ async function refresh() {
     state.syncedAt = Date.now();
     saveCache();
     hideBanner();
+    renderAll();
+  } catch (err) {
+    showLibraryError("network");
     renderAll();
   } finally {
     $("loading").classList.add("hidden");
@@ -503,6 +542,7 @@ async function persist() {
     etag: state.etag,
   });
   if (put.ok) {
+    if (put.etag) state.etag = put.etag;
     state.bytes = computeBytes();
     state.syncedAt = Date.now();
     saveCache();

--- a/extension/dav.js
+++ b/extension/dav.js
@@ -7,20 +7,27 @@
  * open, so page contexts and the service worker can both call it). Error
  * kinds mirror what the instance can actually return:
  *   network        — fetch threw or no instance URL
+ *   timeout        — AbortController fired (large library / slow network)
  *   disabled       — webdav feature flag off (404 before auth)
  *   notConfigured  — server lacks WEBDAV_USERNAME/PASSWORD (403)
  *   unauthorized   — wrong credentials (401)
  *   conflict       — If-Match precondition failed (412)
- *   httpNNN        — anything else
+ *   httpNNN        — anything else (callers should surface the status)
  */
 
 var DavflareDav = (function () {
   var HTML_PATH = "bookmarks.html";
   var JSON_PATH = "bookmarks.json";
+  // Large libraries (900+ bookmarks) can take a while over WebDAV; keep a
+  // generous default so genuine slow GETs finish, while still failing loud
+  // instead of hanging the MV3 service worker forever (#68 / #69).
+  var DEFAULT_TIMEOUT_MS = 45000;
 
   function mapStatusKind(status) {
+    if (!status) return "network";
     if (status === 401) return "unauthorized";
     if (status === 403) return "notConfigured";
+    if (status === 412) return "conflict";
     return "http" + status;
   }
 
@@ -36,6 +43,10 @@ var DavflareDav = (function () {
     var username = String(opts.username || "");
     var password = String(opts.password || "");
     var fetchImpl = opts.fetchImpl || (typeof fetch === "function" ? fetch : null);
+    var defaultTimeoutMs =
+      typeof opts.timeoutMs === "number" && isFinite(opts.timeoutMs)
+        ? opts.timeoutMs
+        : DEFAULT_TIMEOUT_MS;
 
     function authHeader() {
       return "Basic " + btoa(unescape(encodeURIComponent(username + ":" + password)));
@@ -49,14 +60,37 @@ var DavflareDav = (function () {
       var headers = { Authorization: authHeader() };
       var keys = Object.keys(extra.headers || {});
       for (var i = 0; i < keys.length; i++) headers[keys[i]] = extra.headers[keys[i]];
+
+      var timeoutMs =
+        typeof extra.timeoutMs === "number" && isFinite(extra.timeoutMs)
+          ? extra.timeoutMs
+          : defaultTimeoutMs;
+      var controller = null;
+      var timer = null;
       try {
-        var res = await fetchImpl(url, {
+        var init = {
           method: method,
           headers: headers,
           body: extra.body,
-        });
+        };
+        if (
+          timeoutMs > 0 &&
+          typeof AbortController === "function"
+        ) {
+          controller = new AbortController();
+          init.signal = controller.signal;
+          timer = setTimeout(function () {
+            try {
+              controller.abort();
+            } catch (abortErr) {
+              /* ignore */
+            }
+          }, timeoutMs);
+        }
+        var res = await fetchImpl(url, init);
         var text = "";
-        if (method === "GET" || method === "PROPFIND") {
+        // 304 has no body; skip reading. GET/PROPFIND otherwise need the payload.
+        if (res.status !== 304 && (method === "GET" || method === "PROPFIND")) {
           try {
             text = await res.text();
           } catch (err) {
@@ -77,7 +111,18 @@ var DavflareDav = (function () {
           etag: etag,
         };
       } catch (err) {
-        return { status: 0, ok: false, kind: "network", text: "", etag: null };
+        var aborted =
+          (err && err.name === "AbortError") ||
+          (controller && controller.signal && controller.signal.aborted);
+        return {
+          status: 0,
+          ok: false,
+          kind: aborted ? "timeout" : "network",
+          text: "",
+          etag: null,
+        };
+      } finally {
+        if (timer) clearTimeout(timer);
       }
     }
 
@@ -86,7 +131,9 @@ var DavflareDav = (function () {
       var res = await request("PROPFIND", root + "/", { headers: { Depth: "0" } });
       if (res.ok) return { ok: true };
       if (res.status === 404) return { ok: false, kind: "disabled" };
-      return { ok: false, kind: res.kind || "network" };
+      var out = { ok: false, kind: res.kind || "network" };
+      if (res.status) out.status = res.status;
+      return out;
     }
 
     /**
@@ -105,10 +152,10 @@ var DavflareDav = (function () {
         }
         prefix += seg + "/";
         var res = await request("MKCOL", root + "/" + prefix);
-        if (res.status === 0) return { ok: false, kind: "network" };
+        if (res.status === 0) return { ok: false, kind: res.kind || "network" };
         if (res.ok || res.status === 405) continue;
         if (res.status === 404) return { ok: false, kind: "disabled" };
-        return { ok: false, kind: mapStatusKind(res.status) };
+        return { ok: false, kind: mapStatusKind(res.status), status: res.status };
       }
       return { ok: true };
     }
@@ -131,32 +178,38 @@ var DavflareDav = (function () {
         }
         prefix += seg + "/";
         var res = await request("MKCOL", dir + prefix);
-        if (res.status === 0) return { ok: false, kind: "network" };
+        if (res.status === 0) return { ok: false, kind: res.kind || "network" };
         if (res.ok || res.status === 405) continue;
         if (res.status === 404) return { ok: false, kind: "disabled" };
-        return { ok: false, kind: mapStatusKind(res.status) };
+        return { ok: false, kind: mapStatusKind(res.status), status: res.status };
       }
       return { ok: true };
-    }
-
-    async function getJsonText() {
-      var res = await request("GET", dir + JSON_PATH);
-      return res.status === 200 ? res.text : null;
     }
 
     /**
      * GET one file under bookmarks/. A 404 is ambiguous (missing file vs
      * feature flag off), so probe the root to disambiguate.
+     * Pass options.headers (e.g. If-None-Match) for conditional GET (#69).
      */
-    async function getFile(fileName) {
-      var res = await request("GET", dir + fileName);
-      if (res.status === 0) return { ok: false, kind: "network" };
+    async function getFile(fileName, options) {
+      options = options || {};
+      var res = await request("GET", dir + fileName, { headers: options.headers || {} });
+      if (res.status === 0) return { ok: false, kind: res.kind || "network" };
+      if (res.status === 304) {
+        return {
+          ok: true,
+          notModified: true,
+          missing: false,
+          text: null,
+          etag: res.etag || (options.headers && options.headers["If-None-Match"]) || null,
+        };
+      }
       if (res.status === 404) {
         var probeRes = await probe();
         if (!probeRes.ok) return probeRes;
         return { ok: true, missing: true, text: null, etag: null };
       }
-      if (!res.ok) return { ok: false, kind: res.kind };
+      if (!res.ok) return { ok: false, kind: res.kind, status: res.status };
       return { ok: true, missing: false, text: res.text, etag: res.etag };
     }
 
@@ -170,24 +223,63 @@ var DavflareDav = (function () {
         body: String(body == null ? "" : body),
         headers: headers,
       });
-      if (res.status === 0) return { ok: false, kind: "network" };
+      if (res.status === 0) return { ok: false, kind: res.kind || "network" };
       if (res.status === 412) return { ok: false, kind: "conflict" };
-      if (!res.ok) return { ok: false, kind: res.kind };
-      return { ok: true };
+      if (!res.ok) return { ok: false, kind: res.kind, status: res.status };
+      return { ok: true, etag: res.etag };
     }
 
     /** DELETE one file under bookmarks/; a missing file counts as deleted. */
     async function deleteFile(fileName) {
       var res = await request("DELETE", dir + fileName);
-      if (res.status === 0) return { ok: false, kind: "network" };
+      if (res.status === 0) return { ok: false, kind: res.kind || "network" };
       if (res.ok || res.status === 404) return { ok: true };
-      return { ok: false, kind: mapStatusKind(res.status) };
+      return { ok: false, kind: mapStatusKind(res.status), status: res.status };
     }
 
-    async function getBookmarks() {
-      var html = await getFile(HTML_PATH);
-      if (!html.ok) return html;
-      var jsonText = await getJsonText();
+    /**
+     * Load the bookmark library. Fetches html + json in parallel (#69).
+     * options.ifNoneMatch → conditional GET; 304 yields { notModified: true }.
+     */
+    async function getBookmarks(options) {
+      options = options || {};
+      var cond = {};
+      if (options.ifNoneMatch) {
+        cond["If-None-Match"] = options.ifNoneMatch;
+      }
+      var htmlPromise = getFile(HTML_PATH, { headers: cond });
+      var jsonPromise = request("GET", dir + JSON_PATH, {
+        headers: cond,
+      });
+
+      var html = await htmlPromise;
+      if (html.notModified) {
+        // Settle the companion request; its body is unused on 304.
+        try {
+          await jsonPromise;
+        } catch (err) {
+          /* ignore */
+        }
+        return {
+          ok: true,
+          notModified: true,
+          missing: false,
+          html: "",
+          etag: html.etag || options.ifNoneMatch || null,
+          jsonText: null,
+        };
+      }
+      if (!html.ok) {
+        try {
+          await jsonPromise;
+        } catch (err2) {
+          /* ignore */
+        }
+        return html;
+      }
+
+      var jres = await jsonPromise;
+      var jsonText = jres && jres.status === 200 ? jres.text : null;
       return {
         ok: true,
         missing: Boolean(html.missing),
@@ -209,9 +301,9 @@ var DavflareDav = (function () {
         body: String(payload.html || ""),
         headers: headers,
       });
-      if (res.status === 0) return { ok: false, kind: "network" };
+      if (res.status === 0) return { ok: false, kind: res.kind || "network" };
       if (res.status === 412) return { ok: false, kind: "conflict" };
-      if (!res.ok) return { ok: false, kind: res.kind };
+      if (!res.ok) return { ok: false, kind: res.kind, status: res.status };
 
       var jsonSaved = false;
       if (typeof payload.json === "string") {
@@ -221,7 +313,7 @@ var DavflareDav = (function () {
         });
         jsonSaved = jres.ok;
       }
-      return { ok: true, jsonSaved: jsonSaved };
+      return { ok: true, jsonSaved: jsonSaved, etag: res.etag || null };
     }
 
     return {
@@ -236,7 +328,7 @@ var DavflareDav = (function () {
     };
   }
 
-  return { createDavClient: createDavClient };
+  return { createDavClient: createDavClient, DEFAULT_TIMEOUT_MS: DEFAULT_TIMEOUT_MS };
 })();
 
 if (typeof module !== "undefined" && module.exports) {

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Davflare",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "Save any page to your own WebDAV bookmark library from the toolbar popup.",
   "icons": {
     "16": "icons/icon16.png",

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -6,10 +6,14 @@
  * to the instance's WebDAV library, and offer entries into the shell home
  * page (bookmarks.html) and its settings view. The right-click quick-save in
  * background.js keeps working for one-click saves without the dialog.
+ *
+ * #69: open from bookmarksCache first (≤2–3s to actionable), then soft-sync
+ * with a conditional GET so large libraries do not block the Save button.
  */
 
 var THEME_KEY = "davflare-theme";
 var LAST_FOLDER_KEY = "popupLastFolder";
+var CACHE_KEY = "bookmarksCache";
 
 var COPY = {
   en: {
@@ -25,11 +29,13 @@ var COPY = {
     needConfig: "Configure your instance URL and WebDAV credentials in settings first.",
     goSettings: "Open settings",
     loading: "Loading library…",
+    syncing: "Updating library…",
     retry: "Retry",
     errDisabled: "WebDAV is disabled on this instance.",
     errNotConfigured: "The server has no WebDAV credentials configured.",
     errUnauthorized: "Wrong WebDAV username or password. Check settings.",
     errNetwork: "Cannot reach the instance.",
+    errTimeout: "The instance timed out (large library or slow network). Try again.",
     errConflict: "The library changed elsewhere — reloaded, please save again.",
     errOther: "The instance returned an unexpected response.",
     home: "Open Davflare",
@@ -48,11 +54,13 @@ var COPY = {
     needConfig: "请先在「设置」里配置实例地址与 WebDAV 凭据。",
     goSettings: "去设置",
     loading: "正在读取书签库…",
+    syncing: "正在同步书签库…",
     retry: "重试",
     errDisabled: "该实例已关闭 WebDAV。",
     errNotConfigured: "服务端未配置 WebDAV 凭据。",
     errUnauthorized: "WebDAV 用户名或密码错误，请在设置里检查。",
     errNetwork: "无法连接实例。",
+    errTimeout: "实例响应超时（库较大或网络慢），请重试。",
     errConflict: "书签库已在别处更新——已重新加载，请再点一次收藏。",
     errOther: "实例返回了未预期的响应。",
     home: "插件主页",
@@ -65,6 +73,7 @@ var ERROR_KEY = {
   notConfigured: "errNotConfigured",
   unauthorized: "errUnauthorized",
   network: "errNetwork",
+  timeout: "errTimeout",
   conflict: "errConflict",
 };
 
@@ -77,6 +86,7 @@ var state = {
   etag: null,
   exists: false,
   ready: false,
+  syncing: false,
 };
 
 function $(id) {
@@ -89,7 +99,14 @@ function pickLang() {
 
 function errorText(kind) {
   var key = ERROR_KEY[kind];
-  return key ? state.t[key] : state.t.errOther;
+  if (key) return state.t[key];
+  if (kind && String(kind).indexOf("http") === 0) {
+    var code = String(kind).slice(4);
+    return state.lang === "zh"
+      ? "实例返回了未预期的响应（HTTP " + code + "）。"
+      : "Unexpected response from the instance (HTTP " + code + ").";
+  }
+  return state.t.errOther;
 }
 
 function applyTheme() {
@@ -177,31 +194,39 @@ function setSaveEnabled(enabled, label) {
   btn.textContent = label;
 }
 
-/**
- * GET + parse the remote library. Fills the folder datalist, re-checks
- * "already saved", and decides whether the save button is usable. User-typed
- * inputs (title/folder/tags) are left alone unless prefillTitle is set.
- */
-async function loadModel(opts) {
-  var options = opts || {};
-  state.ready = false;
-  setSaveEnabled(false, state.t.save);
-  if (options.prefillTitle) setStatus(state.t.loading);
-  var client = DavflareDav.createDavClient(options.cfg);
-  var res = await client.getBookmarks();
-  if (!res.ok) {
-    showNotice(errorText(res.kind), state.t.retry, function () {
-      init();
-    });
-    return;
-  }
+function writeCache(model, etag) {
+  var normalized = Bookmarks.normalizeModel(model);
+  var payload = {};
+  payload[CACHE_KEY] = {
+    model: normalized,
+    etag: etag || null,
+    syncedAt: Date.now(),
+    bytes:
+      Bookmarks.serializeHtml(normalized).length +
+      Bookmarks.modelToJsonText(normalized).length,
+  };
+  chrome.storage.local.set(payload, function () {
+    void chrome.runtime.lastError;
+  });
+}
+
+function parseRemoteLibrary(res) {
   var model = Bookmarks.parseHtml(res.html || "");
   if (res.jsonText) {
     var parsed = Bookmarks.modelFromJson(res.jsonText);
     if (parsed.ok) model = Bookmarks.adoptRichFields(model, parsed.model);
   }
+  return model;
+}
+
+/**
+ * Apply a loaded model to the form (folders, exists, save button).
+ * User-typed inputs are left alone unless prefill* flags are set.
+ */
+async function applyLoadedModel(model, etag, options) {
+  var opts = options || {};
   state.model = model;
-  state.etag = res.etag;
+  state.etag = etag || null;
 
   var folders = Bookmarks.folderPaths(model);
   var datalist = $("folderOptions");
@@ -220,10 +245,10 @@ async function loadModel(opts) {
       })
   );
 
-  if (options.prefillTitle && !$("saveTitle").value) {
+  if (opts.prefillTitle && !$("saveTitle").value) {
     $("saveTitle").value = (state.tab && state.tab.title) || state.url;
   }
-  if (options.prefillFolder && !$("saveFolder").value) {
+  if (opts.prefillFolder && !$("saveFolder").value) {
     var stored = await chrome.storage.local.get([LAST_FOLDER_KEY]);
     var last = stored && typeof stored[LAST_FOLDER_KEY] === "string" ? stored[LAST_FOLDER_KEY] : "";
     if (Bookmarks.folderPaths(model).indexOf(last) !== -1) {
@@ -235,9 +260,67 @@ async function loadModel(opts) {
   if (state.exists) {
     setStatus(state.t.exists, "ok");
     setSaveEnabled(false, state.t.exists);
+    state.ready = false;
   } else {
     state.ready = true;
     setSaveEnabled(true, state.t.save);
+    if (!state.syncing) setStatus("");
+  }
+}
+
+/**
+ * Full remote GET + parse. Used when there is no usable cache.
+ */
+async function loadModel(opts) {
+  var options = opts || {};
+  state.ready = false;
+  setSaveEnabled(false, state.t.save);
+  if (options.prefillTitle) setStatus(state.t.loading);
+  var client = DavflareDav.createDavClient(options.cfg);
+  var res = await client.getBookmarks();
+  if (!res.ok) {
+    showNotice(errorText(res.kind), state.t.retry, function () {
+      init();
+    });
+    return;
+  }
+  var model = parseRemoteLibrary(res);
+  writeCache(model, res.etag || null);
+  await applyLoadedModel(model, res.etag || null, options);
+}
+
+/**
+ * Background revalidation (#69): If-None-Match when we have an etag so large
+ * libraries stay cheap on the happy path. Failures are non-blocking when the
+ * form is already usable from cache.
+ */
+async function softSync(cfg) {
+  state.syncing = true;
+  if (state.ready && !state.exists) setStatus(state.t.syncing);
+  try {
+    var client = DavflareDav.createDavClient(cfg);
+    var opts = state.etag ? { ifNoneMatch: state.etag } : {};
+    var res = await client.getBookmarks(opts);
+    if (!res.ok) {
+      if (!state.model) {
+        showNotice(errorText(res.kind), state.t.retry, function () {
+          init();
+        });
+      } else if (state.ready && !state.exists) {
+        setStatus("");
+      }
+      return;
+    }
+    if (res.notModified) {
+      if (state.ready && !state.exists) setStatus("");
+      return;
+    }
+    var model = parseRemoteLibrary(res);
+    writeCache(model, res.etag || null);
+    // Refresh exists / folders; keep whatever the user already typed.
+    await applyLoadedModel(model, res.etag || null, {});
+  } finally {
+    state.syncing = false;
   }
 }
 
@@ -293,7 +376,9 @@ async function saveCurrent(event) {
     return;
   }
   state.model = add.model;
+  state.etag = put.etag || null;
   state.exists = true;
+  writeCache(add.model, put.etag || null);
   setStatus(state.t.saved, "ok");
   setSaveEnabled(false, state.t.saved);
   chrome.storage.local.set({ popupLastFolder: folder }, function () {
@@ -350,6 +435,18 @@ async function init() {
     showNotice(t.needConfig, t.goSettings, function () {
       openShell("settings");
     });
+    return;
+  }
+
+  // Cache-first (#69): enable Save from local library, then soft-sync.
+  var stored = await chrome.storage.local.get([CACHE_KEY]);
+  var cache = stored && stored[CACHE_KEY];
+  if (cache && cache.model) {
+    await applyLoadedModel(Bookmarks.normalizeModel(cache.model), cache.etag || null, {
+      prefillTitle: true,
+      prefillFolder: true,
+    });
+    softSync(cfg);
     return;
   }
 

--- a/src/app/__tests__/extensionDav.test.ts
+++ b/src/app/__tests__/extensionDav.test.ts
@@ -6,8 +6,8 @@ const DavflareDav = nodeRequire("../../../extension/dav.js") as {
   createDavClient: (options: Record<string, unknown>) => {
     deleteFile: (fileName: string) => Promise<Resolved>;
     ensureDir: () => Promise<Resolved>;
-    getBookmarks: () => Promise<Resolved>;
-    getFile: (fileName: string) => Promise<Resolved>;
+    getBookmarks: (options?: Record<string, unknown>) => Promise<Resolved>;
+    getFile: (fileName: string, options?: Record<string, unknown>) => Promise<Resolved>;
     paths: { root: string; dir: string; html: string; json: string };
     probe: () => Promise<Resolved>;
     putBookmarks: (payload: Record<string, unknown>) => Promise<Resolved>;
@@ -94,7 +94,7 @@ describe("extension/dav.js request basics", () => {
       password: "p",
       fetchImpl: fetchMock(() => ({ status: 207 })).fetch,
     });
-    expect(await noUrl.probe()).toEqual({ ok: false, kind: "network" });
+    expect(await noUrl.probe()).toMatchObject({ ok: false, kind: "network" });
 
     const { client } = clientWith(
       {
@@ -178,7 +178,7 @@ describe("extension/dav.js ensureDir nested basePath (issue #60)", () => {
     });
     expect(
       await client.putBookmarks({ html: "<DL><p></DL><p>", json: '{"bookmarks":[]}' })
-    ).toEqual({ ok: true, jsonSaved: true });
+    ).toEqual({ ok: true, jsonSaved: true, etag: null });
     expect(calls.map((c) => (c.init.method as string) + " " + c.url)).toEqual([
       "MKCOL " + ROOT + "/_pm_qa/",
       "MKCOL " + nestedDir,
@@ -195,7 +195,7 @@ describe("extension/dav.js ensureDir nested basePath (issue #60)", () => {
     });
     expect(
       await client.putFile("snapshots/s1.html", "<html></html>", "text/html; charset=utf-8")
-    ).toEqual({ ok: true });
+    ).toEqual({ ok: true, etag: null });
     expect(calls.map((c) => (c.init.method as string) + " " + c.url)).toEqual([
       "MKCOL " + ROOT + "/a/",
       "MKCOL " + nestedDir,
@@ -233,10 +233,10 @@ describe("extension/dav.js probe", () => {
     expect(await disabled.client.probe()).toEqual({ ok: false, kind: "disabled" });
 
     const unauthorized = clientWith({}, () => ({ status: 401 }));
-    expect(await unauthorized.client.probe()).toEqual({ ok: false, kind: "unauthorized" });
+    expect(await unauthorized.client.probe()).toMatchObject({ ok: false, kind: "unauthorized" });
 
     const notConfigured = clientWith({}, () => ({ status: 403 }));
-    expect(await notConfigured.client.probe()).toEqual({
+    expect(await notConfigured.client.probe()).toMatchObject({
       ok: false,
       kind: "notConfigured",
     });
@@ -269,7 +269,7 @@ describe("extension/dav.js getBookmarks", () => {
     });
     const res = await client.getBookmarks();
     expect(res).toMatchObject({ ok: true, missing: true, html: "" });
-    expect(calls[1].init.method).toBe("PROPFIND");
+    expect(calls.some((c) => c.init.method === "PROPFIND")).toBe(true);
   });
 
   test("a 404 everywhere means the webdav flag is off", async () => {
@@ -279,12 +279,12 @@ describe("extension/dav.js getBookmarks", () => {
 
   test("auth failures surface as unauthorized / notConfigured", async () => {
     const unauthorized = clientWith({}, () => ({ status: 401 }));
-    expect(await unauthorized.client.getBookmarks()).toEqual({
+    expect(await unauthorized.client.getBookmarks()).toMatchObject({
       ok: false,
       kind: "unauthorized",
     });
     const notConfigured = clientWith({}, () => ({ status: 403 }));
-    expect(await notConfigured.client.getBookmarks()).toEqual({
+    expect(await notConfigured.client.getBookmarks()).toMatchObject({
       ok: false,
       kind: "notConfigured",
     });
@@ -304,7 +304,7 @@ describe("extension/dav.js putBookmarks", () => {
       json: '{"bookmarks":[]}',
       etag: '"etag-1"',
     });
-    expect(res).toEqual({ ok: true, jsonSaved: true });
+    expect(res).toEqual({ ok: true, jsonSaved: true, etag: null });
 
     const methods = calls.map((c) => (c.init.method as string) + " " + c.url);
     expect(methods).toEqual([
@@ -344,6 +344,7 @@ describe("extension/dav.js putBookmarks", () => {
     expect(await client.putBookmarks({ html: "x", json: "{}" })).toEqual({
       ok: true,
       jsonSaved: false,
+      etag: null,
     });
   });
 
@@ -408,6 +409,7 @@ describe("extension/dav.js generic getFile / putFile", () => {
     const { client, calls } = clientWith({}, () => ({ status: 204 }));
     expect(await client.putFile("workspaces.json", "[]", "application/json")).toEqual({
       ok: true,
+      etag: null,
     });
     expect((calls[1].init.headers as Record<string, string>)["If-Match"]).toBeUndefined();
   });
@@ -419,7 +421,7 @@ describe("extension/dav.js generic getFile / putFile", () => {
     });
     expect(
       await client.putFile("snapshots/snap-1.html", "<html></html>", "text/html; charset=utf-8")
-    ).toEqual({ ok: true });
+    ).toEqual({ ok: true, etag: null });
     expect(calls.map((c) => c.init.method + " " + c.url)).toEqual([
       "MKCOL " + DIR,
       "MKCOL " + DIR + "snapshots/",
@@ -437,7 +439,7 @@ describe("extension/dav.js deleteFile", () => {
     expect(await missing.client.deleteFile("snapshots/snap-1.html")).toEqual({ ok: true });
 
     const denied = clientWith({}, () => ({ status: 401 }));
-    expect(await denied.client.deleteFile("snapshots/snap-1.html")).toEqual({
+    expect(await denied.client.deleteFile("snapshots/snap-1.html")).toMatchObject({
       ok: false,
       kind: "unauthorized",
     });
@@ -446,6 +448,91 @@ describe("extension/dav.js deleteFile", () => {
     expect(await offline.client.deleteFile("snapshots/snap-1.html")).toEqual({
       ok: false,
       kind: "network",
+    });
+  });
+});
+
+
+describe("extension/dav.js large-library helpers (#68/#69)", () => {
+  test("getBookmarks fetches html and json in parallel", async () => {
+    let inFlight = 0;
+    let maxInFlight = 0;
+    const { client, calls } = clientWith({}, async (url) => {
+      inFlight += 1;
+      maxInFlight = Math.max(maxInFlight, inFlight);
+      await new Promise((r) => setTimeout(r, 20));
+      inFlight -= 1;
+      return url.endsWith("bookmarks.html")
+        ? { status: 200, body: "<DL><p></DL><p>", etag: '"e1"' }
+        : { status: 200, body: '{"bookmarks":[]}' };
+    });
+    const res = await client.getBookmarks();
+    expect(res.ok).toBe(true);
+    expect(maxInFlight).toBeGreaterThanOrEqual(2);
+    expect(calls.map((c) => c.url).sort()).toEqual(
+      [DIR + "bookmarks.html", DIR + "bookmarks.json"].sort()
+    );
+  });
+
+  test("getBookmarks honors If-None-Match and returns notModified on 304", async () => {
+    const { client, calls } = clientWith({}, () => ({ status: 304, etag: '"abc"' }));
+    const res = await client.getBookmarks({ ifNoneMatch: '"abc"' });
+    expect(res).toMatchObject({ ok: true, notModified: true, etag: '"abc"' });
+    const headers = calls[0].init.headers as Record<string, string>;
+    expect(headers["If-None-Match"]).toBe('"abc"');
+  });
+
+  test("request abort maps to timeout kind", async () => {
+    const mock = fetchMock(async (_url, init) => {
+      await new Promise<void>((_resolve, reject) => {
+        const signal = init.signal as AbortSignal | undefined;
+        if (!signal) {
+          reject(new Error("missing signal"));
+          return;
+        }
+        if (signal.aborted) {
+          const err = new Error("aborted");
+          (err as Error & { name: string }).name = "AbortError";
+          reject(err);
+          return;
+        }
+        signal.addEventListener("abort", () => {
+          const err = new Error("aborted");
+          (err as Error & { name: string }).name = "AbortError";
+          reject(err);
+        });
+      });
+      return { status: 200 };
+    });
+    const client = DavflareDav.createDavClient({
+      instanceUrl: "https://drive.example",
+      username: "walter",
+      password: "s3cret",
+      fetchImpl: mock.fetch,
+      timeoutMs: 40,
+    });
+    expect(await client.getBookmarks()).toEqual({ ok: false, kind: "timeout" });
+  });
+
+  test("putBookmarks returns response etag when present", async () => {
+    const { client } = clientWith({}, (url, init) => {
+      if ((init.method as string) === "MKCOL") return { status: 405 };
+      if (url.endsWith("bookmarks.html")) return { status: 204, etag: '"new"' };
+      return { status: 204 };
+    });
+    expect(await client.putBookmarks({ html: "x", json: "{}" })).toEqual({
+      ok: true,
+      jsonSaved: true,
+      etag: '"new"',
+    });
+  });
+
+  test("5xx surfaces as httpNNN so UI can show the status code", async () => {
+    const { client } = clientWith({}, () => ({ status: 524, body: "timeout" }));
+    expect(await client.getBookmarks()).toEqual({
+      ok: false,
+      kind: "http524",
+      status: 524,
     });
   });
 });


### PR DESCRIPTION
## Summary
- **#68** Context-menu save: return the async Promise from the MV3 click listener so the service worker stays alive; badge+notification feedback (incl. start `…`); prefer `bookmarksCache` + etag fast-path PUT with conflict→re-GET retry; distinct error copy (未配置 / 401 / 网络 / 超时 / HTTP 码 / 已存在).
- **#69** Popup opens from local cache (Save actionable without waiting on a full Netscape download), then soft-syncs with `If-None-Match`; library page shows HTTP status + Retry on unexpected failures; dav client parallelizes html/json GET, adds timeouts and 304 handling.
- Bump extension manifest **1.3.1 → 1.3.2**.

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npx vitest run` (867 passed) incl. new dav cases (parallel GET, 304, timeout, http524)
- [ ] Manual: large library (~900) — popup Save enabled in ≤2–3s from cache; library refresh Retry / HTTP banner; context-menu save shows notification/badge and writes remotely

Fixes #68
Fixes #69