### PR TITLE
fix(扩展): SW 无 DOMParser 时 JSON 优先解析远端书签库 (#75)

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -64,18 +64,29 @@ function t() {
   return MESSAGES[pickLang()];
 }
 
-function errorText(kind) {
+function errorText(kind, detail) {
   var known = ERROR_COPY[kind];
-  if (known) return known[pickLang()];
-  if (kind && String(kind).indexOf("http") === 0) {
+  var base;
+  if (known) {
+    base = known[pickLang()];
+  } else if (kind && String(kind).indexOf("http") === 0) {
     var code = String(kind).slice(4);
-    return pickLang() === "zh"
-      ? "实例返回了未预期的响应（HTTP " + code + "）。"
-      : "Unexpected response from the instance (HTTP " + code + ").";
+    base =
+      pickLang() === "zh"
+        ? "实例返回了未预期的响应（HTTP " + code + "）。"
+        : "Unexpected response from the instance (HTTP " + code + ").";
+  } else {
+    base =
+      pickLang() === "zh"
+        ? "实例返回了未预期的响应。"
+        : "Unexpected response from the instance.";
   }
-  return pickLang() === "zh"
-    ? "实例返回了未预期的响应。"
-    : "Unexpected response from the instance.";
+  // #75: append throw/message detail on unexpected so QA is not blind.
+  if (kind === "unexpected" && detail) {
+    var clipped = String(detail).replace(/\s+/g, " ").trim().slice(0, 160);
+    if (clipped) base = base + " (" + clipped + ")";
+  }
+  return base;
 }
 
 function flashBadge(text) {
@@ -160,12 +171,7 @@ async function writeBookmarksCache(model, etag) {
 }
 
 function parseRemoteLibrary(res) {
-  var model = Bookmarks.parseHtml(res.html || "");
-  if (res.jsonText) {
-    var parsed = Bookmarks.modelFromJson(res.jsonText);
-    if (parsed.ok) model = Bookmarks.adoptRichFields(model, parsed.model);
-  }
-  return model;
+  return Bookmarks.parseRemoteLibrary(res);
 }
 
 async function toggleDefaultMode() {
@@ -189,6 +195,8 @@ async function toggleDefaultMode() {
  * #73: wrap the whole body in try/catch so an unexpected throw after
  * flashBadge("…") still reaches failFeedback (badge + notification) instead
  * of dying silently when the SW tears down a rejected listener Promise.
+ * #75: unexpected copy includes err.message; parseRemote prefers JSON so the
+ * SW never needs DOMParser for a normal Davflare library GET.
  */
 async function savePage(tab) {
   var copy = t();
@@ -222,9 +230,10 @@ async function savePage(tab) {
       okFeedback(result.status === "exists" ? copy.saveExists : copy.saveOk);
       return;
     }
-    failFeedback(errorText(result.kind));
+    failFeedback(errorText(result.kind, result.message));
   } catch (err) {
-    failFeedback(errorText("unexpected"));
+    var detail = err && err.message ? String(err.message) : String(err || "");
+    failFeedback(errorText("unexpected", detail));
   }
 }
 

--- a/extension/bookmarks.js
+++ b/extension/bookmarks.js
@@ -168,15 +168,129 @@ var Bookmarks = (function () {
     walkLevel(dl, path, out, { heading: null });
   }
 
-  function parseHtml(text) {
-    if (typeof DOMParser === "undefined") {
-      throw new Error("parseHtml requires DOMParser");
-    }
-    var doc = new DOMParser().parseFromString(String(text || ""), "text/html");
-    var rootDl = doc.querySelector("dl");
+  function decodeBasicEntities(value) {
+    return String(value == null ? "" : value)
+      .replace(/&nbsp;/gi, " ")
+      .replace(/&amp;/g, "&")
+      .replace(/&lt;/g, "<")
+      .replace(/&gt;/g, ">")
+      .replace(/&quot;/g, '"')
+      .replace(/&#(\d+);/g, function (_, n) {
+        return String.fromCharCode(parseInt(n, 10));
+      })
+      .replace(/&#x([0-9a-f]+);/gi, function (_, n) {
+        return String.fromCharCode(parseInt(n, 16));
+      });
+  }
+
+  /**
+   * Netscape HTML tokenizer for environments without DOMParser (MV3 service
+   * workers — #75). Mirrors walkLevel/collectLevel: Hn names the next A/DL at
+   * this level; nested DL inherits joinFolder(path, heading).
+   */
+  function parseHtmlFallback(text) {
+    var src = String(text || "");
     var out = [];
-    if (rootDl) collectLevel(rootDl, "", out);
+    var stack = [];
+    var pendingHeading = null;
+    var i = 0;
+
+    function currentPath() {
+      return stack.length ? stack[stack.length - 1] : "";
+    }
+
+    while (i < src.length) {
+      if (src.charAt(i) !== "<") {
+        var nextLt = src.indexOf("<", i + 1);
+        i = nextLt === -1 ? src.length : nextLt;
+        continue;
+      }
+      var slice = src.slice(i);
+      var mDlOpen = /^<DL\b[^>]*>/i.exec(slice);
+      if (mDlOpen) {
+        stack.push(joinFolder(currentPath(), pendingHeading));
+        pendingHeading = null;
+        i += mDlOpen[0].length;
+        continue;
+      }
+      var mDlClose = /^<\/DL\b[^>]*>/i.exec(slice);
+      if (mDlClose) {
+        if (stack.length) stack.pop();
+        pendingHeading = null;
+        i += mDlClose[0].length;
+        continue;
+      }
+      var mH = /^<H([2-5])\b[^>]*>([\s\S]*?)<\/H\1>/i.exec(slice);
+      if (mH) {
+        var heading = decodeBasicEntities(mH[2].replace(/<[^>]+>/g, "")).trim();
+        pendingHeading = heading || null;
+        i += mH[0].length;
+        continue;
+      }
+      var mA = /^<A\s+([^>]*)>([\s\S]*?)<\/A>/i.exec(slice);
+      if (mA) {
+        var attrs = mA[1];
+        var hrefM =
+          /\bHREF\s*=\s*"([^"]*)"/i.exec(attrs) ||
+          /\bHREF\s*=\s*'([^']*)'/i.exec(attrs) ||
+          /\bHREF\s*=\s*([^\s>]+)/i.exec(attrs);
+        var addM =
+          /\bADD_DATE\s*=\s*"([^"]*)"/i.exec(attrs) ||
+          /\bADD_DATE\s*=\s*'([^']*)'/i.exec(attrs) ||
+          /\bADD_DATE\s*=\s*([^\s>]+)/i.exec(attrs);
+        var href = hrefM ? decodeBasicEntities(hrefM[1]).trim() : "";
+        var title = decodeBasicEntities(mA[2].replace(/<[^>]+>/g, "")).trim();
+        if (isWebUrl(href)) {
+          var addRaw = addM ? parseInt(addM[1], 10) : NaN;
+          out.push(
+            sanitizeBookmark({
+              title: title,
+              url: href,
+              folder: joinFolder(currentPath(), pendingHeading),
+              added: isFinite(addRaw) && addRaw > 0 ? addRaw * 1000 : 0,
+            })
+          );
+        }
+        i += mA[0].length;
+        continue;
+      }
+      i += 1;
+    }
     return { version: MODEL_VERSION, bookmarks: out };
