### PR TITLE
chore(扩展): bump to 1.3.6 after #78 library live-update

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Davflare",
-  "version": "1.3.5",
+  "version": "1.3.6",
   "description": "Save any page to your own WebDAV bookmark library from the toolbar popup.",
   "icons": {
     "16": "icons/icon16.png",


### PR DESCRIPTION
## Summary
- Bump `extension/manifest.json` **1.3.5 → 1.3.6** after #78 (library page `chrome.storage.onChanged` live-update + Refresh button, Closes #77).
- No product/code changes. Package/docs do not track the extension version.

## Test plan
- [ ] CI green (typecheck / unit / coverage / build / CLI / e2e)