### PR TITLE
docs: acknowledge HamHome bookmark library UX reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,6 +273,7 @@ SKIP_BUILD=1 npm run test:e2e   # reuse an existing build/ for faster iterations
 
 - [longern/FlareDrive](https://github.com/longern/FlareDrive) by [longern](https://github.com/longern) — original fork; this project has been fully rewritten since. Internal object prefix is still `_$flaredrive$/`.
 - [r2-webdav](https://github.com/abersheeran/r2-webdav) by [abersheeran](https://github.com/abersheeran) — WebDAV implementation.
+- [HamHome](https://github.com/bingoYB/ham_home) by [bingoYB](https://github.com/bingoYB) — bookmark library UX was inspired by this open-source reference.
 
 ## License
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -271,6 +271,7 @@ SKIP_BUILD=1 npm run test:e2e   # reuse an existing build/ for faster iterations
 
 - [longern/FlareDrive](https://github.com/longern/FlareDrive) by [longern](https://github.com/longern) —— 最初的 fork 来源；本项目此后已全面重写。内部对象前缀仍为 `_$flaredrive$/`。
 - [r2-webdav](https://github.com/abersheeran/r2-webdav) by [abersheeran](https://github.com/abersheeran) —— WebDAV 实现。
+- [HamHome](https://github.com/bingoYB/ham_home) by [bingoYB](https://github.com/bingoYB) —— 书签库交互参考，感谢开源。
 
 ## 许可证
 


### PR DESCRIPTION
## Summary
- Add HamHome ([bingoYB/ham_home](https://github.com/bingoYB/ham_home)) to README Acknowledgments / 致谢 as the bookmark library UX open-source reference.
- Docs-only; no extension version bump, no product changes.

## Test plan
- [x] README.md Acknowledgments lists HamHome with link
- [x] README.zh-CN.md 致谢 mirrors briefly
- [ ] CI green