### PR TITLE
feat(mcp): trash_list / trash_restore / trash_empty

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Share (expiry + extract code):
 - Share links with expiry or forever, extract code, folder zip, and a zero-JS landing page
 - Recycle bin with configurable retention (`TRASH_RETENTION_DAYS`)
 - WebDAV Class 1/2 at `/webdav` (toggleable without affecting the web UI)
-- API keys for scripted upload / download / sync, plus remote MCP at `/mcp` (21 tools)
+- API keys for scripted upload / download / sync, plus remote MCP at `/mcp` (24 tools)
 - Static sites and image host on a separate hostname (`SITES_HOST`)
 - Owner Settings with five persistent feature switches
 - `davflare-cli`, optional Chrome MV3 extension, and agent layouts on R2

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -30,7 +30,7 @@
 - 分享链接（限时或永久）、提取码、文件夹 zip，以及零脚本落地页
 - 回收站，保留天数可配（`TRASH_RETENTION_DAYS`）
 - WebDAV Class 1/2，路径 `/webdav`（可关闭，不影响网页端）
-- API Key 支持脚本上传 / 下载 / 同步，远程 MCP 在 `/mcp`（21 个工具）
+- API Key 支持脚本上传 / 下载 / 同步，远程 MCP 在 `/mcp`（24 个工具）
 - 静态站点与图床走单独域名（`SITES_HOST`）
 - 拥有者设置页五个持久化功能开关
 - `davflare-cli`、可选 Chrome MV3 扩展，以及 R2 上的 Agent 目录约定

