### PR TITLE
chore(扩展): bump to 1.3.7 after #80–#82 bookmark library features

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Davflare",
-  "version": "1.3.6",
+  "version": "1.3.7",
   "description": "Save any page to your own WebDAV bookmark library from the toolbar popup.",
   "icons": {
     "16": "icons/icon16.png",


### PR DESCRIPTION
## Summary
- Bump `extension/manifest.json` **1.3.6 → 1.3.7** after #80/#81/#82 (bookmark library batch/pin/folders, Chrome/HamHome write-back safety, filter presets + portability docs; Closes #63 #64 already via #80).
- No product/code changes beyond the version string. Package/docs do not track the extension version.

## Test plan
- [ ] CI green (typecheck / unit / coverage / build / CLI / e2e)