### PR TITLE
fix(扩展): #80 写回安全与确认取消挂起（review follow-up）

### DIFF
--- a/extension/bookmarks.js
+++ b/extension/bookmarks.js
@@ -46,7 +46,7 @@ var Bookmarks = (function () {
       id: asString(src.id) || makeId(),
       title: asString(src.title),
       url: asString(src.url),
-      folder: asString(src.folder),
+      folder: sanitizeFolderPath(asString(src.folder)),
       tags: sanitizeTags(src.tags),
       note: asString(src.note),
       added: added,
@@ -65,23 +65,25 @@ var Bookmarks = (function () {
    * are otherwise implied by bookmark paths only. Kept sorted and unique;
    * path segments must be non-empty and free of "." / "..".
    */
+  /** One folder path: trim, drop empties / "." / ".."; "" means unfiled. */
+  function sanitizeFolderPath(value) {
+    var path =
+      typeof value === "string" ? value.trim().replace(/^\/+|\/+$/g, "") : "";
+    if (!path) return "";
+    var segs = path.split("/");
+    for (var j = 0; j < segs.length; j++) {
+      if (!segs[j] || segs[j] === "." || segs[j] === "..") return "";
+    }
+    return path;
+  }
+
   function sanitizeFolderList(value) {
     if (!Array.isArray(value)) return [];
     var seen = Object.create(null);
     var out = [];
     for (var i = 0; i < value.length; i++) {
-      var path =
-        typeof value[i] === "string" ? value[i].trim().replace(/^\/+|\/+$/g, "") : "";
+      var path = sanitizeFolderPath(value[i]);
       if (!path || seen[path]) continue;
-      var segs = path.split("/");
-      var bad = false;
-      for (var j = 0; j < segs.length; j++) {
-        if (!segs[j] || segs[j] === "." || segs[j] === "..") {
-          bad = true;
-          break;
-        }
-      }
-      if (bad) continue;
       seen[path] = true;
       out.push(path);
     }
@@ -520,7 +522,10 @@ var Bookmarks = (function () {
     var next = normalizeModel(model);
     var drop = idSet(ids);
     if (!drop) return next;
-    var target = String(folder == null ? "" : folder).trim().replace(/^\/+|\/+$/g, "");
+    var raw = String(folder == null ? "" : folder).trim().replace(/^\/+|\/+$/g, "");
+    var target = sanitizeFolderPath(raw);
+    // Reject junk paths (e.g. "../x") instead of silently unfiling.
+    if (raw && !target) return next;
     for (var i = 0; i < next.bookmarks.length; i++) {
       if (drop[next.bookmarks[i].id]) next.bookmarks[i].folder = target;
     }
@@ -579,8 +584,8 @@ var Bookmarks = (function () {
    */
   function renameFolder(model, fromPath, toPath) {
     var next = normalizeModel(model);
-    var from = String(fromPath == null ? "" : fromPath).trim().replace(/^\/+|\/+$/g, "");
-    var to = String(toPath == null ? "" : toPath).trim().replace(/^\/+|\/+$/g, "");
+    var from = sanitizeFolderPath(fromPath);
+    var to = sanitizeFolderPath(toPath);
     if (!from || !to || from === to) return next;
     function mapPath(path) {
       if (path === from) return to;
@@ -603,7 +608,7 @@ var Bookmarks = (function () {
   /** Declare an empty folder path; no-op when it already exists. */
   function addFolder(model, path) {
     var next = normalizeModel(model);
-    var clean = String(path == null ? "" : path).trim().replace(/^\/+|\/+$/g, "");
+    var clean = sanitizeFolderPath(path);
     if (!clean) return next;
     next.folders = sanitizeFolderList(next.folders.concat(clean));
     return next;

--- a/extension/bookmarksApp.js
+++ b/extension/bookmarksApp.js
@@ -454,6 +454,7 @@ var editingRuleId = null;
 var editingWsId = null;
 var tagDialogBookmark = null;
 var pendingConfirm = null;
+var pendingConfirmCancel = null;
 
 var lang =
   (navigator.language || "en").toLowerCase().indexOf("zh") === 0 ? "zh" : "en";
@@ -1219,9 +1220,10 @@ function pickBox(item) {
 }
 
 function togglePinBookmark(item) {
-  state.model = Bookmarks.setPinned(state.model, [item.id], !item.pinned);
+  var nextPinned = !item.pinned;
+  state.model = Bookmarks.setPinned(state.model, [item.id], nextPinned);
   persist().then(function (ok) {
-    if (ok) flashStatus(item.pinned ? t.pinAdd : t.pinRemove);
+    if (ok) flashStatus(nextPinned ? t.pinAdd : t.pinRemove);
   });
 }
 
@@ -2508,6 +2510,13 @@ async function submitFolderDialog(event) {
     $("folderError").textContent = t.invalidName;
     return;
   }
+  var segs = value.split("/");
+  for (var s = 0; s < segs.length; s++) {
+    if (!segs[s] || segs[s] === "." || segs[s] === "..") {
+      $("folderError").textContent = t.invalidName;
+      return;
+    }
+  }
   if (folderDialogMode === "rename") {
     if (value === folderDialogTarget) {
       $("folderDialog").close();
@@ -2657,9 +2666,18 @@ async function exportChromeWrite() {
   }
   if (clear && countSubtree(target) > 0) {
     var doomed = countSubtree(target);
-    await new Promise(function (resolve) {
-      confirmThen(fmt(t.exportChromeClearConfirm, { n: doomed }), resolve);
+    var confirmed = await new Promise(function (resolve) {
+      confirmThen(
+        fmt(t.exportChromeClearConfirm, { n: doomed }),
+        function () {
+          resolve(true);
+        },
+        function () {
+          resolve(false);
+        }
+      );
     });
+    if (!confirmed) return;
     for (var i = 0; i < target.children.length; i++) {
       await chrome.bookmarks.removeTree(target.children[i].id);
     }
@@ -2700,10 +2718,16 @@ async function exportHamHomeWrite() {
     return;
   }
   var cats = await hh.getFile("categories.json");
+  // Abort on read failure — never treat a network/auth error as "empty remote"
+  // or we would overwrite HamHome categories.json with a rebuilt tree (#80 review).
+  if (!cats.ok) {
+    showBanner(errorText(cats.kind), t.openSettings, openSettings);
+    return;
+  }
   var res = HamHome.exportTo(
     state.model,
     meta.missing ? null : meta.text,
-    cats.ok && !cats.missing ? cats.text : null,
+    cats.missing ? null : cats.text,
     Date.now()
   );
   if (!res.ok) {
@@ -2788,10 +2812,18 @@ async function onImportFilePicked(event) {
 
 /* ---------- dialogs ---------- */
 
-function confirmThen(message, fn) {
+function confirmThen(message, fn, onCancel) {
   pendingConfirm = fn;
+  pendingConfirmCancel = typeof onCancel === "function" ? onCancel : null;
   $("confirmText").textContent = message;
   $("confirmDialog").showModal();
+}
+
+function clearPendingConfirm() {
+  var cancel = pendingConfirmCancel;
+  pendingConfirm = null;
+  pendingConfirmCancel = null;
+  return cancel;
 }
 
 function openWsNameDialog(workspace, pendingPages) {
@@ -3120,11 +3152,18 @@ function wireEvents() {
     if (await persistTabRules()) renderTabRules();
   });
   $("confirmCancel").addEventListener("click", function () {
-    pendingConfirm = null;
+    var cancel = clearPendingConfirm();
     $("confirmDialog").close();
+    if (cancel) cancel();
+  });
+  $("confirmDialog").addEventListener("cancel", function () {
+    // Escape closes the dialog; treat as cancel so awaiters do not hang.
+    var cancel = clearPendingConfirm();
+    if (cancel) cancel();
   });
   $("confirmOk").addEventListener("click", function () {
     var fn = pendingConfirm;
+    pendingConfirmCancel = null;
     pendingConfirm = null;
     $("confirmDialog").close();
     if (fn) fn();

--- a/src/app/__tests__/extensionBatch.test.ts
+++ b/src/app/__tests__/extensionBatch.test.ts
@@ -97,6 +97,13 @@ describe("extension/bookmarks.js batch ops (#63)", () => {
     expect(unfiled.bookmarks[2].folder).toBe("");
   });
 
+  test("moveBookmarks / renameFolder reject . and .. path segments", () => {
+    const rejected = Bookmarks.moveBookmarks(base, ["a"], "../Escape");
+    expect(rejected.bookmarks[0].folder).toBe("Dev");
+    const renamed = Bookmarks.renameFolder(base, "Dev", "Dev/../Other");
+    expect(renamed.bookmarks[0].folder).toBe("Dev");
+  });
+
   test("adjustTags adds and removes without dupes", () => {
     const adjusted = Bookmarks.adjustTags(base, ["a", "b"], ["x", "z "], ["y"]);
     expect(adjusted.bookmarks[0].tags).toEqual(["x", "z"]);


### PR DESCRIPTION
## 背景
#80 已合入 main（`a8abeff`）。Review 发现两处合入前应修的问题，本 PR 补上。

## 修复
1. **HamHome 写回**：`categories.json` GET 失败时中止，避免被当成空远端后覆盖 HamHome 分类树
2. **Chrome「先清空目标夹」确认**：Cancel / Escape 正确 abort，不再 `await` 挂死
3. 文件夹路径统一 sanitize（move / rename / `bookmark.folder` 拒 `.` / `..`）
4. 置顶闪讯文案按操作后状态；新建/重命名对话框校验非法路径
5. 单测：`moveBookmarks` / `renameFolder` 拒非法路径

## 测试
- 本地 vitest：`extensionBatch` / `extensionHamhome` / `extensionBookmarksView` 全绿

Refs #80 / #63 / #64