### PR TITLE
docs: slim bilingual README; move detail into docs index

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,6 @@
 
 Cloudflare R2 file manager on Pages + Workers — free 10 GB storage and 100,000 Worker invocations per day. [R2 pricing](https://developers.cloudflare.com/r2/platform/pricing/)
 
-基于 Cloudflare R2 的网盘：免费 10GB 存储、每天 10 万次 Worker 调用。[R2 定价](https://developers.cloudflare.com/r2/platform/pricing/)
-
 ## Screenshots
 
 Grid light:
@@ -28,252 +26,38 @@ Share (expiry + extract code):
 
 ## Features
 
-- Chunked web uploads for large files
-- Folders, search, drag-and-drop, image/video/PDF thumbnails
-- Share links with expiry or forever, extract code, and folder zip download — the link opens a zero-JS landing page (light/dark) with name, type, size, shared time, and inline preview; `?download=1` for direct download, `?raw=1` for inline bytes
-- Recycle bin with `TRASH_RETENTION_DAYS` (default 30; `-1` disables; lazy purge up to 200 items when trash is opened)
-- WebDAV Class 1/2 at `/webdav` (can be switched off without affecting the web file manager)
-- API keys for scripted upload, download, and bidirectional sync
-- Remote MCP at `/mcp` (21 tools: files, search, move/copy, shares, sites, `pull` / `push` / `publish_site`, plus `image_upload` / `image_list` / `image_delete`). Uploads auto-chunk up to 25 MB; downloads page with `part`. **MCP requires an API Key** — if the API Key switch is off, `/mcp` is 404 even when the MCP switch is on
-- Sites manager in the UI (`#/sites`): zip deploy, SPA toggle, per-site delete
-- Static sites on a separate host (`SITES_HOST` + `sites/{slug}/`); [docs/sites.md](docs/sites.md)
-- Image host on the same sites hostname at `/i/{id}` (stored under `_$flaredrive$/img/`, not `sites/` or share links)
-- Owner Settings (`#/settings`) with five persistent feature switches (default all on)
-- `davflare-cli` for login / ls / mkdir / rm / mv / cp / sync ([cli/README.md](cli/README.md))
-- Optional Chrome MV3 extension in `extension/` (toolbar opens **your** instance; does not change the new tab)
-- Agent layouts on R2: `agents/{global|agent|agent/project}/{skills|rules|mcp}/` (`pull` / `push` tools; see [docs/agents.md](docs/agents.md)); reproducible demo in [`agents/examples/hello-site/`](agents/examples/hello-site/)
-- Chinese / English UI (globe icon in the header; defaults to browser language, persisted locally)
+- Chunked web uploads, folders, search, drag-and-drop, image/video/PDF thumbnails
+- Share links with expiry or forever, extract code, folder zip, and a zero-JS landing page
+- Recycle bin with configurable retention (`TRASH_RETENTION_DAYS`)
+- WebDAV Class 1/2 at `/webdav` (toggleable without affecting the web UI)
+- API keys for scripted upload / download / sync, plus remote MCP at `/mcp` (21 tools)
+- Static sites and image host on a separate hostname (`SITES_HOST`)
+- Owner Settings with five persistent feature switches
+- `davflare-cli`, optional Chrome MV3 extension, and agent layouts on R2
+- Chinese / English UI
 
-## Try it in Cursor (copy-paste)
+## Quick start
 
-1. Leave **API Key** + **MCP** + **Sites** on in `#/settings`. Create a key.
-2. Paste into Cursor `mcp.json` (replace host + key):
+1. One-click deploy with the button above (needs a Cloudflare account with R2 activated and a payment method on file).
+2. Bind your R2 bucket to `BUCKET`, set `WEBDAV_USERNAME` and `WEBDAV_PASSWORD`, then retry deploy.
+3. Optional: `WEBDAV_PUBLIC_READ=1`, `TRASH_RETENTION_DAYS` (default `30`, `-1` disables), and for public sites/images bind `sites.<your-domain>` and set `SITES_HOST=sites.<your-domain>`.
+4. Optional: add a custom domain for the drive UI.
 
-```json
-{
-  "mcpServers": {
-    "davflare": {
-      "url": "https://<your-domain.com>/mcp",
-      "headers": { "Authorization": "Bearer <apiKey>" }
-    }
-  }
-}
-```
+Manual Pages / Wrangler steps and the five feature switches: [docs/deploy.md](docs/deploy.md).
 
-3. Open this repo’s [`agents/examples/hello-site/`](agents/examples/hello-site/) and tell Cursor to follow `SKILL.md` (uses only `publish_site` / optional `image_upload`).
-4. When it finishes you get **`https://sites.<your-domain>/hello/`** (your real `SITES_HOST`). No public shared demo.
+## Documentation
 
-## Follow along
-
-Three short paths. Use **your** bound host — there is no public live demo other people can open.
-
-### Publish a static site from Cursor
-
-1. Wire MCP as in [Try it in Cursor](#try-it-in-cursor-copy-paste). Bind Pages env `SITES_HOST` and redeploy.
-2. Ask Cursor (copy-paste), with `agents/examples/hello-site/` in context:
-
-   ```
-   Follow agents/examples/hello-site/SKILL.md: upload index.html, then publish_site slug=hello from that folder. Done when https://<SITES_HOST>/hello/ returns 200.
-   ```
-
-3. Open `https://<SITES_HOST>/hello/` on the hostname you bound to **this** Pages project. Until `SITES_HOST` is set and redeployed, that URL will not open.
-
-### Host an image and copy its URL
-
-1. Open `#/images` in the drive UI.
-2. Drag an image onto the page (or click Upload).
-3. Click **Copy URL** or **Copy Markdown** (`![](https://<SITES_HOST>/i/{id})`). Public URLs only work after you bind a custom domain and set Pages env `SITES_HOST` (hostname only).
-
-### Toggle the five Settings switches
-
-1. Open `#/settings` from the account menu.
-2. The five switches are WebDAV, MCP, API Key, Sites, and Image host (all default on). Stored files are not deleted when a switch is off.
-3. MCP depends on API Key: if Key is off, `/mcp` is 404 even if MCP is on. Sites and image-host public URLs also need `SITES_HOST`.
-
-### Mount WebDAV with rclone (optional)
-
-1. In rclone: `rclone config` → New remote → type `webdav` → URL `https://<your-domain.com>/webdav` → vendor `other` → user/pass = your Pages `WEBDAV_USERNAME` / `WEBDAV_PASSWORD`.
-2. Leave the WebDAV switch on in `#/settings`.
-3. `rclone ls davflare:` (or whatever you named the remote) should list the drive root.
-
-## Deploy
-
-One-click:
-
-[![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/fanchenggang/Davflare)
-
-You need a [Cloudflare](https://dash.cloudflare.com/) account with a payment method and R2 activated (create at least one bucket).
-
-After the first deploy:
-
-1. Bind your R2 bucket to the `BUCKET` variable
-2. Set `WEBDAV_USERNAME` and `WEBDAV_PASSWORD`
-3. Optional: `WEBDAV_PUBLIC_READ=1` for public read; `TRASH_RETENTION_DAYS` (default `30`, `-1` disables purge)
-4. Optional static sites: bind `sites.<your-domain>` to this same Pages project and set `SITES_HOST=sites.<your-domain>`
-5. Retry deploy so the binding and env vars apply
-6. Optional: add a custom domain for the drive UI
-
-### Manual Cloudflare Pages
-
-- Framework preset: **None (React/Vite, not Docusaurus)**
-- Output directory: `build`
-- Then bind `BUCKET`, set the env vars above, and retry deploy
-
-### Wrangler CLI
-
-`wrangler.toml` binds R2 as `BUCKET` (default bucket name `webdav`). Change `bucket_name` to your bucket if needed.
-
-```bash
-npm run build
-npx wrangler pages deploy build
-```
-
-## WebDAV
-
-Endpoint: `https://<your-domain.com>/webdav`
-
-Use any WebDAV client (for example [Cx File Explorer](https://play.google.com/store/apps/details?id=com.cxinventor.file.explorer) or [BD File Manager](https://play.google.com/store/apps/details?id=com.liuzho.file.explorer)). Fill in the endpoint plus the username and password you set.
-
-Cloudflare Workers limit a single PUT to **128 MB**. Oversized PUTs return **HTTP 413** (Chinese message: use the web uploader). Upload large files through the web UI, which supports chunked uploads.
-
-The in-app WebDAV panel shows URL, username, and whether public-read is on. It does **not** display the password.
-
-## Open API
-
-Create keys in the web UI (「API」 / 「开放接口」). Auth: `Authorization: Bearer <apiKey>` or `X-Api-Key: <apiKey>`. Full request examples: [Open API docs](docs/API.md).
-
-| Method | Path | Purpose |
-| --- | --- | --- |
-| GET / PATCH | `/api/config` | Session: username, public-read, sitesHost, feature flags. PATCH is Basic-only |
-| GET / POST / DELETE | `/api/images` | Image host (session or API key): list, upload, delete. Public bytes on `SITES_HOST /i/{id}` |
-| GET / POST / DELETE | `/api/keys` | Create, list, and revoke keys (session auth) |
-| POST / PUT / DELETE | `/api/upload` | Upload a file (multipart, raw body, overwrite, or chunked >100MB) |
-| GET | `/api/list` | Depth-1 folder listing (size, uploaded, etag) |
-| GET | `/api/download` | Download one file (Range / 206 resume) |
-| POST | `/api/mkdir` | Create a folder (parents auto-created) |
-| POST | `/api/rename` | Rename or move a file or folder |
-| POST | `/api/copy` | Copy a file |
-| GET | `/api/stat` | Object metadata |
-| GET | `/api/search` | Filename substring search |
-| POST | `/api/backup` | Rename remote to `name.conflict-<UTC>` before overwrite |
-| DELETE | `/api/delete` | Hard delete, or `soft=1` to trash |
-| POST | `/api/shares` | Share a file or folder (folder → zip) |
-| GET / POST / DELETE | `/api/sites` | List, SPA-config, or delete static sites |
-| POST | `/mcp` | Remote MCP (JSON-RPC 2.0; same API keys; 21 tools) |
-
-Same keys work for a bidirectional sync client (local wins; backup remote on conflict). Details in the [API docs](docs/API.md).
-
-**Share links** (`/share/<token>`) return a server-rendered, zero-JS landing page: file name, type, size, shared time, plus inline preview (`<img>` / `<video>` / `<audio>` / `<iframe>`) for preview-safe types; the language follows `Accept-Language`. Scripts that used to download from the plain share link must switch: **`?download=1` returns the raw bytes as an attachment download** (folders stream the zip), and **`?raw=1` returns the body inline** for preview-safe types (image / video / audio / PDF / text), keeping the same security headers (`Content-Security-Policy: sandbox`, `X-Content-Type-Options: nosniff`) and Range support. Expired shares return **410**, revoked **404**, and extract-code gating applies to the page and both params alike.
-
-`GET /api/config` (session) returns username, public-read, `sitesHost`, and the five feature flags. `PATCH /api/config` updates flags and is **web session (Basic) only** — API keys cannot change switches.
-
-## Feature switches
-
-Owner-only Settings (`#/settings`, account menu) persist five flags in R2 at `_$flaredrive$/config.json` (survive deploys; not set in `wrangler.toml`). Default: all **on**.
-
-| Switch | Off means |
+| Topic | Link |
 | --- | --- |
-| WebDAV | Hide the WebDAV button/panel. Clients cannot mount `/webdav` (404). The web file manager still uses session (Basic) I/O. |
-| MCP | `POST /mcp` → 404; hide MCP copy in the API panel. |
-| API Key | Hide key management. Bearer / `X-Api-Key` Open API calls fail (401). Session APIs keep working. **MCP also becomes 404/unusable** because it authenticates with API keys. |
-| Sites | Hide `#/sites`. Slug sites on `SITES_HOST` 404. Objects under `sites/` are not deleted. |
-| Image host | Hide the image-host UI. `/i/*` on `SITES_HOST` 404. Stored images are not deleted. |
-
-`SITES_HOST` empty still turns public hosting off at the infra level. The Sites / Image host switches are extra product toggles when that host is bound.
-
-## MCP
-
-Same-origin Model Context Protocol (Streamable HTTP) at `/mcp`. Auth is the same API key as the Open API (`Authorization: Bearer <apiKey>` or `X-Api-Key`). **MCP depends on API Key: if the API Key switch is off, MCP is unusable even if the MCP switch is on.**
-
-Tools (21): `list`, `upload`, `download`, `mkdir`, `delete`, `search`, `move`, `copy`, `stat`, `share_create`, `share_list`, `share_revoke`, `sites_list`, `sites_config`, `sites_delete`, `pull`, `push`, `publish_site`, `image_upload`, `image_list`, `image_delete`.
-
-### Expiring share from chat
-
-1. Ask the agent to call `share_create` on a file or folder path, with `expiresInHours=24` (optional `extractCode`).
-2. Forward the returned share `url` (path `/share/{token}`).
-3. Manage with `share_list` / `share_revoke` (pass the `token`).
-
-Uploads up to 1 MiB go inline; larger content is auto-chunked (cap **25 MB**). Bigger files: web UI or `davflare-cli`. Downloads over 1 MiB page with `part` / `partSize`. Default `delete` is trash; `hard=true` permanently deletes. Publish a static site by uploading into `sites/{slug}/` (or `publish_site` from a drive folder), then `sites_config` if you need SPA fallback. `pull` / `push` walk `agents/…` (merge: project > agent > global). Details: [docs/API.md](docs/API.md).
-
-Cursor (`mcp.json`):
-
-```json
-{
-  "mcpServers": {
-    "davflare": {
-      "url": "https://<your-domain.com>/mcp",
-      "headers": {
-        "Authorization": "Bearer <apiKey>"
-      }
-    }
-  }
-}
-```
-
-## Static sites
-
-Public HTML from `sites/{slug}/` on a **separate hostname** (`SITES_HOST`). Same Worker, Host routing — not `/sites` on the drive origin.
-
-In the drive UI, **Sites** (`#/sites`) lists each slug with stats, one-click zip deploy, SPA toggle, and delete. MCP `sites_list` / `sites_config` / `sites_delete` wrap the same `/api/sites` endpoints. Details: [docs/sites.md](docs/sites.md).
-
-## CLI
-
-[`davflare-cli`](cli/README.md) is the Open API command-line client: `login`, `ls`, `mkdir`, `rm`, `mv`, `cp`, `sync`. Uploads over 100 MB are chunked; downloads resume with HTTP Range. See `cli/README.md` for install, login, and sync semantics.
-
-## Extension
-
-A Chrome Manifest V3 helper with two toolbar modes — open **your** Davflare drive, or a full bookmark library backed by your instance’s WebDAV. It is not on the Chrome Web Store.
-
-- **Settings live in the main page** — there is no standalone options page. The first launch of the extension page opens the settings view directly: paste your instance URL (Pages / custom domain, starts empty — no built-in site), bookmark directory, and WebDAV credentials; after saving and granting access you land in the drive/bookmarks view (HamHome-style: configure first, then use). The sidebar "Settings" view is always available for changes.
-- **Toolbar modes:** both click-actions open the extension's own page — *drive* (default) **mounts the same React components as the web UI** to render the file manager natively (no iframe involved, so the instance's `X-Frame-Options: DENY` no longer matters), *bookmarks* opens the bookmark library view. Pick the default in Settings; right-click the toolbar icon to switch anytime. With no instance configured, a toolbar click opens the settings view directly. The first visit to the drive view asks for host permission on the instance origin (the `/api/*` endpoints send no CORS headers, so search/trash/etc. need the grant; `/webdav` is CORS-open already); an "Open in new tab" button stays as a fallback.
-- **Save this page** appears in the page context menu — it merges the current tab’s title + URL into your WebDAV bookmark file.
-- WebDAV credentials (same values as your deployment’s `WEBDAV_USERNAME` / `WEBDAV_PASSWORD`) are stored **only** in `chrome.storage.local`; they never sync to a Google account. Saving an instance URL asks for per-site host permission (optional permissions — nothing is pre-granted).
-- **Does not change Chrome's new tab.** An older release shipped a second zip with a new-tab override; because Chrome's `chrome_url_overrides` can only be declared statically in the manifest (it takes over permanently once loaded, with no runtime toggle), that variant has been removed — a single package ships now.
-
-One zip on the GitHub Release: `davflare-extension.zip` (toolbar + in-shell settings + bookmark library + drive view).
-
-**Load unpacked:** Chrome → `chrome://extensions` → Developer mode → Load unpacked → select the `extension/` folder in this repo. Note: the drive view is a vite build product — run `npm ci && npm run build:extension` once before loading the source folder (without it, bookmarks and everything else work while the drive view shows a build hint; the release zip already contains the bundle).
-
-**Release zip:** download from [GitHub Releases](https://github.com/fanchenggang/Davflare/releases), unzip, then load unpacked. A tag (`v*` / `extension-*`) or **Actions → Release extension** attaches the zip.
-
-## Bookmarks (thin bookmarks P2)
-
-The extension’s bookmark library keeps your bookmarks **on your own WebDAV** — no third-party service, no AI. Requires the WebDAV feature switch to be on for your instance.
-
-- **Storage layout** (under your instance’s `/webdav/`, directory configurable in the in-shell Settings view — default `bookmarks/`; e.g. set `qa/bookmarks` to isolate test data): `bookmarks.html` is the authoritative Netscape bookmark file that Chrome/Edge can import directly; `bookmarks.json` is a sidecar carrying tags and notes that the HTML format cannot hold; `workspaces.json`, `tabGroups.json`, and `snapshots.json` hold the features below. Writes go through with `If-Match` (a 412 conflict is surfaced, never silently overwritten).
-- **Library page:** sidebar with folder/tag counts, keyword search over title/URL/tags/notes with **pinyin support** (full spelling and initials, thanks to a bundled compact dictionary), time-range filter, grid/list views, light/dark theme, import from Chrome bookmarks (optional `bookmarks` permission, merge by URL) and export to `bookmarks.html`.
-- **HamHome migration (read-only):** the library page imports from a [HamHome](https://github.com/bingoYB/ham_home) sync directory on the same instance — reads `/HamHomeSync/bookmarks/meta.json` + `categories.json` and merges by URL. Descriptions become notes, tags and category folders survive, deleted rows are skipped. Boundary: our own writes stay in our format; HamHome snapshots/workspaces/tab rules (stored in its IndexedDB or app-internal JSON) are not migrated.
-- **Workspaces:** save the current window — page order, pinned state, native tab-group metadata — and restore all or selected pages into a new window (duplicate URLs skipped, pinned/group state restored).
-- **Tab groups:** local rule engine (domain suffix / URL / title / regex, AND-combined) that groups the current window into native tab groups with custom title/color/collapse/priority; unmatched tabs can fall back to root-domain grouping. Rules sync via `tabGroups.json`.
-- **Snapshots:** capture the current page as a single self-contained HTML file (images best-effort inlined where CORS allows; scripts/iframes stripped; 8 MB cap) onto `bookmarks/snapshots/`. View, download, update, or delete from the bookmark editor. Cross-origin assets without CORS headers cannot be inlined (browser security), and restricted pages such as `chrome://` cannot be captured.
-- **Errors never fail silently:** a disabled WebDAV switch (404), missing server credentials (403), wrong credentials (401), and edit conflicts (412) each get a distinct message with a shortcut to Options.
-
-## Image host
-
-Upload images in the drive UI (`#/images`): drag/drop, copy the public URL or Markdown `![](url)`, list and delete. Blobs live at `_$flaredrive$/img/{id}` with an unguessable id (not the original filename). Public URL is only `https://<SITES_HOST>/i/{id}` (no scheme in `SITES_HOST`). SVG is served as a download (`Content-Disposition: attachment` + `nosniff`), never as a navigable document.
-
-On the sites host, `/i/{id}` is matched **before** slug static sites. The image-host switch is independent of the sites switch: sites off + image host on → slugs 404 but `/i/{id}` works; image host off → `/i/*` 404 even if sites is on. If `SITES_HOST` is unset, the switch can still exist but the UI tells you to bind the host first.
-
-## Agent layouts
-
-Skills, rules, and MCP snippets live on R2 under `agents/`. Repo demo: [`agents/examples/hello-site/`](agents/examples/hello-site/). v2 `pull` / `push` walk the R2 tree (or use the web UI). Merge order: project > agent > global. Never store raw API keys in `mcp.json` — use `${env:DAVFLARE_API_KEY}`. Cursor local paths: [docs/agents.md](docs/agents.md).
-
-## Development & testing
-
-```bash
-npm install
-
-npm run typecheck   # tsc --noEmit (covers src/ and functions/)
-npm test            # Vitest unit tests, single run
-npm run test:ci     # same suite (script name kept for CI compatibility)
-npm run test:coverage   # Vitest + v8 coverage (thresholds enforced)
-npm run build       # typecheck + production build into build/
-
-npm run test:e2e    # one-shot API regression: build → wrangler pages dev (local miniflare R2) → scripts/api-e2e.sh
-SKIP_BUILD=1 npm run test:e2e   # reuse an existing build/ for faster iterations
-```
-
-`test:e2e` creates a local `.dev.vars` (gitignored) with dev credentials if absent, boots `wrangler pages dev` on port 8788 (override with `PORT`), waits for readiness, runs the ~170-assertion suite against it, and tears the server down. Data lives in `.wrangler/state/` — delete that directory to reset the local bucket. See [TESTING.md](./TESTING.md) for the full verification history and [TEST_CASES.md](./TEST_CASES.md) for the manual GUI case library.
+| Deploy, env vars, feature switches | [docs/deploy.md](docs/deploy.md) |
+| WebDAV clients & limits | [docs/webdav.md](docs/webdav.md) |
+| Open API & MCP (incl. chat share example) | [docs/API.md](docs/API.md) |
+| Static sites & image host | [docs/sites.md](docs/sites.md) |
+| Agent layouts (`pull` / `push`) | [docs/agents.md](docs/agents.md) |
+| CLI (`davflare-cli`) | [cli/README.md](cli/README.md) |
+| Chrome extension (install + bookmarks) | [extension/README.md](extension/README.md) |
+| Bookmark portability | [docs/bookmarks-portability.md](docs/bookmarks-portability.md) |
+| Testing | [TESTING.md](TESTING.md) · [TEST_CASES.md](TEST_CASES.md) |
 
 ## Acknowledgments
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -26,252 +26,38 @@
 
 ## 功能
 
-- 网页端分片上传大文件
-- 文件夹、搜索、拖放，以及图片 / 视频 / PDF 缩略图
-- 分享链接（限时或永久）、提取码、文件夹 zip 下载 —— 链接打开零脚本落地页（亮暗双套，含文件名/类型/大小/分享时间与在线预览）；`?download=1` 直链下载，`?raw=1` 内联内容
-- 回收站，由 `TRASH_RETENTION_DAYS` 控制（默认 30 天；`-1` 关闭；打开回收站时惰性清理最多 200 项）
-- WebDAV Class 1/2，路径 `/webdav`（可关闭，不影响网页端文件管理）
-- API Key，可用于脚本上传、下载与双向同步
-- 远程 MCP，路径 `/mcp`（21 个工具：文件、搜索、移动/复制、分享、站点、`pull` / `push` / `publish_site`，以及 `image_upload` / `image_list` / `image_delete`）。上传超过 1 MiB 自动分块，上限 25 MB；下载用 `part` 分页。**MCP 依赖 API Key**：若 API Key 开关关闭，即使 MCP 开关打开，`/mcp` 也是 404
-- 网页端站点管理（`#/sites`）：zip 一键部署、SPA 开关、按站删除
-- 静态站点走单独域名（`SITES_HOST` + `sites/{slug}/`）；[docs/sites.zh-CN.md](docs/sites.zh-CN.md)
-- 图床走同一站点域名的 `/i/{id}`（对象存在 `_$flaredrive$/img/`，不与 `sites/` 或分享链接混用）
-- 拥有者设置页（`#/settings`）五个功能开关（默认全部开启，持久化到 R2）
-- `davflare-cli`：login / ls / mkdir / rm / mv / cp / sync（[cli/README.md](cli/README.md)）
-- 可选 Chrome MV3 扩展（`extension/`）：工具栏打开**你自己的**实例；不改 Chrome 新标签页
-- Agent 目录约定：`agents/{global|agent|agent/project}/{skills|rules|mcp}/`（`pull` / `push` 工具，见 [docs/agents.zh-CN.md](docs/agents.zh-CN.md)）；可复现示例见 [`agents/examples/hello-site/`](agents/examples/hello-site/)
-- 中 / 英界面（标题栏地球图标；默认跟随浏览器语言，并保存在本地）
+- 网页端分片上传、文件夹、搜索、拖放，以及图片 / 视频 / PDF 缩略图
+- 分享链接（限时或永久）、提取码、文件夹 zip，以及零脚本落地页
+- 回收站，保留天数可配（`TRASH_RETENTION_DAYS`）
+- WebDAV Class 1/2，路径 `/webdav`（可关闭，不影响网页端）
+- API Key 支持脚本上传 / 下载 / 同步，远程 MCP 在 `/mcp`（21 个工具）
+- 静态站点与图床走单独域名（`SITES_HOST`）
+- 拥有者设置页五个持久化功能开关
+- `davflare-cli`、可选 Chrome MV3 扩展，以及 R2 上的 Agent 目录约定
+- 中 / 英界面
 
-## 用 Cursor 试一把（复制即用）
+## 快速开始
 
-1. `#/settings` 保持 **API Key**、**MCP**、**静态站点** 打开，创建一把密钥。
-2. 粘贴到 Cursor 的 `mcp.json`（换成你的域名和密钥）：
+1. 用上方按钮一键部署（需要已开通 R2、并绑定支付方式的 Cloudflare 账号）。
+2. 将 R2 bucket 绑定到 `BUCKET`，设置 `WEBDAV_USERNAME` 和 `WEBDAV_PASSWORD`，然后重新部署。
+3. 可选：`WEBDAV_PUBLIC_READ=1`、`TRASH_RETENTION_DAYS`（默认 `30`，`-1` 关闭）；公开站点/图床请绑 `sites.<你的域>` 并设 `SITES_HOST=sites.<你的域>`。
+4. 可选：给网盘界面绑自定义域名。
 
-```json
-{
-  "mcpServers": {
-    "davflare": {
-      "url": "https://<your-domain.com>/mcp",
-      "headers": { "Authorization": "Bearer <apiKey>" }
-    }
-  }
-}
-```
+手动 Pages / Wrangler 步骤与五个功能开关见 [docs/deploy.zh-CN.md](docs/deploy.zh-CN.md)。
 
-3. 打开本仓库 [`agents/examples/hello-site/`](agents/examples/hello-site/)，让 Cursor 按 `SKILL.md` 做（只用现有 `publish_site`，可选 `image_upload`）。
-4. 跑完得到 **`https://sites.<你的域>/hello/`**（你真实的 `SITES_HOST`）。没有别人能打开的公共演示站。
+## 文档
 
-## 跟着做
-
-三条短路径。请用**你自己绑定的域名**——没有别人能打开的公开演示站。
-
-### 用 Cursor 对话发布静态站
-
-1. 按 [用 Cursor 试一把](#用-cursor-试一把复制即用) 配好 MCP，并绑定 Pages 环境变量 `SITES_HOST` 后重新部署。
-2. 对 Cursor 说（可直接粘贴），上下文带上 `agents/examples/hello-site/`：
-
-   ```
-   按 agents/examples/hello-site/SKILL.md 做：上传 index.html，再 publish_site slug=hello。完成标准：https://<SITES_HOST>/hello/ 返回 200。
-   ```
-
-3. 在你绑到**本** Pages 项目的主机上打开 `https://<SITES_HOST>/hello/`。未设置 `SITES_HOST` 并重新部署之前，这个地址打不开。
-
-### 图床拖放并复制链接
-
-1. 打开网盘里的 `#/images`。
-2. 把图片拖到页面上（或点上传）。
-3. 点 **复制链接** 或 **复制 Markdown**（`![](https://<SITES_HOST>/i/{id})`）。公开地址只有在绑定自定义域并设置 Pages 环境变量 `SITES_HOST`（只要主机名）之后才可用。
-
-### 设置里的五个开关
-
-1. 从账号菜单打开 `#/settings`。
-2. 五个开关是 WebDAV、MCP、API Key、静态站点、图床（默认全部开启）。关闭开关不会删除已有文件。
-3. MCP 依赖 API Key：Key 关闭时，即使 MCP 打开，`/mcp` 也是 404。站点和图床的公开地址还需要 `SITES_HOST`。
-
-### 用 rclone 挂 WebDAV（可选）
-
-1. `rclone config` → New remote → 类型 `webdav` → URL `https://<your-domain.com>/webdav` → vendor `other` → 用户名/密码 = Pages 里的 `WEBDAV_USERNAME` / `WEBDAV_PASSWORD`。
-2. `#/settings` 里保持 WebDAV 开关打开。
-3. `rclone ls davflare:`（远程名随你）应能列出网盘根目录。
-
-## 部署
-
-一键部署：
-
-[![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/fanchenggang/Davflare)
-
-你需要一个已绑定支付方式、并已开通 R2 的 [Cloudflare](https://dash.cloudflare.com/) 账号（至少创建一个 bucket）。
-
-首次部署之后：
-
-1. 将 R2 bucket 绑定到 `BUCKET` 变量
-2. 设置 `WEBDAV_USERNAME` 和 `WEBDAV_PASSWORD`
-3. 可选：`WEBDAV_PUBLIC_READ=1` 开启公开读取；`TRASH_RETENTION_DAYS`（默认 `30`，`-1` 关闭清理）
-4. 可选静态站点：把 `sites.<你的域>` 绑到同一个 Pages 项目，并设置 `SITES_HOST=sites.<你的域>`
-5. 重新部署，使绑定和环境变量生效
-6. 可选：给网盘界面绑自定义域名
-
-### 手动部署 Cloudflare Pages
-
-- 框架预设：**None（React/Vite，不是 Docusaurus）**
-- 输出目录：`build`
-- 然后绑定 `BUCKET`、设置上述环境变量，并重新部署
-
-### Wrangler CLI
-
-`wrangler.toml` 将 R2 绑定为 `BUCKET`（默认 bucket 名为 `webdav`）。如有需要，把 `bucket_name` 改成你的 bucket。
-
-```bash
-npm run build
-npx wrangler pages deploy build
-```
-
-## WebDAV
-
-地址：`https://<your-domain.com>/webdav`
-
-可用任意 WebDAV 客户端（例如 [Cx File Explorer](https://play.google.com/store/apps/details?id=com.cxinventor.file.explorer) 或 [BD File Manager](https://play.google.com/store/apps/details?id=com.liuzho.file.explorer)）。填入上述地址以及你设置的用户名和密码。
-
-Cloudflare Workers 单次 PUT 上限为 **128 MB**。超限会返回 **HTTP 413**（提示使用网页上传）。大文件请走网页端分片上传。
-
-应用内 WebDAV 面板会显示 URL、用户名，以及是否开启公开读取。**不会**显示密码。
-
-## 开放接口
-
-在网页端「API」 / 「开放接口」创建密钥。鉴权：`Authorization: Bearer <apiKey>` 或 `X-Api-Key: <apiKey>`。完整请求示例见 [开放接口文档](docs/API.zh-CN.md)。
-
-| 方法 | 路径 | 作用 |
-| --- | --- | --- |
-| GET / PATCH | `/api/config` | 会话：用户名、公开读取、sitesHost、功能开关。PATCH 仅 Basic |
-| GET / POST / DELETE | `/api/images` | 图床（会话或 API Key）：列出、上传、删除。公开字节在 `SITES_HOST /i/{id}` |
-| GET / POST / DELETE | `/api/keys` | 创建、列出、作废密钥（需网页登录会话） |
-| POST / PUT / DELETE | `/api/upload` | 上传文件（multipart / 原始 body / 覆盖 / >100MB 分片） |
-| GET | `/api/list` | 列出当前目录（size、uploaded、etag） |
-| GET | `/api/download` | 下载单个文件（Range / 206 断点续传） |
-| POST | `/api/mkdir` | 创建文件夹（自动补齐父目录） |
-| POST | `/api/rename` | 重命名 / 移动文件或文件夹 |
-| POST | `/api/copy` | 复制文件 |
-| GET | `/api/stat` | 对象元数据 |
-| GET | `/api/search` | 按文件名子串搜索 |
-| POST | `/api/backup` | 冲突时把远端改名为 `name.conflict-<UTC>` |
-| DELETE | `/api/delete` | 硬删除，或 `soft=1` 进回收站 |
-| POST | `/api/shares` | 分享文件或文件夹（文件夹为 zip） |
-| GET / POST / DELETE | `/api/sites` | 列出、配置 SPA、删除静态站 |
-| POST | `/mcp` | 远程 MCP（JSON-RPC 2.0；同一把 API 密钥；21 个工具） |
-
-同一把密钥可做双向同步（本地优先，冲突时先备份远端）。详见 [开放接口文档](docs/API.zh-CN.md)。
-
-**分享链接**（`/share/<token>`）默认返回服务端渲染、零脚本的落地页：文件名、类型、大小、分享时间，图片/音视频/PDF/文本还带在线预览（`<img>` / `<video>` / `<audio>` / `<iframe>`）；语言跟随 `Accept-Language`。以前直接抓分享链接原始字节的脚本需要改用：**`?download=1` 返回附件下载直链**（文件夹仍为 zip 流），**`?raw=1` 返回内联内容**（图片/音视频/PDF/文本等可预览类型），安全响应头（`Content-Security-Policy: sandbox`、`X-Content-Type-Options: nosniff`）与 Range 支持保持不变。过期返回 **410**、撤销返回 **404**，提取码门禁对落地页与两个参数同样生效。
-
-`GET /api/config`（网页会话）返回用户名、公开读取、`sitesHost` 以及五个功能开关。`PATCH /api/config` 更新开关，**仅允许网页会话（Basic）**，API Key 不能改开关。
-
-## 功能开关
-
-拥有者在设置页（`#/settings`，账号菜单）开关五项能力。配置存在 R2 的 `_$flaredrive$/config.json`，部署后仍保留，**不要**写进 `wrangler.toml`。默认全部**开启**。
-
-| 开关 | 关闭后 |
+| 主题 | 链接 |
 | --- | --- |
-| WebDAV | 隐藏 WebDAV 按钮/面板。客户端无法挂载 `/webdav`（404）。网页端文件管理仍走会话接口。 |
-| MCP | `POST /mcp` → 404；隐藏 API 面板里的 MCP 说明。 |
-| API Key | 隐藏密钥管理。Bearer / `X-Api-Key` 开放接口返回 401。网页会话接口不受影响。**MCP 也会 404/不可用**（因为它用 API Key 鉴权）。 |
-| 静态站点 | 隐藏 `#/sites`。`SITES_HOST` 上的 slug 站点 404。不会删除 `sites/` 下的对象。 |
-| 图床 | 隐藏图床界面。`SITES_HOST` 上的 `/i/*` 404。不会删除已存图片。 |
-
-`SITES_HOST` 为空时，基础设施层仍不对外提供站点/图床。绑定主机后，站点与图床开关是额外的产品开关。
-
-## MCP
-
-同源 Model Context Protocol（Streamable HTTP），路径 `POST /mcp`。鉴权与开放接口相同（`Authorization: Bearer <apiKey>` 或 `X-Api-Key`）。**MCP 依赖 API Key：API Key 开关关闭后，即使 MCP 开关仍打开也无法使用。**
-
-工具（21 个）：`list`、`upload`、`download`、`mkdir`、`delete`、`search`、`move`、`copy`、`stat`、`share_create`、`share_list`、`share_revoke`、`sites_list`、`sites_config`、`sites_delete`、`pull`、`push`、`publish_site`、`image_upload`、`image_list`、`image_delete`。
-
-### 对话里发限时分享
-
-1. 让助手对某个文件/目录调用 `share_create`，并设 `expiresInHours=24`（可选 `extractCode`）。
-2. 把返回的分享 `url`（路径 `/share/{token}`）转发出去即可。
-3. 用 `share_list` / `share_revoke`（传入 `token`）查看与撤销。
-
-不超过 1 MiB 的上传走内联；更大内容自动分块（上限 **25 MB**）。再大请用网页端或 `davflare-cli`。下载超过 1 MiB 用 `part` / `partSize` 分页。`delete` 默认进回收站，`hard=true` 永久删除。把文件上传到 `sites/{slug}/`（或用 `publish_site` 从网盘目录同步）即发布静态站，需要 SPA 回退再调 `sites_config`。`pull` / `push` 走 `agents/…`（合并：project 覆盖 agent 覆盖 global）。详见 [docs/API.zh-CN.md](docs/API.zh-CN.md)。
-
-Cursor（`mcp.json`）：
-
-```json
-{
-  "mcpServers": {
-    "davflare": {
-      "url": "https://<your-domain.com>/mcp",
-      "headers": {
-        "Authorization": "Bearer <apiKey>"
-      }
-    }
-  }
-}
-```
-
-## 静态站点
-
-`sites/{slug}/` 下的 HTML 只在**单独域名**（`SITES_HOST`）上提供。同一个 Worker，按 Host 分流，不是网盘源上的 `/sites`。
-
-网页端「站点」（`#/sites`）可看每个 slug 的统计、zip 一键部署、SPA 开关和删除。MCP 的 `sites_list` / `sites_config` / `sites_delete` 包装同一套 `/api/sites`。详见 [docs/sites.zh-CN.md](docs/sites.zh-CN.md)。
-
-## 命令行
-
-[`davflare-cli`](cli/README.md) 是开放接口的命令行客户端：`login`、`ls`、`mkdir`、`rm`、`mv`、`cp`、`sync`。超过 100 MB 自动分块上传，下载支持 HTTP Range 断点续传。安装与同步语义见 `cli/README.md`。
-
-## 扩展
-
-Chrome Manifest V3 辅助扩展，双模式工具栏：打开**你自己部署的** Davflare 网盘，或打开由实例 WebDAV 支撑的书签库。不在 Chrome 网上应用店上架。
-
-- **设置内嵌在主页**：没有独立选项页。首次打开扩展页会直接进入设置视图——填实例地址（Pages / 自定义域名，默认空白，没有内置站点）、书签目录、WebDAV 凭据，保存并授权后自动进入网盘/书签视图（HamHome 式：先配置后使用）；侧栏「设置」随时可改。
-- **工具栏双模式**：两种模式都打开扩展自己的页面——*网盘*（默认）**直接挂载 Web 端 React 组件**渲染文件管理器（不再 iframe 嵌实例网页，服务端的 `X-Frame-Options: DENY` 不再有影响），*书签* 打开书签库视图。在设置里选默认，随时右键工具栏图标切换；未配置实例时，工具栏点击直接打开设置视图。首次进入网盘视图会请求实例域名的 host 权限（`/api/*` 没有 CORS 头，必须授权后才能用搜索/回收站等能力；`/webdav` 本就开放 CORS）；「新标签页打开」按钮保留作兜底。
-- 页面右键菜单有「收藏此页」——把当前标签页的标题 + URL 合并进你 WebDAV 上的书签文件。
-- WebDAV 凭据（与部署时的 `WEBDAV_USERNAME` / `WEBDAV_PASSWORD` 一致）**仅**保存在 `chrome.storage.local`，不会同步到 Google 账号。保存实例地址时会按需申请该站点的 host 权限（可选权限，不预授权任何域名）。
-- **不改 Chrome 新标签页。** 旧版曾提供带 newtab 覆盖的第二个 zip；由于 Chrome 的 `chrome_url_overrides` 只能在 manifest 里静态声明、装上即永久接管、无运行时开关，该变体已移除，现在只发一个包。
-
-GitHub Release 附一个 zip：`davflare-extension.zip`（工具栏 + 内嵌设置 + 书签库 + 网盘视图）。
-
-**加载未打包扩展：** Chrome → `chrome://extensions` → 开发者模式 → 加载已解压的扩展程序 → 选本仓库的 `extension/` 目录。注意：网盘视图是 vite 构建产物，源码目录加载前先在仓库根目录执行 `npm ci && npm run build:extension`（未构建时书签等功能照常，网盘视图会显示构建提示；Release zip 已含产物）。
-
-**Release zip：** 从 [GitHub Releases](https://github.com/fanchenggang/Davflare/releases) 下载后解压再按上面的方式加载。打 tag（`v*` / `extension-*`）或在 **Actions → Release extension** 里运行工作流会附上 zip。
-
-## 薄书签（P2）
-
-扩展的书签库把书签存在**你自己的 WebDAV 上**——不依赖第三方服务，不含任何 AI。要求实例的 WebDAV 功能开关已打开。
-
-- **存储布局**（实例 `/webdav/` 下，目录可在主页「设置」视图配置——默认 `bookmarks/`，例如填 `qa/bookmarks` 隔离测试数据）：`bookmarks.html` 是权威的 Netscape 书签文件，可直接用 Chrome/Edge「导入书签」；`bookmarks.json` 是旁路文件，承载 HTML 格式放不下的标签与备注；`workspaces.json`、`tabGroups.json`、`snapshots.json` 分别对应下面几个功能。写入带 `If-Match`，出现 412 冲突会明确提示重试，绝不静默覆盖。
-- **书签库页**：侧栏分类/标签计数；搜索覆盖标题/URL/标签/备注，**支持拼音**（全拼与首字母，内置精简字典）；时间范围筛选；网格/列表视图；明暗主题；从 Chrome 书签导入（可选 `bookmarks` 权限，按 URL 合并）与导出 `bookmarks.html`。
-- **HamHome 迁移（只读导入）**：书签库页可从同实例的 [HamHome](https://github.com/bingoYB/ham_home) 同步目录导入——读取 `/HamHomeSync/bookmarks/meta.json` + `categories.json`，按 URL 去重合并；描述转为备注、标签与分类目录保留、已删除行跳过。边界：我们自己的写入仍是自有格式；HamHome 的快照/工作区/Tab 规则（存其 IndexedDB 或应用内部 JSON）不迁移。
-- **工作区**：把当前窗口存为工作区——页面顺序、固定状态、原生标签组元数据——之后可全部或勾选恢复到新窗口（URL 去重，还原固定与分组）。
-- **Tab 分组**：本地规则引擎（域名后缀 / URL / 标题 / 正则，多条件 AND），一键把当前窗口收进原生标签组，可自定义标题/颜色/折叠/优先级；未命中可按根域名兜底。规则经 `tabGroups.json` 同步。
-- **快照**：把页面捕获为单文件 HTML（CORS 允许的图片尽力内联；剥离 script/iframe；8 MB 上限）存到 `bookmarks/snapshots/`，在书签编辑里查看、下载、更新、删除。无 CORS 头的跨域资源无法内联（浏览器安全限制），`chrome://` 等受限页无法捕获。
-- **错误不静默**：WebDAV 开关关闭（404）、服务端未配置凭据（403）、凭据错误（401）、编辑冲突（412）各有独立文案，并提供打开设置的入口。
-
-## 图床
-
-在网盘界面（`#/images`）拖放上传图片，复制公开 URL 或 Markdown `![](url)`，列出并删除。对象存在 `_$flaredrive$/img/{id}`，`{id}` 为不可猜测的随机值，不是原文件名。公开地址仅为 `https://<SITES_HOST>/i/{id}`（`SITES_HOST` 不含协议）。SVG 以附件下发（`Content-Disposition: attachment` + `nosniff`），不会当成可执行页面打开。
-
-站点域名上先匹配 `/i/{id}`，再走 slug 静态站。图床开关与站点开关独立：站点关、图床开 → slug 404 但 `/i/{id}` 可用；图床关 → 即使站点开，`/i/*` 也是 404。未配置 `SITES_HOST` 时开关仍在，界面会提示先绑定该域名。
-
-## Agent 目录
-
-skills / rules / MCP 片段放在 R2 的 `agents/` 下。仓库示例：[`agents/examples/hello-site/`](agents/examples/hello-site/)。v2 的 `pull` / `push` 会走这棵树（也可用网页端）。合并顺序：project 覆盖 agent 覆盖 global。`mcp.json` 里不要存明文密钥，用 `${env:DAVFLARE_API_KEY}`。Cursor 落地路径见 [docs/agents.zh-CN.md](docs/agents.zh-CN.md)。
-
-## 开发与测试
-
-```bash
-npm install
-
-npm run typecheck   # tsc --noEmit (covers src/ and functions/)
-npm test            # Vitest 单测（单次运行）
-npm run test:ci     # 同一套件（保留脚本名以兼容 CI 文档）
-npm run test:coverage   # Vitest + v8 覆盖率（含阈值校验）
-npm run build       # typecheck + 生产构建到 build/
-
-npm run test:e2e    # one-shot API regression: build → wrangler pages dev (local miniflare R2) → scripts/api-e2e.sh
-SKIP_BUILD=1 npm run test:e2e   # reuse an existing build/ for faster iterations
-```
-
-`test:e2e` 会在缺少时创建本地 `.dev.vars`（已 gitignore）写入开发凭据，在 8788 端口启动 `wrangler pages dev`（可用 `PORT` 覆盖），等待就绪后跑约 170 条断言，再关掉服务。数据在 `.wrangler/state/` —— 删除该目录即可重置本地 bucket。完整验证记录见 [TESTING.md](./TESTING.md)，手工 GUI 用例库见 [TEST_CASES.md](./TEST_CASES.md)。
+| 部署、环境变量、功能开关 | [docs/deploy.zh-CN.md](docs/deploy.zh-CN.md) |
+| WebDAV 客户端与限制 | [docs/webdav.zh-CN.md](docs/webdav.zh-CN.md) |
+| 开放接口与 MCP（含对话分享示例） | [docs/API.zh-CN.md](docs/API.zh-CN.md) |
+| 静态站点与图床 | [docs/sites.zh-CN.md](docs/sites.zh-CN.md) |
+| Agent 目录（`pull` / `push`） | [docs/agents.zh-CN.md](docs/agents.zh-CN.md) |
+| 命令行（`davflare-cli`） | [cli/README.md](cli/README.md) |
+| Chrome 扩展（安装 + 书签） | [extension/README.zh-CN.md](extension/README.zh-CN.md) |
+| 书签可移植性 | [docs/bookmarks-portability.zh-CN.md](docs/bookmarks-portability.zh-CN.md) |
+| 测试 | [TESTING.md](TESTING.md) · [TEST_CASES.md](TEST_CASES.md) |
 
 ## 致谢
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -218,6 +218,19 @@ Cursor (`mcp.json`):
 }
 ```
 
+### Expiring share from chat
+
+1. Ask the agent to call `share_create` on a file or folder path, with `expiresInHours=24` (optional `extractCode`).
+2. Forward the returned share `url` (path `/share/{token}`).
+3. Manage with `share_list` / `share_revoke` (pass the `token`).
+
+### Try MCP from Cursor
+
+1. Leave **API Key** + **MCP** + **Sites** on in `#/settings`. Create a key.
+2. Paste into Cursor `mcp.json` (replace host + key) — same JSON as above.
+3. Open this repo's [`agents/examples/hello-site/`](../agents/examples/hello-site/) and tell Cursor to follow `SKILL.md` (uses only `publish_site` / optional `image_upload`).
+4. When it finishes you get `https://sites.<your-domain>/hello/` (your real `SITES_HOST`). No public shared demo.
+
 ### Agent layouts
 
 Skills / rules / MCP snippets: `agents/{global|{agent}|{agent}/{project}}/{skills|rules|mcp}/`. v2 `pull` / `push` walk this tree (or use the web UI). Merge: project > agent > global. Do not store raw keys in `mcp.json`. Full convention: [agents.md](./agents.md).

--- a/docs/API.zh-CN.md
+++ b/docs/API.zh-CN.md
@@ -206,6 +206,19 @@ Cursor（`mcp.json`）：
 }
 ```
 
+### 对话里发限时分享
+
+1. 让助手对某个文件/目录调用 `share_create`，并设 `expiresInHours=24`（可选 `extractCode`）。
+2. 把返回的分享 `url`（路径 `/share/{token}`）转发出去即可。
+3. 用 `share_list` / `share_revoke`（传入 `token`）查看与撤销。
+
+### 用 Cursor 试 MCP
+
+1. `#/settings` 保持 **API Key**、**MCP**、**静态站点** 打开，创建一把密钥。
+2. 粘贴到 Cursor 的 `mcp.json`（换成你的域名和密钥）——与上方 JSON 相同。
+3. 打开本仓库 [`agents/examples/hello-site/`](../agents/examples/hello-site/)，让 Cursor 按 `SKILL.md` 做（只用现有 `publish_site`，可选 `image_upload`）。
+4. 跑完得到 `https://sites.<你的域>/hello/`（你真实的 `SITES_HOST`）。没有别人能打开的公共演示站。
+
 ### Agent 目录
 
 skills / rules / MCP 片段：`agents/{global|{agent}|{agent}/{project}}/{skills|rules|mcp}/`。v2 的 `pull` / `push` 会走这棵树（也可用网页端）。合并：project 覆盖 agent 覆盖 global。`mcp.json` 不要明文密钥。完整约定：[agents.zh-CN.md](./agents.zh-CN.md)。

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -1,0 +1,58 @@
+# Deploy
+
+[English](deploy.md) | [中文](deploy.zh-CN.md)
+
+← [README](../README.md)
+
+## One-click
+
+[![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/fanchenggang/Davflare)
+
+You need a [Cloudflare](https://dash.cloudflare.com/) account with a payment method and R2 activated (create at least one bucket).
+
+After the first deploy:
+
+1. Bind your R2 bucket to the `BUCKET` variable
+2. Set `WEBDAV_USERNAME` and `WEBDAV_PASSWORD`
+3. Optional: `WEBDAV_PUBLIC_READ=1` for public read; `TRASH_RETENTION_DAYS` (default `30`, `-1` disables purge)
+4. Optional static sites: bind `sites.<your-domain>` to this same Pages project and set `SITES_HOST=sites.<your-domain>`
+5. Retry deploy so the binding and env vars apply
+6. Optional: add a custom domain for the drive UI
+
+## Manual Cloudflare Pages
+
+- Framework preset: **None (React/Vite, not Docusaurus)**
+- Output directory: `build`
+- Then bind `BUCKET`, set the env vars above, and retry deploy
+
+## Wrangler CLI
+
+`wrangler.toml` binds R2 as `BUCKET` (default bucket name `webdav`). Change `bucket_name` to your bucket if needed.
+
+```bash
+npm run build
+npx wrangler pages deploy build
+```
+
+## Feature switches
+
+Owner-only Settings (`#/settings`, account menu) persist five flags in R2 at `_$flaredrive$/config.json` (survive deploys; not set in `wrangler.toml`). Default: all **on**.
+
+| Switch | Off means |
+| --- | --- |
+| WebDAV | Hide the WebDAV button/panel. Clients cannot mount `/webdav` (404). The web file manager still uses session (Basic) I/O. |
+| MCP | `POST /mcp` → 404; hide MCP copy in the API panel. |
+| API Key | Hide key management. Bearer / `X-Api-Key` Open API calls fail (401). Session APIs keep working. **MCP also becomes 404/unusable** because it authenticates with API keys. |
+| Sites | Hide `#/sites`. Slug sites on `SITES_HOST` 404. Objects under `sites/` are not deleted. |
+| Image host | Hide the image-host UI. `/i/*` on `SITES_HOST` 404. Stored images are not deleted. |
+
+`SITES_HOST` empty still turns public hosting off at the infra level. The Sites / Image host switches are extra product toggles when that host is bound.
+
+Toggle them in the UI:
+
+1. Open `#/settings` from the account menu.
+2. Flip any of the five switches. Stored files are not deleted when a switch is off.
+3. MCP depends on API Key: if Key is off, `/mcp` is 404 even if MCP is on. Sites and image-host public URLs also need `SITES_HOST`.
+
+See also [webdav.md](./webdav.md), [sites.md](./sites.md), [API.md](./API.md).
+

--- a/docs/deploy.zh-CN.md
+++ b/docs/deploy.zh-CN.md
@@ -1,0 +1,58 @@
+# 部署
+
+[English](deploy.md) | [中文](deploy.zh-CN.md)
+
+← [README](../README.zh-CN.md)
+
+## 一键部署
+
+[![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/fanchenggang/Davflare)
+
+你需要一个已绑定支付方式、并已开通 R2 的 [Cloudflare](https://dash.cloudflare.com/) 账号（至少创建一个 bucket）。
+
+首次部署之后：
+
+1. 将 R2 bucket 绑定到 `BUCKET` 变量
+2. 设置 `WEBDAV_USERNAME` 和 `WEBDAV_PASSWORD`
+3. 可选：`WEBDAV_PUBLIC_READ=1` 开启公开读取；`TRASH_RETENTION_DAYS`（默认 `30`，`-1` 关闭清理）
+4. 可选静态站点：把 `sites.<你的域>` 绑到同一个 Pages 项目，并设置 `SITES_HOST=sites.<你的域>`
+5. 重新部署，使绑定和环境变量生效
+6. 可选：给网盘界面绑自定义域名
+
+## 手动部署 Cloudflare Pages
+
+- 框架预设：**None（React/Vite，不是 Docusaurus）**
+- 输出目录：`build`
+- 然后绑定 `BUCKET`、设置上述环境变量，并重新部署
+
+## Wrangler CLI
+
+`wrangler.toml` 将 R2 绑定为 `BUCKET`（默认 bucket 名为 `webdav`）。如有需要，把 `bucket_name` 改成你的 bucket。
+
+```bash
+npm run build
+npx wrangler pages deploy build
+```
+
+## 功能开关
+
+拥有者在设置页（`#/settings`，账号菜单）开关五项能力。配置存在 R2 的 `_$flaredrive$/config.json`，部署后仍保留，**不要**写进 `wrangler.toml`。默认全部**开启**。
+
+| 开关 | 关闭后 |
+| --- | --- |
+| WebDAV | 隐藏 WebDAV 按钮/面板。客户端无法挂载 `/webdav`（404）。网页端文件管理仍走会话接口。 |
+| MCP | `POST /mcp` → 404；隐藏 API 面板里的 MCP 说明。 |
+| API Key | 隐藏密钥管理。Bearer / `X-Api-Key` 开放接口返回 401。网页会话接口不受影响。**MCP 也会 404/不可用**（因为它用 API Key 鉴权）。 |
+| 静态站点 | 隐藏 `#/sites`。`SITES_HOST` 上的 slug 站点 404。不会删除 `sites/` 下的对象。 |
+| 图床 | 隐藏图床界面。`SITES_HOST` 上的 `/i/*` 404。不会删除已存图片。 |
+
+`SITES_HOST` 为空时，基础设施层仍不对外提供站点/图床。绑定主机后，站点与图床开关是额外的产品开关。
+
+在界面里切换：
+
+1. 从账号菜单打开 `#/settings`。
+2. 切换任意开关。关闭开关不会删除已有文件。
+3. MCP 依赖 API Key：Key 关闭时，即使 MCP 打开，`/mcp` 也是 404。站点和图床的公开地址还需要 `SITES_HOST`。
+
+另见 [webdav.zh-CN.md](./webdav.zh-CN.md)、[sites.zh-CN.md](./sites.zh-CN.md)、[API.zh-CN.md](./API.zh-CN.md)。
+

--- a/docs/sites.md
+++ b/docs/sites.md
@@ -40,3 +40,9 @@ Then open `https://sites.<your-domain>/blog/` (or `/blog/style.css`). Missing fi
 - Different origin from the file manager: site JS cannot read drive credentials.
 - All slugs share the sites origin (`sites.domain/a/` and `/b/`). Fine for one owner; do not host untrusted third-party HTML on the same sites host.
 - Do not put API keys in the uploaded HTML.
+
+## Image host UI
+
+Upload images in the drive UI (`#/images`): drag/drop, copy the public URL or Markdown `![](url)`, list and delete. Blobs live at `_$flaredrive$/img/{id}` with an unguessable id (not the original filename). Public URL is only `https://<SITES_HOST>/i/{id}` (no scheme in `SITES_HOST`). SVG is served as a download (`Content-Disposition: attachment` + `nosniff`), never as a navigable document.
+
+On the sites host, `/i/{id}` is matched **before** slug static sites. The image-host switch is independent of the sites switch: sites off + image host on → slugs 404 but `/i/{id}` works; image host off → `/i/*` 404 even if sites is on. If `SITES_HOST` is unset, the switch can still exist but the UI tells you to bind the host first.

--- a/docs/sites.zh-CN.md
+++ b/docs/sites.zh-CN.md
@@ -40,3 +40,9 @@ sites/blog/style.css
 - 和网盘不同源：站点脚本读不到网盘登录态。
 - 所有 slug 共用站点域（`sites.domain/a/` 和 `/b/`）。自己用没问题；不要在同一站点域托管别人不可信的 HTML。
 - 不要把 API 密钥写进上传的 HTML。
+
+## 图床界面
+
+在网盘界面（`#/images`）拖放上传图片，复制公开 URL 或 Markdown `![](url)`，列出并删除。对象存在 `_$flaredrive$/img/{id}`，`{id}` 为不可猜测的随机值，不是原文件名。公开地址仅为 `https://<SITES_HOST>/i/{id}`（`SITES_HOST` 不含协议）。SVG 以附件下发（`Content-Disposition: attachment` + `nosniff`），不会当成可执行页面打开。
+
+站点域名上先匹配 `/i/{id}`，再走 slug 静态站。图床开关与站点开关独立：站点关、图床开 → slug 404 但 `/i/{id}` 可用；图床关 → 即使站点开，`/i/*` 也是 404。未配置 `SITES_HOST` 时开关仍在，界面会提示先绑定该域名。

--- a/docs/webdav.md
+++ b/docs/webdav.md
@@ -1,0 +1,22 @@
+# WebDAV
+
+[English](webdav.md) | [中文](webdav.zh-CN.md)
+
+← [README](../README.md)
+
+Endpoint: `https://<your-domain.com>/webdav`
+
+Use any WebDAV client (for example [Cx File Explorer](https://play.google.com/store/apps/details?id=com.cxinventor.file.explorer) or [BD File Manager](https://play.google.com/store/apps/details?id=com.liuzho.file.explorer)). Fill in the endpoint plus the username and password you set.
+
+Cloudflare Workers limit a single PUT to **128 MB**. Oversized PUTs return **HTTP 413** (Chinese message: use the web uploader). Upload large files through the web UI, which supports chunked uploads.
+
+The in-app WebDAV panel shows URL, username, and whether public-read is on. It does **not** display the password.
+
+## Mount with rclone (optional)
+
+1. In rclone: `rclone config` → New remote → type `webdav` → URL `https://<your-domain.com>/webdav` → vendor `other` → user/pass = your Pages `WEBDAV_USERNAME` / `WEBDAV_PASSWORD`.
+2. Leave the WebDAV switch on in `#/settings`.
+3. `rclone ls davflare:` (or whatever you named the remote) should list the drive root.
+
+Deploy / env vars: [deploy.md](./deploy.md).
+

--- a/docs/webdav.zh-CN.md
+++ b/docs/webdav.zh-CN.md
@@ -1,0 +1,22 @@
+# WebDAV
+
+[English](webdav.md) | [中文](webdav.zh-CN.md)
+
+← [README](../README.zh-CN.md)
+
+地址：`https://<your-domain.com>/webdav`
+
+可用任意 WebDAV 客户端（例如 [Cx File Explorer](https://play.google.com/store/apps/details?id=com.cxinventor.file.explorer) 或 [BD File Manager](https://play.google.com/store/apps/details?id=com.liuzho.file.explorer)）。填入上述地址以及你设置的用户名和密码。
+
+Cloudflare Workers 单次 PUT 上限为 **128 MB**。超限会返回 **HTTP 413**（提示使用网页上传）。大文件请走网页端分片上传。
+
+应用内 WebDAV 面板会显示 URL、用户名，以及是否开启公开读取。**不会**显示密码。
+
+## 用 rclone 挂载（可选）
+
+1. `rclone config` → New remote → 类型 `webdav` → URL `https://<your-domain.com>/webdav` → vendor `other` → 用户名/密码 = Pages 里的 `WEBDAV_USERNAME` / `WEBDAV_PASSWORD`。
+2. `#/settings` 里保持 WebDAV 开关打开。
+3. `rclone ls davflare:`（远程名随你）应能列出网盘根目录。
+
+部署与环境变量见 [deploy.zh-CN.md](./deploy.zh-CN.md)。
+

--- a/extension/README.md
+++ b/extension/README.md
@@ -1,0 +1,34 @@
+# Davflare Chrome extension
+
+[English](README.md) | [中文](README.zh-CN.md)
+
+← [README](../README.md)
+
+A Chrome Manifest V3 helper with two toolbar modes — open **your** Davflare drive, or a full bookmark library backed by your instance’s WebDAV. It is not on the Chrome Web Store.
+
+- **Settings live in the main page** — there is no standalone options page. The first launch of the extension page opens the settings view directly: paste your instance URL (Pages / custom domain, starts empty — no built-in site), bookmark directory, and WebDAV credentials; after saving and granting access you land in the drive/bookmarks view (HamHome-style: configure first, then use). The sidebar "Settings" view is always available for changes.
+- **Toolbar modes:** both click-actions open the extension's own page — *drive* (default) **mounts the same React components as the web UI** to render the file manager natively (no iframe involved, so the instance's `X-Frame-Options: DENY` no longer matters), *bookmarks* opens the bookmark library view. Pick the default in Settings; right-click the toolbar icon to switch anytime. With no instance configured, a toolbar click opens the settings view directly. The first visit to the drive view asks for host permission on the instance origin (the `/api/*` endpoints send no CORS headers, so search/trash/etc. need the grant; `/webdav` is CORS-open already); an "Open in new tab" button stays as a fallback.
+- **Save this page** appears in the page context menu — it merges the current tab’s title + URL into your WebDAV bookmark file.
+- WebDAV credentials (same values as your deployment’s `WEBDAV_USERNAME` / `WEBDAV_PASSWORD`) are stored **only** in `chrome.storage.local`; they never sync to a Google account. Saving an instance URL asks for per-site host permission (optional permissions — nothing is pre-granted).
+- **Does not change Chrome's new tab.** An older release shipped a second zip with a new-tab override; because Chrome's `chrome_url_overrides` can only be declared statically in the manifest (it takes over permanently once loaded, with no runtime toggle), that variant has been removed — a single package ships now.
+
+One zip on the GitHub Release: `davflare-extension.zip` (toolbar + in-shell settings + bookmark library + drive view).
+
+**Load unpacked:** Chrome → `chrome://extensions` → Developer mode → Load unpacked → select the `extension/` folder in this repo. Note: the drive view is a vite build product — run `npm ci && npm run build:extension` once before loading the source folder (without it, bookmarks and everything else work while the drive view shows a build hint; the release zip already contains the bundle).
+
+**Release zip:** download from [GitHub Releases](https://github.com/fanchenggang/Davflare/releases), unzip, then load unpacked. A tag (`v*` / `extension-*`) or **Actions → Release extension** attaches the zip.
+
+## Bookmarks
+
+The extension’s bookmark library keeps your bookmarks **on your own WebDAV** — no third-party service, no AI. Requires the WebDAV feature switch to be on for your instance.
+
+- **Storage layout** (under your instance’s `/webdav/`, directory configurable in the in-shell Settings view — default `bookmarks/`; e.g. set `qa/bookmarks` to isolate test data): `bookmarks.html` is the authoritative Netscape bookmark file that Chrome/Edge can import directly; `bookmarks.json` is a sidecar carrying tags and notes that the HTML format cannot hold; `workspaces.json`, `tabGroups.json`, and `snapshots.json` hold the features below. Writes go through with `If-Match` (a 412 conflict is surfaced, never silently overwritten).
+- **Library page:** sidebar with folder/tag counts, keyword search over title/URL/tags/notes with **pinyin support** (full spelling and initials, thanks to a bundled compact dictionary), time-range filter, grid/list views, light/dark theme, import from Chrome bookmarks (optional `bookmarks` permission, merge by URL) and export to `bookmarks.html`.
+- **HamHome migration (read-only):** the library page imports from a [HamHome](https://github.com/bingoYB/ham_home) sync directory on the same instance — reads `/HamHomeSync/bookmarks/meta.json` + `categories.json` and merges by URL. Descriptions become notes, tags and category folders survive, deleted rows are skipped. Boundary: our own writes stay in our format; HamHome snapshots/workspaces/tab rules (stored in its IndexedDB or app-internal JSON) are not migrated.
+- **Workspaces:** save the current window — page order, pinned state, native tab-group metadata — and restore all or selected pages into a new window (duplicate URLs skipped, pinned/group state restored).
+- **Tab groups:** local rule engine (domain suffix / URL / title / regex, AND-combined) that groups the current window into native tab groups with custom title/color/collapse/priority; unmatched tabs can fall back to root-domain grouping. Rules sync via `tabGroups.json`.
+- **Snapshots:** capture the current page as a single self-contained HTML file (images best-effort inlined where CORS allows; scripts/iframes stripped; 8 MB cap) onto `bookmarks/snapshots/`. View, download, update, or delete from the bookmark editor. Cross-origin assets without CORS headers cannot be inlined (browser security), and restricted pages such as `chrome://` cannot be captured.
+- **Errors never fail silently:** a disabled WebDAV switch (404), missing server credentials (403), wrong credentials (401), and edit conflicts (412) each get a distinct message with a shortcut to Options.
+
+Format mapping, HamHome import/export, and conflict rules: [docs/bookmarks-portability.md](../docs/bookmarks-portability.md).
+

--- a/extension/README.zh-CN.md
+++ b/extension/README.zh-CN.md
@@ -1,0 +1,34 @@
+# Davflare Chrome 扩展
+
+[English](README.md) | [中文](README.zh-CN.md)
+
+← [README](../README.zh-CN.md)
+
+Chrome Manifest V3 辅助扩展，双模式工具栏：打开**你自己部署的** Davflare 网盘，或打开由实例 WebDAV 支撑的书签库。不在 Chrome 网上应用店上架。
+
+- **设置内嵌在主页**：没有独立选项页。首次打开扩展页会直接进入设置视图——填实例地址（Pages / 自定义域名，默认空白，没有内置站点）、书签目录、WebDAV 凭据，保存并授权后自动进入网盘/书签视图（HamHome 式：先配置后使用）；侧栏「设置」随时可改。
+- **工具栏双模式**：两种模式都打开扩展自己的页面——*网盘*（默认）**直接挂载 Web 端 React 组件**渲染文件管理器（不再 iframe 嵌实例网页，服务端的 `X-Frame-Options: DENY` 不再有影响），*书签* 打开书签库视图。在设置里选默认，随时右键工具栏图标切换；未配置实例时，工具栏点击直接打开设置视图。首次进入网盘视图会请求实例域名的 host 权限（`/api/*` 没有 CORS 头，必须授权后才能用搜索/回收站等能力；`/webdav` 本就开放 CORS）；「新标签页打开」按钮保留作兜底。
+- 页面右键菜单有「收藏此页」——把当前标签页的标题 + URL 合并进你 WebDAV 上的书签文件。
+- WebDAV 凭据（与部署时的 `WEBDAV_USERNAME` / `WEBDAV_PASSWORD` 一致）**仅**保存在 `chrome.storage.local`，不会同步到 Google 账号。保存实例地址时会按需申请该站点的 host 权限（可选权限，不预授权任何域名）。
+- **不改 Chrome 新标签页。** 旧版曾提供带 newtab 覆盖的第二个 zip；由于 Chrome 的 `chrome_url_overrides` 只能在 manifest 里静态声明、装上即永久接管、无运行时开关，该变体已移除，现在只发一个包。
+
+GitHub Release 附一个 zip：`davflare-extension.zip`（工具栏 + 内嵌设置 + 书签库 + 网盘视图）。
+
+**加载未打包扩展：** Chrome → `chrome://extensions` → 开发者模式 → 加载已解压的扩展程序 → 选本仓库的 `extension/` 目录。注意：网盘视图是 vite 构建产物，源码目录加载前先在仓库根目录执行 `npm ci && npm run build:extension`（未构建时书签等功能照常，网盘视图会显示构建提示；Release zip 已含产物）。
+
+**Release zip：** 从 [GitHub Releases](https://github.com/fanchenggang/Davflare/releases) 下载后解压再按上面的方式加载。打 tag（`v*` / `extension-*`）或在 **Actions → Release extension** 里运行工作流会附上 zip。
+
+## 书签
+
+扩展的书签库把书签存在**你自己的 WebDAV 上**——不依赖第三方服务，不含任何 AI。要求实例的 WebDAV 功能开关已打开。
+
+- **存储布局**（实例 `/webdav/` 下，目录可在主页「设置」视图配置——默认 `bookmarks/`，例如填 `qa/bookmarks` 隔离测试数据）：`bookmarks.html` 是权威的 Netscape 书签文件，可直接用 Chrome/Edge「导入书签」；`bookmarks.json` 是旁路文件，承载 HTML 格式放不下的标签与备注；`workspaces.json`、`tabGroups.json`、`snapshots.json` 分别对应下面几个功能。写入带 `If-Match`，出现 412 冲突会明确提示重试，绝不静默覆盖。
+- **书签库页**：侧栏分类/标签计数；搜索覆盖标题/URL/标签/备注，**支持拼音**（全拼与首字母，内置精简字典）；时间范围筛选；网格/列表视图；明暗主题；从 Chrome 书签导入（可选 `bookmarks` 权限，按 URL 合并）与导出 `bookmarks.html`。
+- **HamHome 迁移（只读导入）**：书签库页可从同实例的 [HamHome](https://github.com/bingoYB/ham_home) 同步目录导入——读取 `/HamHomeSync/bookmarks/meta.json` + `categories.json`，按 URL 去重合并；描述转为备注、标签与分类目录保留、已删除行跳过。边界：我们自己的写入仍是自有格式；HamHome 的快照/工作区/Tab 规则（存其 IndexedDB 或应用内部 JSON）不迁移。
+- **工作区**：把当前窗口存为工作区——页面顺序、固定状态、原生标签组元数据——之后可全部或勾选恢复到新窗口（URL 去重，还原固定与分组）。
+- **Tab 分组**：本地规则引擎（域名后缀 / URL / 标题 / 正则，多条件 AND），一键把当前窗口收进原生标签组，可自定义标题/颜色/折叠/优先级；未命中可按根域名兜底。规则经 `tabGroups.json` 同步。
+- **快照**：把页面捕获为单文件 HTML（CORS 允许的图片尽力内联；剥离 script/iframe；8 MB 上限）存到 `bookmarks/snapshots/`，在书签编辑里查看、下载、更新、删除。无 CORS 头的跨域资源无法内联（浏览器安全限制），`chrome://` 等受限页无法捕获。
+- **错误不静默**：WebDAV 开关关闭（404）、服务端未配置凭据（403）、凭据错误（401）、编辑冲突（412）各有独立文案，并提供打开设置的入口。
+
+格式映射、HamHome 导入导出与冲突策略见 [docs/bookmarks-portability.zh-CN.md](../docs/bookmarks-portability.zh-CN.md)。
+


### PR DESCRIPTION
## Summary

- Slim `README.md` (EN default) and `README.zh-CN.md` to the same structure: intro + screenshots, short features, quick start, docs index, acknowledgments, license. Top EN↔ZH switch links kept.
- Move orphaned meat into docs (prefer existing pages; add only when needed):
  - Deploy / feature switches → `docs/deploy.md` (+ zh)
  - WebDAV + rclone → `docs/webdav.md` (+ zh)
  - MCP chat share example + Cursor try steps → `docs/API.md` (+ zh)
  - Image host UI → `docs/sites.md` (+ zh)
  - Extension install + bookmarks overview → `extension/README.md` (+ zh), linking `docs/bookmarks-portability.md`
- Docs-only; no extension version bump.

## Test plan

- [ ] Skim README.md / README.zh-CN.md length and parallel headings
- [ ] Click every docs-index link (EN + ZH) and confirm targets exist
- [ ] Confirm MCP share example and deploy/WebDAV detail still reachable from docs
- [ ] CI green (docs-only)