+  }
+
+  function parseHtml(text) {
+    if (typeof DOMParser !== "undefined") {
+      var doc = new DOMParser().parseFromString(String(text || ""), "text/html");
+      var rootDl = doc.querySelector("dl");
+      var out = [];
+      if (rootDl) collectLevel(rootDl, "", out);
+      return { version: MODEL_VERSION, bookmarks: out };
+    }
+    return parseHtmlFallback(text);
+  }
+
+  /**
+   * Build a model from a getBookmarks() response.
+   *
+   * Prefer the JSON sidecar when present — it is complete for Davflare writes
+   * and parses without DOMParser, which MV3 service workers lack (#75). When
+   * both HTML and JSON exist in a DOM context, keep html-wins membership and
+   * adopt rich fields from JSON (same as the library page).
+   */
+  function parseRemoteLibrary(res) {
+    res = res || {};
+    var jsonModel = null;
+    if (res.jsonText) {
+      var parsed = modelFromJson(res.jsonText);
+      if (parsed.ok) jsonModel = parsed.model;
+    }
+    var html = res.html || "";
+    if (jsonModel && html && typeof DOMParser !== "undefined") {
+      return adoptRichFields(parseHtml(html), jsonModel);
+    }
+    if (jsonModel) return jsonModel;
+    return parseHtml(html);
   }
 
   function buildTree(model) {
@@ -478,6 +592,7 @@ var Bookmarks = (function () {
     modelToJsonText: modelToJsonText,
     normalizeModel: normalizeModel,
     parseHtml: parseHtml,
+    parseRemoteLibrary: parseRemoteLibrary,
     removeBookmark: removeBookmark,
     searchBookmarks: searchBookmarks,
     serializeHtml: serializeHtml,

--- a/extension/bookmarksApp.js
+++ b/extension/bookmarksApp.js
@@ -510,11 +510,7 @@ async function refresh() {
       renderAll();
       return;
     }
-    var model = Bookmarks.parseHtml(res.html || "");
-    if (res.jsonText) {
-      var parsed = Bookmarks.modelFromJson(res.jsonText);
-      if (parsed.ok) model = Bookmarks.adoptRichFields(model, parsed.model);
-    }
+    var model = Bookmarks.parseRemoteLibrary(res);
     state.model = model;
     state.etag = res.etag;
     state.bytes = computeBytes();

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Davflare",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "description": "Save any page to your own WebDAV bookmark library from the toolbar popup.",
   "icons": {
     "16": "icons/icon16.png",

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -211,12 +211,7 @@ function writeCache(model, etag) {
 }
 
 function parseRemoteLibrary(res) {
-  var model = Bookmarks.parseHtml(res.html || "");
-  if (res.jsonText) {
-    var parsed = Bookmarks.modelFromJson(res.jsonText);
-    if (parsed.ok) model = Bookmarks.adoptRichFields(model, parsed.model);
-  }
-  return model;
+  return Bookmarks.parseRemoteLibrary(res);
 }
 
 /**
@@ -446,7 +441,12 @@ async function init() {
       prefillTitle: true,
       prefillFolder: true,
     });
-    softSync(cfg);
+    // #75 / #69: skip soft-sync when the cache was written recently so Save
+    // stays in the 2–3s path instead of re-downloading a large library.
+    var syncedAt = typeof cache.syncedAt === "number" ? cache.syncedAt : 0;
+    if (!syncedAt || Date.now() - syncedAt > 120000) {
+      softSync(cfg);
+    }
     return;
   }
 

--- a/extension/quickSave.js
+++ b/extension/quickSave.js
@@ -97,7 +97,18 @@ var DavflareQuickSave = (function () {
         return { ok: false, kind: res.kind || "network" };
       }
 
-      var model = parseRemote(res);
+      var model;
+      try {
+        model = parseRemote(res);
+      } catch (err) {
+        // #75: surface the real throw (e.g. legacy DOMParser miss) instead of
+        // a blind unexpected in savePage.
+        return {
+          ok: false,
+          kind: "unexpected",
+          message: err && err.message ? String(err.message) : String(err || ""),
+        };
+      }
       // Keep cache etag aligned with what we just observed remotely, even
       // before the PUT — so a later conflict path does not re-use a stale
       // If-Match from bookmarksCache. Best-effort: never block the PUT (#73).

--- a/src/app/__tests__/extension.test.ts
+++ b/src/app/__tests__/extension.test.ts
@@ -121,10 +121,14 @@ describe("Davflare Chrome extension / default package", () => {
     expect(bg).toContain('importScripts("url.js", "bookmarks.js", "dav.js", "quickSave.js")');
     expect(bg).toContain("DavflareQuickSave.saveBookmark");
     expect(fs.existsSync(path.join(extDir, "quickSave.js"))).toBe(true);
-    // #73: savePage try/catch + return Promise from onClicked so MV3 SW stays alive
+        // #73: savePage try/catch + return Promise from onClicked so MV3 SW stays alive
     // and unexpected throws still reach failFeedback (badge + notification).
+    // #75: catch surfaces err.message; parseRemote delegates to Bookmarks
+    // (JSON-first, SW-safe — no DOMParser required).
     expect(bg).toMatch(/async function savePage\([\s\S]*?try\s*\{/);
-    expect(bg).toMatch(/catch\s*\([^)]*\)\s*\{\s*failFeedback\(/);
+    expect(bg).toMatch(/catch\s*\([^)]*\)\s*\{[\s\S]*?failFeedback\(/);
+    expect(bg).toContain('errorText("unexpected"');
+    expect(bg).toContain("Bookmarks.parseRemoteLibrary");
     expect(bg).toContain("return savePage(tab)");
     expect(bg).toContain("chrome.contextMenus.onClicked.addListener");
   });

--- a/src/app/__tests__/extensionBookmarks.test.ts
+++ b/src/app/__tests__/extensionBookmarks.test.ts
@@ -21,6 +21,10 @@ const Bookmarks = nodeRequire("../../../extension/bookmarks.js") as {
   modelToJsonText: (model: unknown) => string;
   normalizeModel: (raw: unknown) => BookmarkModel;
   parseHtml: (text: string) => BookmarkModel;
+  parseRemoteLibrary: (res: {
+    html?: string;
+    jsonText?: string | null;
+  }) => BookmarkModel;
   removeBookmark: (model: unknown, id: string) => BookmarkModel;
   searchBookmarks: (
     model: unknown,
@@ -106,6 +110,82 @@ describe("extension/bookmarks.js parseHtml", () => {
       version: 1,
       bookmarks: [],
     });
+  });
+
+  test("fallback tokenizer matches DOM parse without DOMParser (#75 SW)", () => {
+    const RealDOMParser = (globalThis as { DOMParser?: unknown }).DOMParser;
+    // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
+    delete (globalThis as { DOMParser?: unknown }).DOMParser;
+    try {
+      const model = Bookmarks.parseHtml(CHROME_EXPORT);
+      expect(model.bookmarks).toHaveLength(4);
+      expect(model.bookmarks[0]).toMatchObject({
+        title: "Root Link",
+        url: "https://root.example/",
+        folder: "",
+      });
+      expect(model.bookmarks[3]).toMatchObject({
+        title: "Rust",
+        url: "https://rust-lang.org",
+        folder: "书签栏/Dev/Rust",
+      });
+      expect(model.bookmarks[2]).toMatchObject({
+        title: "A & B",
+        url: "https://example.org/?q=1&x=2",
+      });
+    } finally {
+      if (RealDOMParser) {
+        (globalThis as { DOMParser?: unknown }).DOMParser = RealDOMParser;
+      }
+    }
+  });
+});
+
+describe("extension/bookmarks.js parseRemoteLibrary (#75)", () => {
+  test("prefers JSON when HTML would need DOMParser", () => {
+    const model = Bookmarks.addBookmark(Bookmarks.emptyModel(), {
+      title: "T",
+      url: "https://json-only.example/",
+      folder: "Dev",
+      tags: ["a"],
+      added: 1_700_000_000_000,
+    }).model;
+    const RealDOMParser = (globalThis as { DOMParser?: unknown }).DOMParser;
+    // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
+    delete (globalThis as { DOMParser?: unknown }).DOMParser;
+    try {
+      const parsed = Bookmarks.parseRemoteLibrary({
+        html: "<p>ignored</p>",
+        jsonText: Bookmarks.modelToJsonText(model),
+      });
+      expect(parsed.bookmarks).toHaveLength(1);
+      expect(parsed.bookmarks[0]).toMatchObject({
+        url: "https://json-only.example/",
+        folder: "Dev",
+        tags: ["a"],
+      });
+    } finally {
+      if (RealDOMParser) {
+        (globalThis as { DOMParser?: unknown }).DOMParser = RealDOMParser;
+      }
+    }
+  });
+
+  test("HTML-only still works without DOMParser via fallback", () => {
+    const RealDOMParser = (globalThis as { DOMParser?: unknown }).DOMParser;
+    // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
+    delete (globalThis as { DOMParser?: unknown }).DOMParser;
+    try {
+      const parsed = Bookmarks.parseRemoteLibrary({
+        html: CHROME_EXPORT,
+        jsonText: null,
+      });
+      expect(parsed.bookmarks).toHaveLength(4);
+    } finally {
+      if (RealDOMParser) {
+        (globalThis as { DOMParser?: unknown }).DOMParser = RealDOMParser;
+      }
+    }
   });
 });
 

--- a/src/app/__tests__/extensionQuickSave.test.ts
+++ b/src/app/__tests__/extensionQuickSave.test.ts
@@ -14,13 +14,14 @@ const Bookmarks = nodeRequire("../../../extension/bookmarks.js") as {
   serializeHtml: (model: unknown) => string;
   adoptRichFields: (htmlModel: unknown, jsonModel: unknown) => unknown;
   modelFromJson: (text: string) => { ok: boolean; model?: unknown };
+  parseRemoteLibrary: (res: { html?: string; jsonText?: string | null }) => unknown;
 };
 
 const DavflareQuickSave = nodeRequire("../../../extension/quickSave.js") as {
   saveBookmark: (
     deps: Record<string, unknown>,
     page: { title: string; url: string; added?: number }
-  ) => Promise<{ ok: boolean; status?: string; kind?: string }>;
+  ) => Promise<{ ok: boolean; status?: string; kind?: string; message?: string }>;
 };
 
 type PutCall = { etag: string | null | undefined; html: string };
@@ -37,14 +38,7 @@ function htmlWith(url: string, title = "Remote") {
 }
 
 function parseRemote(res: { html?: string; jsonText?: string | null }) {
-  let model = Bookmarks.parseHtml(res.html || "");
-  if (res.jsonText) {
-    const parsed = Bookmarks.modelFromJson(res.jsonText);
-    if (parsed.ok && parsed.model) {
-      model = Bookmarks.adoptRichFields(model, parsed.model);
-    }
-  }
-  return model;
+  return Bookmarks.parseRemoteLibrary(res);
 }
 
 function makeDeps(options: {
@@ -122,7 +116,7 @@ function makeDeps(options: {
   };
 }
 
-describe("extension/quickSave.js (#71 If-Match conflict retry / #73 cache harden)", () => {
+describe("extension/quickSave.js (#71 If-Match conflict retry / #73 cache harden / #75 SW parse)", () => {
   const page = {
     title: "New Page",
     url: "https://example.com/fresh",
@@ -271,4 +265,62 @@ describe("extension/quickSave.js (#71 If-Match conflict retry / #73 cache harden
     expect(result).toEqual({ ok: true, status: "saved" });
     expect(harness.puts).toHaveLength(1);
   });
+
+  test("GET with JSON-only body saves without calling parseHtml (#75 SW / no DOMParser)", async () => {
+    const remoteModel = Bookmarks.addBookmark(Bookmarks.emptyModel(), {
+      title: "Other",
+      url: "https://example.com/other",
+      added: 1,
+    }).model;
+    const jsonText = Bookmarks.modelToJsonText(remoteModel);
+    // Simulate MV3 service worker: no DOMParser. JSON-first parseRemote must still work.
+    const RealDOMParser = (globalThis as { DOMParser?: unknown }).DOMParser;
+    // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
+    delete (globalThis as { DOMParser?: unknown }).DOMParser;
+    try {
+      const harness = makeDeps({
+        cache: null,
+        getSequence: [
+          {
+            ok: true,
+            html: "<p>not parseable without DOM and unused when JSON present</p>",
+            jsonText,
+            etag: '"e1"',
+          },
+        ],
+        putSequence: [{ ok: true, etag: '"after"' }],
+      });
+      const result = await DavflareQuickSave.saveBookmark(harness.deps, page);
+      expect(result).toEqual({ ok: true, status: "saved" });
+      expect(harness.puts).toHaveLength(1);
+      expect(harness.puts[0].html).toContain("https://example.com/fresh");
+      expect(harness.puts[0].html).toContain("https://example.com/other");
+    } finally {
+      if (RealDOMParser) {
+        (globalThis as { DOMParser?: unknown }).DOMParser = RealDOMParser;
+      }
+    }
+  });
+
+  test("parseRemote throw is returned as unexpected with message (#75)", async () => {
+    const harness = makeDeps({
+      cache: null,
+      getSequence: [{ ok: true, html: "<DL></DL>", etag: '"e1"' }],
+      putSequence: [],
+    });
+    const result = await DavflareQuickSave.saveBookmark(
+      {
+        ...harness.deps,
+        parseRemote: () => {
+          throw new Error("parseHtml requires DOMParser");
+        },
+      },
+      page
+    );
+    expect(result.ok).toBe(false);
+    expect(result.kind).toBe("unexpected");
+    expect(result.message).toContain("DOMParser");
+    expect(harness.puts).toHaveLength(0);
+  });
+
 });


### PR DESCRIPTION
## Summary
- **#75** After 1.3.4 (#74), failure feedback works (red ! + unexpected copy) but right-click **still does not write** a new https URL on a large library. Popup save on the same instance succeeds; after popup save, right-click correctly reports already in library.
- **Root cause:** MV3 service workers have **no `DOMParser`**. `parseRemoteLibrary` always called `Bookmarks.parseHtml` first, which threw `parseHtml requires DOMParser` on every GET→merge path (cold cache, missing etag, or 412 retry). That throw hit `savePage`'s catch → generic unexpected. The exists path never needed parse, so post-popup right-click looked fine.
- **Fix:**
  - `Bookmarks.parseRemoteLibrary`: **JSON-first** (complete for Davflare writes, no DOM); DOM html+json adopt only when DOMParser exists; HTML-only uses a Netscape **fallback tokenizer** when DOMParser is missing.
  - `savePage` / `quickSave`: unexpected includes `err.message` / parse throw message.
  - Popup: skip soft-sync when `bookmarksCache.syncedAt` is &lt; 2 minutes old (#69 regression / ~10s "Updating library…").
- Manifest **1.3.4 → 1.3.5**.

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npx vitest run` (879 passed) — SW/no-DOMParser JSON-first save, HTML fallback vs Chrome export, parseRemote throw → unexpected+message, background contract
- [ ] Manual (PM): large library — right-click Save on a **new** https URL writes remotely + ✓; second click → exists; unexpected (if any) shows message; warm popup Save without long soft-sync when cache is fresh

Fixes #75
