### PR TITLE
fix(扩展): 右键收藏 try/catch + 缓存写入不阻断 PUT (#73)

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -50,6 +50,10 @@ var ERROR_COPY = {
     en: "The library changed elsewhere. Please retry.",
     zh: "书签库已在别处更新，请重试。",
   },
+  unexpected: {
+    en: "Something went wrong while saving. Please retry.",
+    zh: "收藏时出错，请重试。",
+  },
 };
 
 function pickLang() {
@@ -136,17 +140,23 @@ async function readBookmarksCache() {
 }
 
 async function writeBookmarksCache(model, etag) {
-  var normalized = Bookmarks.normalizeModel(model);
-  var payload = {};
-  payload[CACHE_KEY] = {
-    model: normalized,
-    etag: etag || null,
-    syncedAt: Date.now(),
-    bytes:
-      Bookmarks.serializeHtml(normalized).length +
-      Bookmarks.modelToJsonText(normalized).length,
-  };
-  await chrome.storage.local.set(payload);
+  // Best-effort like the popup (#73): large libraries can exceed storage
+  // quota; never throw into savePage and abort the WebDAV write.
+  try {
+    var normalized = Bookmarks.normalizeModel(model);
+    var payload = {};
+    payload[CACHE_KEY] = {
+      model: normalized,
+      etag: etag || null,
+      syncedAt: Date.now(),
+      bytes:
+        Bookmarks.serializeHtml(normalized).length +
+        Bookmarks.modelToJsonText(normalized).length,
+    };
+    await chrome.storage.local.set(payload);
+  } catch (err) {
+    /* ignore — remote write must still proceed / report its own result */
+  }
 }
 
 function parseRemoteLibrary(res) {
@@ -167,7 +177,7 @@ async function toggleDefaultMode() {
 }
 
 /**
- * Context-menu / fallback quick-save (#68 / #71).
+ * Context-menu / fallback quick-save (#68 / #71 / #73).
  *
  * MV3 service workers are killed if the click listener does not return the
  * async work as a Promise — previously savePage was fire-and-forget, so a
@@ -175,39 +185,47 @@ async function toggleDefaultMode() {
  * write. We prefer the local bookmarksCache (+ etag) for a fast PUT, and on
  * 412 we re-GET the latest etag, merge, and retry PUT once (#71) so a stale
  * If-Match from cache does not leave the user with only a conflict toast.
+ *
+ * #73: wrap the whole body in try/catch so an unexpected throw after
+ * flashBadge("…") still reaches failFeedback (badge + notification) instead
+ * of dying silently when the SW tears down a rejected listener Promise.
  */
 async function savePage(tab) {
   var copy = t();
   flashBadge("…");
-  var url = (tab && tab.url) || "";
-  var title = (tab && tab.title) || "";
-  if (!Bookmarks.isWebUrl(url)) {
-    failFeedback(copy.skipPage);
-    return;
-  }
+  try {
+    var url = (tab && tab.url) || "";
+    var title = (tab && tab.title) || "";
+    if (!Bookmarks.isWebUrl(url)) {
+      failFeedback(copy.skipPage);
+      return;
+    }
 
-  var cfg = await loadConfig();
-  if (!cfg.instanceUrl) {
-    failFeedback(copy.needConfig);
-    return;
-  }
+    var cfg = await loadConfig();
+    if (!cfg.instanceUrl) {
+      failFeedback(copy.needConfig);
+      return;
+    }
 
-  var result = await DavflareQuickSave.saveBookmark(
-    {
-      client: DavflareDav.createDavClient(cfg),
-      Bookmarks: Bookmarks,
-      readCache: readBookmarksCache,
-      writeCache: writeBookmarksCache,
-      parseRemote: parseRemoteLibrary,
-    },
-    { title: title, url: url, added: Date.now() }
-  );
+    var result = await DavflareQuickSave.saveBookmark(
+      {
+        client: DavflareDav.createDavClient(cfg),
+        Bookmarks: Bookmarks,
+        readCache: readBookmarksCache,
+        writeCache: writeBookmarksCache,
+        parseRemote: parseRemoteLibrary,
+      },
+      { title: title, url: url, added: Date.now() }
+    );
 
-  if (result.ok) {
-    okFeedback(result.status === "exists" ? copy.saveExists : copy.saveOk);
-    return;
+    if (result.ok) {
+      okFeedback(result.status === "exists" ? copy.saveExists : copy.saveOk);
+      return;
+    }
+    failFeedback(errorText(result.kind));
+  } catch (err) {
+    failFeedback(errorText("unexpected"));
   }
-  failFeedback(errorText(result.kind));
 }
 
 /**
@@ -318,7 +336,9 @@ chrome.omnibox.onInputEntered.addListener(async function (text, disposition) {
   }
 });
 
-// Return the Promise so MV3 keeps the service worker alive until save finishes (#68).
+// Return the Promise from the listener so MV3 keeps the service worker alive
+// for the full async write + badge/notification (#68 / #73). Do not fire-and-
+// forget savePage — a discarded Promise lets Chrome kill the SW mid-flight.
 chrome.contextMenus.onClicked.addListener(function (info, tab) {
   if (info.menuItemId === MENU_MODE) {
     return toggleDefaultMode();

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Davflare",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "description": "Save any page to your own WebDAV bookmark library from the toolbar popup.",
   "icons": {
     "16": "icons/icon16.png",

--- a/extension/quickSave.js
+++ b/extension/quickSave.js
@@ -1,7 +1,7 @@
 "use strict";
 
 /**
- * Context-menu / silent quick-save core (#71).
+ * Context-menu / silent quick-save core (#71 / #73).
  *
  * Separated from background.js so vitest can exercise the 412→re-GET→merge→
  * retry PUT loop without Chrome APIs. background.js only maps the result to
@@ -10,6 +10,19 @@
  * Plain script with a module.exports guard so vitest can require() it.
  */
 var DavflareQuickSave = (function () {
+  /**
+   * Cache writes are best-effort (#73). On a large library, chrome.storage.local
+   * may reject (quota / serialization). Never let that abort the WebDAV PUT —
+   * the popup path already ignores storage errors the same way.
+   */
+  async function safeWriteCache(writeCache, model, etag) {
+    try {
+      await writeCache(model, etag);
+    } catch (err) {
+      /* ignore — remote write must still proceed */
+    }
+  }
+
   /**
    * Persist one bookmark via WebDAV.
    *
@@ -64,7 +77,7 @@ var DavflareQuickSave = (function () {
           etag: cachedEtag,
         });
         if (putCached.ok) {
-          await writeCache(early.model, putCached.etag || null);
+          await safeWriteCache(writeCache, early.model, putCached.etag || null);
           return { ok: true, status: "saved" };
         }
         if (putCached.kind !== "conflict") {
@@ -72,7 +85,7 @@ var DavflareQuickSave = (function () {
         }
         // Stale cache etag — drop it before the GET/merge loop so we never
         // keep serving a precondition that already failed (#71).
-        await writeCache(cachedModel, null);
+        await safeWriteCache(writeCache, cachedModel, null);
       }
     }
 
@@ -87,8 +100,8 @@ var DavflareQuickSave = (function () {
       var model = parseRemote(res);
       // Keep cache etag aligned with what we just observed remotely, even
       // before the PUT — so a later conflict path does not re-use a stale
-      // If-Match from bookmarksCache.
-      await writeCache(model, res.etag || null);
+      // If-Match from bookmarksCache. Best-effort: never block the PUT (#73).
+      await safeWriteCache(writeCache, model, res.etag || null);
 
       var add = Bookmarks.addBookmark(model, {
         title: title,
@@ -105,7 +118,7 @@ var DavflareQuickSave = (function () {
         etag: res.etag || null,
       });
       if (put.ok) {
-        await writeCache(add.model, put.etag || null);
+        await safeWriteCache(writeCache, add.model, put.etag || null);
         return { ok: true, status: "saved" };
       }
       if (put.kind !== "conflict") {
@@ -121,7 +134,7 @@ var DavflareQuickSave = (function () {
     return { ok: false, kind: "conflict" };
   }
 
-  return { saveBookmark: saveBookmark };
+  return { saveBookmark: saveBookmark, safeWriteCache: safeWriteCache };
 })();
 
 if (typeof module !== "undefined" && module.exports) {

--- a/src/app/__tests__/extension.test.ts
+++ b/src/app/__tests__/extension.test.ts
@@ -121,6 +121,12 @@ describe("Davflare Chrome extension / default package", () => {
     expect(bg).toContain('importScripts("url.js", "bookmarks.js", "dav.js", "quickSave.js")');
     expect(bg).toContain("DavflareQuickSave.saveBookmark");
     expect(fs.existsSync(path.join(extDir, "quickSave.js"))).toBe(true);
+    // #73: savePage try/catch + return Promise from onClicked so MV3 SW stays alive
+    // and unexpected throws still reach failFeedback (badge + notification).
+    expect(bg).toMatch(/async function savePage\([\s\S]*?try\s*\{/);
+    expect(bg).toMatch(/catch\s*\([^)]*\)\s*\{\s*failFeedback\(/);
+    expect(bg).toContain("return savePage(tab)");
+    expect(bg).toContain("chrome.contextMenus.onClicked.addListener");
   });
 
   test("standalone options page is gone; settings live in the shell page", () => {

--- a/src/app/__tests__/extensionQuickSave.test.ts
+++ b/src/app/__tests__/extensionQuickSave.test.ts
@@ -122,7 +122,7 @@ function makeDeps(options: {
   };
 }
 
-describe("extension/quickSave.js (#71 If-Match conflict retry)", () => {
+describe("extension/quickSave.js (#71 If-Match conflict retry / #73 cache harden)", () => {
   const page = {
     title: "New Page",
     url: "https://example.com/fresh",
@@ -218,5 +218,57 @@ describe("extension/quickSave.js (#71 If-Match conflict retry)", () => {
     expect(result).toEqual({ ok: true, status: "exists" });
     expect(harness.puts).toHaveLength(0);
     expect(harness.gets).toHaveLength(0);
+  });
+
+  test("writeCache throw after GET does not abort PUT (#73 large-library quota)", async () => {
+    let writes = 0;
+    const harness = makeDeps({
+      cache: null,
+      getSequence: [
+        {
+          ok: true,
+          html: htmlWith("https://example.com/a", "A"),
+          etag: '"e1"',
+        },
+      ],
+      putSequence: [{ ok: true, etag: '"after"' }],
+    });
+    const throwingWrite = async (model: unknown, etag: string | null) => {
+      writes += 1;
+      // First write (post-GET, pre-PUT) blows up — must not prevent PUT.
+      if (writes === 1) {
+        throw new Error("QuotaExceededError");
+      }
+      return harness.deps.writeCache(model, etag);
+    };
+
+    const result = await DavflareQuickSave.saveBookmark(
+      { ...harness.deps, writeCache: throwingWrite },
+      page
+    );
+    expect(result).toEqual({ ok: true, status: "saved" });
+    expect(harness.puts).toHaveLength(1);
+    expect(harness.puts[0].html).toContain("https://example.com/fresh");
+    expect(harness.puts[0].html).toContain("https://example.com/a");
+  });
+
+  test("writeCache throw after successful PUT still reports saved (#73)", async () => {
+    const harness = makeDeps({
+      cache: {
+        model: Bookmarks.normalizeModel(Bookmarks.emptyModel()),
+        etag: '"ok"',
+      },
+      getSequence: [],
+      putSequence: [{ ok: true, etag: '"written"' }],
+    });
+    const throwingWrite = async () => {
+      throw new Error("QuotaExceededError");
+    };
+    const result = await DavflareQuickSave.saveBookmark(
+      { ...harness.deps, writeCache: throwingWrite },
+      page
+    );
+    expect(result).toEqual({ ok: true, status: "saved" });
+    expect(harness.puts).toHaveLength(1);
   });
 });


### PR DESCRIPTION
## Summary
- **#73** After 1.3.3, PM retest: popup save OK on large library, but right-click still does **not** write and shows almost **no** feedback.
- Root cause narrows to the SW silent path vs popup: (1) `savePage` had no try/catch — any throw after `flashBadge("…")` never reached `failFeedback`; (2) `quickSave` **awaited** `writeCache` *before* PUT — on large libraries `chrome.storage.local` quota/serialization can reject, aborting the WebDAV write (popup already ignores storage errors).
- Fix: wrap `savePage` in try/catch → `failFeedback`; keep `contextMenus.onClicked` **returning** the `savePage` Promise so MV3 keeps the SW alive for the full async write+feedback; make cache writes best-effort in `quickSave` + `writeBookmarksCache`.
- Manifest **1.3.3 → 1.3.4**.

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npx vitest run` (874 passed) incl. writeCache-throw-still-PUTs + background contract asserts (#73)
- [ ] Manual (PM): large library — right-click Save on a new https URL should write remotely + show badge/notification; second click → exists; popup still OK

Fixes #73