--- a/docs/API.md
+++ b/docs/API.md
@@ -187,7 +187,7 @@ Public URL: `https://<SITES_HOST>/i/{id}`. SVG responses use `Content-Dispositio
 
 ### MCP
 
-Same-origin Streamable HTTP MCP at `POST /mcp` (JSON-RPC 2.0). Auth is the same `Authorization: Bearer <apiKey>` or `X-Api-Key` as the rest of this API (no web session, no OAuth). **MCP depends on the API Key switch** — if API Key is off (or MCP is off), `/mcp` returns **404**. Missing or invalid keys return **HTTP 401**. Tools: `list`, `upload`, `download`, `mkdir`, `delete`, `search`, `move`, `copy`, `stat`, `share_create`, `share_list`, `share_revoke`, `sites_list`, `sites_config`, `sites_delete`, `pull`, `push`, `publish_site`, `image_upload`, `image_list`, `image_delete` (they wrap the Open API handlers above). Uploads over 1 MiB are automatically sent in multipart chunks (cap **25 MB**; larger returns a tool error — use the web UI or scripts). Downloads over 1 MiB page with `part` / `partSize` (base64 slices). Default `delete` is soft-delete to trash; pass `hard=true` to permanently delete. `sites_*` manage the static sites under `sites/` (see [sites.md](./sites.md)); `upload`/`delete` also work directly on `sites/<slug>/` keys. `pull` walks `agents/{global|agent|agent/project}/{skills|rules|mcp}/` and returns layered files (merge: project > agent > global); large files page like `download`. `push` writes that tree (`mcp.json` must use `${env:...}`, not raw keys). `publish_site` copies a drive folder onto `sites/{slug}/` (overwrite same names; SPA config is kept; 404 if the Sites switch is off). `image_upload` / `image_list` / `image_delete` wrap `/api/images` (public `https://<SITES_HOST>/i/{id}` + Markdown; 20 MB cap; 404 if Image Host is off).
+Same-origin Streamable HTTP MCP at `POST /mcp` (JSON-RPC 2.0). Auth is the same `Authorization: Bearer <apiKey>` or `X-Api-Key` as the rest of this API (no web session, no OAuth). **MCP depends on the API Key switch** — if API Key is off (or MCP is off), `/mcp` returns **404**. Missing or invalid keys return **HTTP 401**. Tools: `list`, `upload`, `download`, `mkdir`, `delete`, `search`, `move`, `copy`, `stat`, `share_create`, `share_list`, `share_revoke`, `trash_list`, `trash_restore`, `trash_empty`, `sites_list`, `sites_config`, `sites_delete`, `pull`, `push`, `publish_site`, `image_upload`, `image_list`, `image_delete` (they wrap the Open API handlers above). Uploads over 1 MiB are automatically sent in multipart chunks (cap **25 MB**; larger returns a tool error — use the web UI or scripts). Downloads over 1 MiB page with `part` / `partSize` (base64 slices). Default `delete` is soft-delete to trash; pass `hard=true` to permanently delete. Recover with `trash_list` / `trash_restore`; permanently clear with `trash_empty`. `sites_*` manage the static sites under `sites/` (see [sites.md](./sites.md)); `upload`/`delete` also work directly on `sites/<slug>/` keys. `pull` walks `agents/{global|agent|agent/project}/{skills|rules|mcp}/` and returns layered files (merge: project > agent > global); large files page like `download`. `push` writes that tree (`mcp.json` must use `${env:...}`, not raw keys). `publish_site` copies a drive folder onto `sites/{slug}/` (overwrite same names; SPA config is kept; 404 if the Sites switch is off). `image_upload` / `image_list` / `image_delete` wrap `/api/images` (public `https://<SITES_HOST>/i/{id}` + Markdown; 20 MB cap; 404 if Image Host is off).
 
 ```bash
 # initialize
@@ -223,6 +223,13 @@ Cursor (`mcp.json`):
 1. Ask the agent to call `share_create` on a file or folder path, with `expiresInHours=24` (optional `extractCode`).
 2. Forward the returned share `url` (path `/share/{token}`).
 3. Manage with `share_list` / `share_revoke` (pass the `token`).
+
+### Recover a mistaken delete from chat
+
+1. Soft-deleted via `delete` (default) — the file is in trash.
+2. Call `trash_list` to see `trashKey` / `originalKey`.
+3. Call `trash_restore` with that `trashKey` to put it back.
+4. Or `trash_empty` to permanently clear trash.
 
 ### Try MCP from Cursor
 

--- a/docs/API.zh-CN.md
+++ b/docs/API.zh-CN.md
@@ -175,7 +175,7 @@ curl -X DELETE "https://<your-domain.com>/api/images?id=<id>" \
 
 ### MCP
 
-同源 Streamable HTTP MCP：`POST /mcp`（JSON-RPC 2.0）。鉴权与其它开放接口相同（`Authorization: Bearer <apiKey>` 或 `X-Api-Key`；不走网页会话，无 OAuth）。**MCP 依赖 API Key 开关** —— API Key 关闭（或 MCP 关闭）时 `/mcp` 返回 **404**。密钥缺失或无效返回 **HTTP 401**。工具：`list`、`upload`、`download`、`mkdir`、`delete`、`search`、`move`、`copy`、`stat`、`share_create`、`share_list`、`share_revoke`、`sites_list`、`sites_config`、`sites_delete`、`pull`、`push`、`publish_site`、`image_upload`、`image_list`、`image_delete`（包装上方 Open API）。超过 1 MiB 的上传自动改走分块（上限 **25 MB**；再大返回工具错误，请用网页端或 davflare-cli）。下载超过 1 MiB 用 `part` / `partSize` 分页。`delete` 默认进回收站；`hard=true` 为永久删除。`sites_*` 管理 `sites/` 下的静态站；`upload` / `delete` 也可以直接操作 `sites/<slug>/`。`pull` 走 `agents/{global|agent|agent/project}/{skills|rules|mcp}/` 并返回分层文件（合并：project 覆盖 agent 覆盖 global）；大文件与 `download` 一样分页。`push` 写入该树（`mcp.json` 只能用 `${env:...}`，不要明文密钥）。`publish_site` 把网盘目录同步到 `sites/{slug}/`（同名覆盖，不删 SPA 配置；站点开关关闭时 404）。 `image_upload` / `image_list` / `image_delete` 包装 `/api/images`（公开地址 `https://<SITES_HOST>/i/{id}` 和 Markdown；上限 20 MB；图床开关关闭时 404）。
+同源 Streamable HTTP MCP：`POST /mcp`（JSON-RPC 2.0）。鉴权与其它开放接口相同（`Authorization: Bearer <apiKey>` 或 `X-Api-Key`；不走网页会话，无 OAuth）。**MCP 依赖 API Key 开关** —— API Key 关闭（或 MCP 关闭）时 `/mcp` 返回 **404**。密钥缺失或无效返回 **HTTP 401**。工具：`list`、`upload`、`download`、`mkdir`、`delete`、`search`、`move`、`copy`、`stat`、`share_create`、`share_list`、`share_revoke`、`trash_list`、`trash_restore`、`trash_empty`、`sites_list`、`sites_config`、`sites_delete`、`pull`、`push`、`publish_site`、`image_upload`、`image_list`、`image_delete`（包装上方 Open API）。超过 1 MiB 的上传自动改走分块（上限 **25 MB**；再大返回工具错误，请用网页端或 davflare-cli）。下载超过 1 MiB 用 `part` / `partSize` 分页。`delete` 默认进回收站；`hard=true` 为永久删除。可用 `trash_list` / `trash_restore` 捞回；`trash_empty` 永久清空回收站。`sites_*` 管理 `sites/` 下的静态站；`upload` / `delete` 也可以直接操作 `sites/<slug>/`。`pull` 走 `agents/{global|agent|agent/project}/{skills|rules|mcp}/` 并返回分层文件（合并：project 覆盖 agent 覆盖 global）；大文件与 `download` 一样分页。`push` 写入该树（`mcp.json` 只能用 `${env:...}`，不要明文密钥）。`publish_site` 把网盘目录同步到 `sites/{slug}/`（同名覆盖，不删 SPA 配置；站点开关关闭时 404）。 `image_upload` / `image_list` / `image_delete` 包装 `/api/images`（公开地址 `https://<SITES_HOST>/i/{id}` 和 Markdown；上限 20 MB；图床开关关闭时 404）。
 
 ```bash
 # initialize
@@ -211,6 +211,13 @@ Cursor（`mcp.json`）：
 1. 让助手对某个文件/目录调用 `share_create`，并设 `expiresInHours=24`（可选 `extractCode`）。
 2. 把返回的分享 `url`（路径 `/share/{token}`）转发出去即可。
 3. 用 `share_list` / `share_revoke`（传入 `token`）查看与撤销。
+
+### 对话里误删再捞回来
+
+1. `delete` 默认进回收站（软删）。
+2. 用 `trash_list` 查看 `trashKey` / `originalKey`。
+3. 用 `trash_restore`（传入 `trashKey`）还原。
+4. 或 `trash_empty` 永久清空回收站。
 
 ### 用 Cursor 试 MCP
 

--- a/functions/_mcp.ts
+++ b/functions/_mcp.ts
@@ -105,6 +105,12 @@ export type ToolCallApis = {
   }) => Promise<Response>;
   shareList: () => Promise<Response>;
   shareRevoke: (query: { token: string }) => Promise<Response>;
+  trashList: () => Promise<Response>;
+  trashRestore: (query: { trashKeys: string[] }) => Promise<Response>;
+  trashEmpty: (query: {
+    trashKeys?: string[];
+    all?: boolean;
+  }) => Promise<Response>;
   sitesList: (query: { withStats?: boolean }) => Promise<Response>;
   sitesConfig: (query: { slug: string; spa: boolean }) => Promise<Response>;
   sitesDelete: (query: { slug: string; purge?: boolean }) => Promise<Response>;
@@ -335,6 +341,46 @@ export const MCP_TOOLS = [
         token: { type: "string", description: "Share token from share_create/share_list" },
       },
       required: ["token"],
+    },
+  },
+  {
+    name: "trash_list",
+    description:
+      "List soft-deleted items in trash (trashKey, originalKey, name, deletedAt, size).",
+    inputSchema: { type: "object", properties: {} },
+  },
+  {
+    name: "trash_restore",
+    description:
+      "Restore soft-deleted item(s) from trash by trashKey (from trash_list). Fails with conflict if the original path already exists.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        trashKey: {
+          type: "string",
+          description: "Single trash id from trash_list",
+        },
+        trashKeys: {
+          type: "array",
+          items: { type: "string" },
+          description: "One or more trash ids from trash_list",
+        },
+      },
+    },
+  },
+  {
+    name: "trash_empty",
+    description:
+      "Permanently delete trash entries. With no args, empties the entire trash. Pass trashKeys to delete specific entries only.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        trashKeys: {
+          type: "array",
+          items: { type: "string" },
+          description: "Optional trash ids; omit to empty all",
+        },
+      },
     },
   },
   {
@@ -1244,6 +1290,38 @@ async function callTool(
       const token = asString(args.token);
       if (!token) return toolError("token is required");
       return wrapApiResponse(await apis.shareRevoke({ token }));
+    }
+    case "trash_list": {
+      return wrapApiResponse(await apis.trashList());
+    }
+    case "trash_restore": {
+      const trashKeys: string[] = [];
+      const single = asString(args.trashKey).trim();
+      if (single) trashKeys.push(single);
+      if (Array.isArray(args.trashKeys)) {
+        for (const item of args.trashKeys) {
+          const key = asString(item).trim();
+          if (key) trashKeys.push(key);
+        }
+      }
+      if (trashKeys.length === 0) {
+        return toolError("trashKey or trashKeys is required");
+      }
+      return wrapApiResponse(await apis.trashRestore({ trashKeys }));
+    }
+    case "trash_empty": {
+      if (Array.isArray(args.trashKeys) && args.trashKeys.length > 0) {
+        const trashKeys: string[] = [];
+        for (const item of args.trashKeys) {
+          const key = asString(item).trim();
+          if (key) trashKeys.push(key);
+        }
+        if (trashKeys.length === 0) {
+          return toolError("trashKeys must be non-empty strings");
+        }
+        return wrapApiResponse(await apis.trashEmpty({ trashKeys }));
+      }
+      return wrapApiResponse(await apis.trashEmpty({ all: true }));
     }
     case "sites_list": {
       const withStats = asOptionalBoolean(args.stats) !== false;

--- a/functions/api/trash.ts
+++ b/functions/api/trash.ts
@@ -1,8 +1,8 @@
 import {
   ensureFolderMarkers,
   isInternalKey,
+  isSessionOrKeyAuthorized,
   textResponse,
-  verifyBasicAuth,
 } from "./_apikey";
 
 interface TrashEnv {
@@ -114,7 +114,12 @@ async function listTrashItems(bucket: R2Bucket) {
 
 export const onRequestGet: PagesFunction<TrashEnv> = async (context) => {
   const { request, env } = context;
-  if (!verifyBasicAuth(request, env.WEBDAV_USERNAME, env.WEBDAV_PASSWORD)) {
+  if (!(await isSessionOrKeyAuthorized(
+    request,
+    env.BUCKET,
+    env.WEBDAV_USERNAME,
+    env.WEBDAV_PASSWORD
+  ))) {
     return textResponse("Unauthorized", 401);
   }
   await purgeExpiredTrash(env.BUCKET, retentionDaysFrom(env));
@@ -126,7 +131,12 @@ export const onRequestGet: PagesFunction<TrashEnv> = async (context) => {
 
 export const onRequestPost: PagesFunction<TrashEnv> = async (context) => {
   const { request, env } = context;
-  if (!verifyBasicAuth(request, env.WEBDAV_USERNAME, env.WEBDAV_PASSWORD)) {
+  if (!(await isSessionOrKeyAuthorized(
+    request,
+    env.BUCKET,
+    env.WEBDAV_USERNAME,
+    env.WEBDAV_PASSWORD
+  ))) {
     return textResponse("Unauthorized", 401);
   }
 
@@ -139,7 +149,12 @@ export const onRequestPost: PagesFunction<TrashEnv> = async (context) => {
 
 export const onRequestDelete: PagesFunction<TrashEnv> = async (context) => {
   const { request, env } = context;
-  if (!verifyBasicAuth(request, env.WEBDAV_USERNAME, env.WEBDAV_PASSWORD)) {
+  if (!(await isSessionOrKeyAuthorized(
+    request,
+    env.BUCKET,
+    env.WEBDAV_USERNAME,
+    env.WEBDAV_PASSWORD
+  ))) {
     return textResponse("Unauthorized", 401);
   }
 

--- a/functions/mcp.ts
+++ b/functions/mcp.ts
@@ -13,6 +13,11 @@ import {
   onRequestPost as sharesOnPost,
 } from "./api/shares";
 import {
+  onRequestDelete as trashOnDelete,
+  onRequestGet as trashOnGet,
+  onRequestPost as trashOnPost,
+} from "./api/trash";
+import {
   onRequestDelete as sitesOnDelete,
   onRequestGet as sitesOnGet,
   onRequestPost as sitesOnPost,
@@ -98,7 +103,7 @@ function withRequest<T extends { BUCKET: R2Bucket }>(
   context: McpContext,
   request: Request
 ): EventContext<T, any, any> {
-  // MCP 流程已通过 API key 鉴权；shares/sites handler 的 Basic 凭据字段在
+  // MCP 流程已通过 API key 鉴权；shares/sites/trash handler 的 Basic 凭据字段在
   // 该分支下仅用于"是否同时允许会话"的判定，缺失时安全跳过。
   return Object.assign({}, context, { request }) as unknown as EventContext<
     T,
@@ -250,6 +255,31 @@ function makeApis(context: McpContext): ToolCallApis {
       url.searchParams.set("token", token);
       const request = cloneApiRequest(context.request, "DELETE", url);
       return sharesOnDelete(withRequest(context, request));
+    },
+    async trashList() {
+      const url = new URL("/api/trash", origin);
+      const request = cloneApiRequest(context.request, "GET", url);
+      return trashOnGet(withRequest(context, request));
+    },
+    async trashRestore({ trashKeys }) {
+      const url = new URL("/api/trash", origin);
+      url.searchParams.set("action", "restore");
+      const request = cloneApiRequest(context.request, "POST", url, {
+        body: JSON.stringify({ trashKeys }),
+        headers: { "Content-Type": "application/json" },
+      });
+      return trashOnPost(withRequest(context, request));
+    },
+    async trashEmpty({ trashKeys, all }) {
+      const url = new URL("/api/trash", origin);
+      const body: Record<string, unknown> = {};
+      if (all) body.all = true;
+      if (trashKeys) body.trashKeys = trashKeys;
+      const request = cloneApiRequest(context.request, "DELETE", url, {
+        body: JSON.stringify(body),
+        headers: { "Content-Type": "application/json" },
+      });
+      return trashOnDelete(withRequest(context, request));
     },
     async sitesList({ withStats }) {
       const url = new URL("/api/sites", origin);

--- a/src/app/__tests__/mcp.test.ts
+++ b/src/app/__tests__/mcp.test.ts
@@ -45,6 +45,9 @@ function mockApis(overrides: Partial<ToolCallApis> = {}): ToolCallApis {
     shareCreate: async () => httpJsonResponse({ token: "tok-1", url: "http://x/share/tok-1" }, 201),
     shareList: async () => httpJsonResponse([]),
     shareRevoke: async () => new Response(null, { status: 204 }),
+    trashList: async () => httpJsonResponse([]),
+    trashRestore: async () => httpJsonResponse([{ trashKey: "t1", status: "restored" }]),
+    trashEmpty: async () => new Response(null, { status: 204 }),
     sitesList: async () => httpJsonResponse({ sitesHost: "sites.example.com", sites: [] }),
     sitesConfig: async () => httpJsonResponse({ slug: "demo", spa: true }),
     sitesDelete: async () => httpJsonResponse({ slug: "demo", deleted: 2 }),
@@ -82,7 +85,7 @@ function toolPayload(result: Awaited<ReturnType<typeof dispatchMcpRequest>>) {
 }
 
 describe("mcp protocol", () => {
-  test("tool catalog: base + search/move/copy/stat/share/sites + pull/push/publish_site", () => {
+  test("tool catalog: base + search/move/copy/stat/share/trash/sites + pull/push/publish_site", () => {
     expect(MCP_TOOL_NAMES).toEqual([
       "list",
       "upload",
@@ -96,6 +99,9 @@ describe("mcp protocol", () => {
       "share_create",
       "share_list",
       "share_revoke",
+      "trash_list",
+      "trash_restore",
+      "trash_empty",
       "sites_list",
       "sites_config",
       "sites_delete",
@@ -106,7 +112,7 @@ describe("mcp protocol", () => {
       "image_list",
       "image_delete",
     ]);
-    expect(MCP_TOOLS).toHaveLength(21);
+    expect(MCP_TOOLS).toHaveLength(24);
   });
 
   test("parseJsonRpcBody rejects invalid json", () => {
@@ -323,6 +329,51 @@ describe("mcp protocol", () => {
     const missing = await callTool("share_create", {}, { shareCreate });
     expect(toolPayload(missing).isError).toBe(true);
     expect(shareCreate).not.toHaveBeenCalled();
+  });
+
+  test("trash tools list, restore, empty", async () => {
+    const trashList = vi.fn(async () =>
+      httpJsonResponse([{ trashKey: "tid-1", originalKey: "notes.txt" }])
+    );
+    const listed = await callTool("trash_list", {}, { trashList });
+    expect(trashList).toHaveBeenCalledTimes(1);
+    expect(JSON.parse(toolPayload(listed).content[0].text)[0].trashKey).toBe("tid-1");
+
+    const trashRestore = vi.fn(async () =>
+      httpJsonResponse([{ trashKey: "tid-1", status: "restored" }])
+    );
+    const restored = await callTool(
+      "trash_restore",
+      { trashKey: "tid-1" },
+      { trashRestore }
+    );
+    expect(trashRestore).toHaveBeenCalledWith({ trashKeys: ["tid-1"] });
+    expect(JSON.parse(toolPayload(restored).content[0].text)[0].status).toBe("restored");
+
+    const trashRestoreMany = vi.fn(async () =>
+      httpJsonResponse([{ trashKey: "a", status: "restored" }])
+    );
+    await callTool(
+      "trash_restore",
+      { trashKeys: ["a", "b"] },
+      { trashRestore: trashRestoreMany }
+    );
+    expect(trashRestoreMany).toHaveBeenCalledWith({ trashKeys: ["a", "b"] });
+
+    const trashEmpty = vi.fn(async () => new Response(null, { status: 204 }));
+    await callTool("trash_empty", {}, { trashEmpty });
+    expect(trashEmpty).toHaveBeenCalledWith({ all: true });
+
+    const trashEmptySome = vi.fn(async () => new Response(null, { status: 204 }));
+    await callTool("trash_empty", { trashKeys: ["tid-1"] }, { trashEmpty: trashEmptySome });
+    expect(trashEmptySome).toHaveBeenCalledWith({ trashKeys: ["tid-1"] });
+  });
+
+  test("trash_restore rejects missing trashKey", async () => {
+    const trashRestore = vi.fn(async () => httpJsonResponse([]));
+    const missing = await callTool("trash_restore", {}, { trashRestore });
+    expect(toolPayload(missing).isError).toBe(true);
+    expect(trashRestore).not.toHaveBeenCalled();
   });
 
   test("sites tools list/config/delete", async () => {


### PR DESCRIPTION
## Summary
- Add MCP tools `trash_list`, `trash_restore`, `trash_empty` wrapping `/api/trash` (same pattern as `share_*`).
- Trash HTTP handlers now accept session **or** API key (`isSessionOrKeyAuthorized`) so `/mcp` Bearer auth works.
- Docs: bilingual chat example «对话里误删再捞回来» / recover mistaken delete; tool count 21→24 in README.

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npx vitest run` (920 passed)
- [ ] CI green
- [ ] QA: exercise via `/mcp` — soft `delete` → `trash_list` → `trash_restore`; `trash_empty`