### PR TITLE
fix(扩展): 右键收藏 If-Match 412 自动重试写入 (#71)

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -1,6 +1,6 @@
 "use strict";
 
-importScripts("url.js", "bookmarks.js", "dav.js");
+importScripts("url.js", "bookmarks.js", "dav.js", "quickSave.js");
 
 var MENU_SAVE = "davflare-save-page";
 var MENU_MODE = "davflare-toggle-mode";
@@ -167,13 +167,14 @@ async function toggleDefaultMode() {
 }
 
 /**
- * Context-menu / fallback quick-save (#68).
+ * Context-menu / fallback quick-save (#68 / #71).
  *
  * MV3 service workers are killed if the click listener does not return the
  * async work as a Promise — previously savePage was fire-and-forget, so a
  * large-library GET could be aborted mid-flight with no notification and no
- * write. We also prefer the local bookmarksCache (+ etag) so the common path
- * does not wait on a full Netscape re-download before PUT.
+ * write. We prefer the local bookmarksCache (+ etag) for a fast PUT, and on
+ * 412 we re-GET the latest etag, merge, and retry PUT once (#71) so a stale
+ * If-Match from cache does not leave the user with only a conflict toast.
  */
 async function savePage(tab) {
   var copy = t();
@@ -191,69 +192,23 @@ async function savePage(tab) {
     return;
   }
 
-  var client = DavflareDav.createDavClient(cfg);
-  var cache = await readBookmarksCache();
-  var cachedModel = cache && cache.model ? Bookmarks.normalizeModel(cache.model) : null;
-  var cachedEtag = cache && cache.etag ? cache.etag : null;
+  var result = await DavflareQuickSave.saveBookmark(
+    {
+      client: DavflareDav.createDavClient(cfg),
+      Bookmarks: Bookmarks,
+      readCache: readBookmarksCache,
+      writeCache: writeBookmarksCache,
+      parseRemote: parseRemoteLibrary,
+    },
+    { title: title, url: url, added: Date.now() }
+  );
 
-  if (cachedModel) {
-    var early = Bookmarks.addBookmark(cachedModel, {
-      title: title,
-      url: url,
-      added: Date.now(),
-    });
-    if (!early.added) {
-      okFeedback(copy.saveExists);
-      return;
-    }
-
-    // Fast path: PUT against the cached etag (If-Match). Conflict → re-GET.
-    if (cachedEtag) {
-      var putCached = await client.putBookmarks({
-        html: Bookmarks.serializeHtml(early.model),
-        json: Bookmarks.modelToJsonText(early.model),
-        etag: cachedEtag,
-      });
-      if (putCached.ok) {
-        await writeBookmarksCache(early.model, putCached.etag || null);
-        okFeedback(copy.saveOk);
-        return;
-      }
-      if (putCached.kind !== "conflict") {
-        failFeedback(errorText(putCached.kind));
-        return;
-      }
-    }
-  }
-
-  var res = await client.getBookmarks();
-  if (!res.ok) {
-    failFeedback(errorText(res.kind));
+  if (result.ok) {
+    okFeedback(result.status === "exists" ? copy.saveExists : copy.saveOk);
     return;
   }
-
-  var model = parseRemoteLibrary(res);
-  var add = Bookmarks.addBookmark(model, { title: title, url: url, added: Date.now() });
-  if (!add.added) {
-    await writeBookmarksCache(model, res.etag || null);
-    okFeedback(copy.saveExists);
-    return;
-  }
-
-  var put = await client.putBookmarks({
-    html: Bookmarks.serializeHtml(add.model),
-    json: Bookmarks.modelToJsonText(add.model),
-    etag: res.etag,
-  });
-  if (!put.ok) {
-    failFeedback(errorText(put.kind));
-    return;
-  }
-  await writeBookmarksCache(add.model, put.etag || null);
-  okFeedback(copy.saveOk);
+  failFeedback(errorText(result.kind));
 }
-
-// 工具栏左键点击由 popup.html（收藏弹窗）接管；右键菜单保留一键收藏与主页默认视图切换。
 
 /**
  * #62 P1: the configurable shortcut triggers the same quick-save as the

--- a/extension/dav.js
+++ b/extension/dav.js
@@ -72,6 +72,9 @@ var DavflareDav = (function () {
           method: method,
           headers: headers,
           body: extra.body,
+          // Avoid HTTP-cache serving a stale ETag after a 412 (#71). Extension
+          // SW fetch can otherwise re-GET an old body+etag and fail If-Match again.
+          cache: "no-store",
         };
         if (
           timeoutMs > 0 &&

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Davflare",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "description": "Save any page to your own WebDAV bookmark library from the toolbar popup.",
   "icons": {
     "16": "icons/icon16.png",

--- a/extension/quickSave.js
+++ b/extension/quickSave.js
@@ -1,0 +1,129 @@
+"use strict";
+
+/**
+ * Context-menu / silent quick-save core (#71).
+ *
+ * Separated from background.js so vitest can exercise the 412→re-GET→merge→
+ * retry PUT loop without Chrome APIs. background.js only maps the result to
+ * badge + notification copy.
+ *
+ * Plain script with a module.exports guard so vitest can require() it.
+ */
+var DavflareQuickSave = (function () {
+  /**
+   * Persist one bookmark via WebDAV.
+   *
+   * Strategy:
+   *  1. Optional fast path: PUT against bookmarksCache etag (If-Match).
+   *  2. On miss / 412 / no cache: unconditional GET → merge → PUT.
+   *  3. On 412 again: re-GET latest etag, merge, retry PUT once more.
+   *  4. Cache etag is rewritten after every successful GET/PUT so a stale
+   *     If-Match from bookmarksCache cannot stick around after remote moved.
+   *
+   * @param {object} deps
+   * @param {{getBookmarks: Function, putBookmarks: Function}} deps.client
+   * @param {object} deps.Bookmarks  — extension/bookmarks.js API
+   * @param {() => Promise<{model: object, etag?: string}|null>} deps.readCache
+   * @param {(model: object, etag: string|null) => Promise<void>} deps.writeCache
+   * @param {(res: object) => object} deps.parseRemote
+   * @param {{title: string, url: string, added?: number}} page
+   * @returns {Promise<
+   *   | { ok: true, status: "saved" | "exists" }
+   *   | { ok: false, kind: string }
+   * >}
+   */
+  async function saveBookmark(deps, page) {
+    var client = deps.client;
+    var Bookmarks = deps.Bookmarks;
+    var readCache = deps.readCache;
+    var writeCache = deps.writeCache;
+    var parseRemote = deps.parseRemote;
+    var title = page.title || "";
+    var url = page.url || "";
+    var added = typeof page.added === "number" ? page.added : Date.now();
+
+    var cache = await readCache();
+    var cachedModel = cache && cache.model ? Bookmarks.normalizeModel(cache.model) : null;
+    var cachedEtag = cache && cache.etag ? cache.etag : null;
+
+    if (cachedModel) {
+      var early = Bookmarks.addBookmark(cachedModel, {
+        title: title,
+        url: url,
+        added: added,
+      });
+      if (!early.added) {
+        return { ok: true, status: "exists" };
+      }
+
+      // Fast path: PUT against the cached etag (If-Match). Conflict → re-GET.
+      if (cachedEtag) {
+        var putCached = await client.putBookmarks({
+          html: Bookmarks.serializeHtml(early.model),
+          json: Bookmarks.modelToJsonText(early.model),
+          etag: cachedEtag,
+        });
+        if (putCached.ok) {
+          await writeCache(early.model, putCached.etag || null);
+          return { ok: true, status: "saved" };
+        }
+        if (putCached.kind !== "conflict") {
+          return { ok: false, kind: putCached.kind || "network" };
+        }
+        // Stale cache etag — drop it before the GET/merge loop so we never
+        // keep serving a precondition that already failed (#71).
+        await writeCache(cachedModel, null);
+      }
+    }
+
+    // Fresh GET + PUT, with one 412 retry (re-GET → merge → PUT).
+    var maxAttempts = 2;
+    for (var attempt = 0; attempt < maxAttempts; attempt++) {
+      var res = await client.getBookmarks();
+      if (!res.ok) {
+        return { ok: false, kind: res.kind || "network" };
+      }
+
+      var model = parseRemote(res);
+      // Keep cache etag aligned with what we just observed remotely, even
+      // before the PUT — so a later conflict path does not re-use a stale
+      // If-Match from bookmarksCache.
+      await writeCache(model, res.etag || null);
+
+      var add = Bookmarks.addBookmark(model, {
+        title: title,
+        url: url,
+        added: added,
+      });
+      if (!add.added) {
+        return { ok: true, status: "exists" };
+      }
+
+      var put = await client.putBookmarks({
+        html: Bookmarks.serializeHtml(add.model),
+        json: Bookmarks.modelToJsonText(add.model),
+        etag: res.etag || null,
+      });
+      if (put.ok) {
+        await writeCache(add.model, put.etag || null);
+        return { ok: true, status: "saved" };
+      }
+      if (put.kind !== "conflict") {
+        return { ok: false, kind: put.kind || "network" };
+      }
+      // 412: loop once more with a brand-new GET (latest etag). After the
+      // final attempt, surface conflict so the UI can ask the user to retry.
+      if (attempt === maxAttempts - 1) {
+        return { ok: false, kind: "conflict" };
+      }
+    }
+
+    return { ok: false, kind: "conflict" };
+  }
+
+  return { saveBookmark: saveBookmark };
+})();
+
+if (typeof module !== "undefined" && module.exports) {
+  module.exports = DavflareQuickSave;
+}

--- a/src/app/__tests__/extension.test.ts
+++ b/src/app/__tests__/extension.test.ts
@@ -117,6 +117,10 @@ describe("Davflare Chrome extension / default package", () => {
     // 弹窗接管点击后，background 不应再有工具栏点击监听
     const bg = fs.readFileSync(path.join(extDir, "background.js"), "utf8");
     expect(bg).not.toContain("chrome.action.onClicked");
+    // #71: conflict retry lives in quickSave.js; SW must import it.
+    expect(bg).toContain('importScripts("url.js", "bookmarks.js", "dav.js", "quickSave.js")');
+    expect(bg).toContain("DavflareQuickSave.saveBookmark");
+    expect(fs.existsSync(path.join(extDir, "quickSave.js"))).toBe(true);
   });
 
   test("standalone options page is gone; settings live in the shell page", () => {
@@ -262,6 +266,7 @@ describe("Davflare Chrome extension / release zip", () => {
     expect(names).not.toContain("options.js");
     expect(names).toContain("manifest.json");
     expect(names).toContain("background.js");
+    expect(names).toContain("quickSave.js");
     expect(names).toContain("bookmarks.html");
     expect(names).toContain("bookmarks.css");
     expect(names).toContain("bookmarksApp.js");

--- a/src/app/__tests__/extensionDav.test.ts
+++ b/src/app/__tests__/extensionDav.test.ts
@@ -64,6 +64,12 @@ const ROOT = "https://drive.example/webdav";
 const DIR = ROOT + "/bookmarks/";
 
 describe("extension/dav.js request basics", () => {
+  test("fetch uses cache no-store so stale ETags cannot poison If-Match (#71)", async () => {
+    const { client, calls } = clientWith({}, () => ({ status: 207 }));
+    await client.probe();
+    expect(calls[0].init.cache).toBe("no-store");
+  });
+
   test("sends Basic auth to the /webdav endpoints", async () => {
     const { client, calls } = clientWith({}, () => ({ status: 207 }));
     await client.probe();

--- a/src/app/__tests__/extensionQuickSave.test.ts
+++ b/src/app/__tests__/extensionQuickSave.test.ts
@@ -1,0 +1,222 @@
+import { createRequire } from "module";
+
+const nodeRequire = createRequire(import.meta.url);
+
+const Bookmarks = nodeRequire("../../../extension/bookmarks.js") as {
+  addBookmark: (model: unknown, input: Record<string, unknown>) => {
+    added: boolean;
+    model: unknown;
+  };
+  emptyModel: () => { bookmarks: unknown[] };
+  modelToJsonText: (model: unknown) => string;
+  normalizeModel: (model: unknown) => unknown;
+  parseHtml: (html: string) => unknown;
+  serializeHtml: (model: unknown) => string;
+  adoptRichFields: (htmlModel: unknown, jsonModel: unknown) => unknown;
+  modelFromJson: (text: string) => { ok: boolean; model?: unknown };
+};
+
+const DavflareQuickSave = nodeRequire("../../../extension/quickSave.js") as {
+  saveBookmark: (
+    deps: Record<string, unknown>,
+    page: { title: string; url: string; added?: number }
+  ) => Promise<{ ok: boolean; status?: string; kind?: string }>;
+};
+
+type PutCall = { etag: string | null | undefined; html: string };
+type GetCall = { ifNoneMatch?: string };
+
+function htmlWith(url: string, title = "Remote") {
+  return (
+    `<!DOCTYPE NETSCAPE-Bookmark-file-1>\n` +
+    `<META HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=UTF-8">\n` +
+    `<TITLE>Bookmarks</TITLE>\n<H1>Bookmarks</H1>\n<DL><p>\n` +
+    `    <DT><A HREF="${url}" ADD_DATE="1">${title}</A>\n` +
+    `</DL><p>\n`
+  );
+}
+
+function parseRemote(res: { html?: string; jsonText?: string | null }) {
+  let model = Bookmarks.parseHtml(res.html || "");
+  if (res.jsonText) {
+    const parsed = Bookmarks.modelFromJson(res.jsonText);
+    if (parsed.ok && parsed.model) {
+      model = Bookmarks.adoptRichFields(model, parsed.model);
+    }
+  }
+  return model;
+}
+
+function makeDeps(options: {
+  cache?: { model: unknown; etag: string | null } | null;
+  getSequence: Array<{
+    ok?: boolean;
+    kind?: string;
+    html?: string;
+    etag?: string | null;
+    jsonText?: string | null;
+  }>;
+  putSequence: Array<{
+    ok?: boolean;
+    kind?: string;
+    etag?: string | null;
+  }>;
+}) {
+  const cacheWrites: Array<{ model: unknown; etag: string | null }> = [];
+  let cache = options.cache ?? null;
+  const puts: PutCall[] = [];
+  const gets: GetCall[] = [];
+  let getIdx = 0;
+  let putIdx = 0;
+
+  const client = {
+    getBookmarks: async (opts?: { ifNoneMatch?: string }) => {
+      gets.push({ ifNoneMatch: opts?.ifNoneMatch });
+      const next = options.getSequence[getIdx++] ?? {
+        ok: false,
+        kind: "network",
+      };
+      if (next.ok === false) {
+        return { ok: false, kind: next.kind || "network" };
+      }
+      return {
+        ok: true,
+        html: next.html ?? "",
+        etag: next.etag ?? null,
+        jsonText: next.jsonText ?? null,
+        missing: false,
+      };
+    },
+    putBookmarks: async (payload: {
+      html: string;
+      json?: string;
+      etag?: string | null;
+    }) => {
+      puts.push({ etag: payload.etag, html: payload.html });
+      const next = options.putSequence[putIdx++] ?? {
+        ok: false,
+        kind: "network",
+      };
+      if (next.ok === false) {
+        return { ok: false, kind: next.kind || "network" };
+      }
+      return { ok: true, etag: next.etag ?? '"written"', jsonSaved: true };
+    },
+  };
+
+  return {
+    deps: {
+      client,
+      Bookmarks,
+      readCache: async () => cache,
+      writeCache: async (model: unknown, etag: string | null) => {
+        cache = { model, etag };
+        cacheWrites.push({ model, etag });
+      },
+      parseRemote,
+    },
+    puts,
+    gets,
+    cacheWrites,
+    getCache: () => cache,
+  };
+}
+
+describe("extension/quickSave.js (#71 If-Match conflict retry)", () => {
+  const page = {
+    title: "New Page",
+    url: "https://example.com/fresh",
+    added: 1_700_000_000_000,
+  };
+
+  test("cached etag 412 → re-GET latest → merge → retry PUT succeeds", async () => {
+    const staleModel = Bookmarks.normalizeModel(Bookmarks.emptyModel());
+    const remoteHtml = htmlWith("https://example.com/other", "Other");
+    const harness = makeDeps({
+      cache: { model: staleModel, etag: '"stale"' },
+      getSequence: [{ ok: true, html: remoteHtml, etag: '"fresh"' }],
+      putSequence: [
+        { ok: false, kind: "conflict" }, // fast-path If-Match miss
+        { ok: true, etag: '"after"' }, // retry PUT
+      ],
+    });
+
+    const result = await DavflareQuickSave.saveBookmark(harness.deps, page);
+    expect(result).toEqual({ ok: true, status: "saved" });
+
+    // Fast path used stale etag; retry PUT used the GET etag.
+    expect(harness.puts.map((p) => p.etag)).toEqual(['"stale"', '"fresh"']);
+    expect(harness.gets).toHaveLength(1);
+    expect(harness.gets[0].ifNoneMatch).toBeUndefined();
+
+    // Retry body must include both the remote bookmark and the new URL.
+    expect(harness.puts[1].html).toContain("https://example.com/other");
+    expect(harness.puts[1].html).toContain("https://example.com/fresh");
+
+    // Cache ends on the successful write etag (not the stale one).
+    expect(harness.getCache()?.etag).toBe('"after"');
+    // After the initial 412 we cleared the stale etag before GET.
+    expect(harness.cacheWrites.some((w) => w.etag === null)).toBe(true);
+  });
+
+  test("GET→PUT 412 then second GET→PUT still 412 surfaces conflict and keeps latest etag in cache", async () => {
+    const harness = makeDeps({
+      cache: null,
+      getSequence: [
+        {
+          ok: true,
+          html: htmlWith("https://example.com/a", "A"),
+          etag: '"e1"',
+        },
+        {
+          ok: true,
+          html: htmlWith("https://example.com/b", "B"),
+          etag: '"e2"',
+        },
+      ],
+      putSequence: [
+        { ok: false, kind: "conflict" },
+        { ok: false, kind: "conflict" },
+      ],
+    });
+
+    const result = await DavflareQuickSave.saveBookmark(harness.deps, page);
+    expect(result).toEqual({ ok: false, kind: "conflict" });
+    expect(harness.gets).toHaveLength(2);
+    expect(harness.puts.map((p) => p.etag)).toEqual(['"e1"', '"e2"']);
+    // Cache etag stays consistent with the last observed remote GET.
+    expect(harness.getCache()?.etag).toBe('"e2"');
+  });
+
+  test("non-conflict PUT failure does not retry", async () => {
+    const harness = makeDeps({
+      cache: {
+        model: Bookmarks.normalizeModel(Bookmarks.emptyModel()),
+        etag: '"ok"',
+      },
+      getSequence: [],
+      putSequence: [{ ok: false, kind: "unauthorized" }],
+    });
+    const result = await DavflareQuickSave.saveBookmark(harness.deps, page);
+    expect(result).toEqual({ ok: false, kind: "unauthorized" });
+    expect(harness.gets).toHaveLength(0);
+    expect(harness.puts).toHaveLength(1);
+  });
+
+  test("url already in cached model reports exists without network", async () => {
+    const model = Bookmarks.addBookmark(Bookmarks.emptyModel(), {
+      title: "New Page",
+      url: page.url,
+      added: 1,
+    }).model;
+    const harness = makeDeps({
+      cache: { model, etag: '"x"' },
+      getSequence: [],
+      putSequence: [],
+    });
+    const result = await DavflareQuickSave.saveBookmark(harness.deps, page);
+    expect(result).toEqual({ ok: true, status: "exists" });
+    expect(harness.puts).toHaveLength(0);
+    expect(harness.gets).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary
- **#71** Context-menu / silent `savePage` often failed with *The library changed elsewhere* after #70: cached `bookmarksCache` etag → If-Match 412, and the follow-up write path did not reliably recover.
- Extract `extension/quickSave.js`: on 412, clear stale cache etag → unconditional GET → merge → retry PUT once; rewrite cache etag after every observed GET/PUT so a stale If-Match cannot stick.
- `dav.js` fetch uses `cache: "no-store"` so HTTP cache cannot re-serve an old ETag after a conflict.
- Manifest **1.3.2 → 1.3.3**.

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npx vitest run` (872 passed) incl. `extensionQuickSave` (412→retry success, still-conflict failure + cache etag) and dav `cache: no-store`
- [ ] Manual: large library — right-click Save on a new https URL should write remotely (not only toast conflict); popup save still OK

Fixes #71