### PR TITLE
fix(docs): Pages deploy path instead of Workers button (#91)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,11 @@
 
 [English](README.md) | [中文](README.zh-CN.md)
 
-[![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/fanchenggang/Davflare)
+[![Deploy to Cloudflare Pages](https://img.shields.io/badge/Deploy%20to%20Cloudflare-Pages-F38020?logo=cloudflare&logoColor=white)](https://dash.cloudflare.com/?to=/:account/workers-and-pages/create) · [Deploy guide](docs/deploy.md)
 
-Cloudflare R2 file manager on Pages + Workers — free 10 GB storage and 100,000 Worker invocations per day. [R2 pricing](https://developers.cloudflare.com/r2/platform/pricing/)
+Cloudflare R2 file manager on **Cloudflare Pages** (API via Pages Functions) — free 10 GB storage and 100,000 invocations per day. [R2 pricing](https://developers.cloudflare.com/r2/platform/pricing/)
+
+> **Pages, not Workers.** This repo sets `pages_build_output_dir` in `wrangler.toml` and has no Worker `main`. Do **not** use the [Workers Deploy to Cloudflare](https://deploy.workers.cloudflare.com/) button or `wrangler deploy` — that looks for a Worker entry point and fails with «entry point not configured».
 
 ## Screenshots
 
@@ -38,12 +40,13 @@ Share (expiry + extract code):
 
 ## Quick start
 
-1. One-click deploy with the button above (needs a Cloudflare account with R2 activated and a payment method on file).
-2. Bind your R2 bucket to `BUCKET`, set `WEBDAV_USERNAME` and `WEBDAV_PASSWORD`, then retry deploy.
-3. Optional: `WEBDAV_PUBLIC_READ=1`, `TRASH_RETENTION_DAYS` (default `30`, `-1` disables), and for public sites/images bind `sites.<your-domain>` and set `SITES_HOST=sites.<your-domain>`.
-4. Optional: add a custom domain for the drive UI.
+1. Open [Workers & Pages → Create](https://dash.cloudflare.com/?to=/:account/workers-and-pages/create) → **Pages** → **Connect to Git**, pick this repo (needs a Cloudflare account with R2 activated and a payment method on file).
+2. Framework preset **None**, build `npm run build`, output directory `build` (or rely on `wrangler.toml`'s `pages_build_output_dir`).
+3. Bind your R2 bucket to `BUCKET`, set `WEBDAV_USERNAME` and `WEBDAV_PASSWORD`, then retry deploy.
+4. Optional: `WEBDAV_PUBLIC_READ=1`, `TRASH_RETENTION_DAYS` (default `30`, `-1` disables), and for public sites/images bind `sites.<your-domain>` and set `SITES_HOST=sites.<your-domain>`.
+5. Optional: add a custom domain for the drive UI.
 
-Manual Pages / Wrangler steps and the five feature switches: [docs/deploy.md](docs/deploy.md).
+Full Pages / Wrangler steps and the five feature switches: [docs/deploy.md](docs/deploy.md).
 
 ## Documentation
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -2,9 +2,11 @@
 
 [English](README.md) | [中文](README.zh-CN.md)
 
-[![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/fanchenggang/Davflare)
+[![Deploy to Cloudflare Pages](https://img.shields.io/badge/Deploy%20to%20Cloudflare-Pages-F38020?logo=cloudflare&logoColor=white)](https://dash.cloudflare.com/?to=/:account/workers-and-pages/create) · [部署说明](docs/deploy.zh-CN.md)
 
-基于 Cloudflare Pages + Workers 的 R2 网盘 —— 免费 10 GB 存储、每天 10 万次 Worker 调用。[R2 定价](https://developers.cloudflare.com/r2/platform/pricing/)
+基于 **Cloudflare Pages**（API 走 Pages Functions）的 R2 网盘 —— 免费 10 GB 存储、每天 10 万次调用。[R2 定价](https://developers.cloudflare.com/r2/platform/pricing/)
+
+> **这是 Pages，不是 Workers。** 本仓库在 `wrangler.toml` 里配置了 `pages_build_output_dir`，没有 Worker `main`。请**不要**用 [Workers 一键部署按钮](https://deploy.workers.cloudflare.com/) 或 `wrangler deploy`——那会去找 Worker 入口，并报 «entry point not configured / entry point 没有配置」。
 
 ## 截图
 
@@ -38,12 +40,13 @@
 
 ## 快速开始
 
-1. 用上方按钮一键部署（需要已开通 R2、并绑定支付方式的 Cloudflare 账号）。
-2. 将 R2 bucket 绑定到 `BUCKET`，设置 `WEBDAV_USERNAME` 和 `WEBDAV_PASSWORD`，然后重新部署。
-3. 可选：`WEBDAV_PUBLIC_READ=1`、`TRASH_RETENTION_DAYS`（默认 `30`，`-1` 关闭）；公开站点/图床请绑 `sites.<你的域>` 并设 `SITES_HOST=sites.<你的域>`。
-4. 可选：给网盘界面绑自定义域名。
+1. 打开 [Workers & Pages → Create](https://dash.cloudflare.com/?to=/:account/workers-and-pages/create) → **Pages** → **Connect to Git**，选择本仓库（需要已开通 R2、并绑定支付方式的 Cloudflare 账号）。
+2. 框架预设选 **None**，构建命令 `npm run build`，输出目录 `build`（也可直接用 `wrangler.toml` 里的 `pages_build_output_dir`）。
+3. 将 R2 bucket 绑定到 `BUCKET`，设置 `WEBDAV_USERNAME` 和 `WEBDAV_PASSWORD`，然后重新部署。
+4. 可选：`WEBDAV_PUBLIC_READ=1`、`TRASH_RETENTION_DAYS`（默认 `30`，`-1` 关闭）；公开站点/图床请绑 `sites.<你的域>` 并设 `SITES_HOST=sites.<你的域>`。
+5. 可选：给网盘界面绑自定义域名。
 
-手动 Pages / Wrangler 步骤与五个功能开关见 [docs/deploy.zh-CN.md](docs/deploy.zh-CN.md)。
+完整 Pages / Wrangler 步骤与五个功能开关见 [docs/deploy.zh-CN.md](docs/deploy.zh-CN.md)。
 
 ## 文档
 

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -4,13 +4,35 @@
 
 ← [README](../README.md)
 
-## One-click
+## This project is Cloudflare Pages
 
-[![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/fanchenggang/Davflare)
+Davflare deploys as a **Cloudflare Pages** app (static UI in `build/` + backend in `functions/` as Pages Functions).
+
+Evidence in-repo:
+
+- `wrangler.toml` has `pages_build_output_dir = "build"`
+- There is **no** Worker `main` entry — do **not** invent one just to satisfy Workers tooling
+- Correct CLI: `npx wrangler pages deploy build`
+- **Wrong** CLI: `npx wrangler deploy` (Workers) → «Missing entry-point / entry point not configured»
+- **Wrong** button: [Deploy to Cloudflare Workers](https://deploy.workers.cloudflare.com/?url=https://github.com/fanchenggang/Davflare) — same failure mode
 
 You need a [Cloudflare](https://dash.cloudflare.com/) account with a payment method and R2 activated (create at least one bucket).
 
-After the first deploy:
+## Deploy via Cloudflare Dashboard (recommended)
+
+There is no official Pages equivalent of the Workers one-click Deploy button. Use the dashboard:
+
+1. Open [Workers & Pages → Create](https://dash.cloudflare.com/?to=/:account/workers-and-pages/create)
+2. Choose **Pages** → **Connect to Git** → select `fanchenggang/Davflare` (or your fork)
+3. Build settings:
+   - Framework preset: **None** (React/Vite, not Docusaurus)
+   - Build command: `npm run build`
+   - Output directory: `build`
+4. Deploy, then configure bindings / env vars (next section) and **retry deploy** so they apply
+
+Official guide: [Pages Git integration](https://developers.cloudflare.com/pages/get-started/git-integration/).
+
+## After the first deploy
 
 1. Bind your R2 bucket to the `BUCKET` variable
 2. Set `WEBDAV_USERNAME` and `WEBDAV_PASSWORD`
@@ -19,19 +41,22 @@ After the first deploy:
 5. Retry deploy so the binding and env vars apply
 6. Optional: add a custom domain for the drive UI
 
-## Manual Cloudflare Pages
-
-- Framework preset: **None (React/Vite, not Docusaurus)**
-- Output directory: `build`
-- Then bind `BUCKET`, set the env vars above, and retry deploy
-
-## Wrangler CLI
+## Wrangler CLI (Pages)
 
 `wrangler.toml` binds R2 as `BUCKET` (default bucket name `webdav`). Change `bucket_name` to your bucket if needed.
 
 ```bash
 npm run build
 npx wrangler pages deploy build
+```
+
+Do **not** run `npx wrangler deploy` against this repo — that is the Workers path and will complain that no entry point is configured.
+
+Local preview (Pages + Functions):
+
+```bash
+npm run build
+npx wrangler pages dev build
 ```
 
 ## Feature switches
@@ -55,4 +80,3 @@ Toggle them in the UI:
 3. MCP depends on API Key: if Key is off, `/mcp` is 404 even if MCP is on. Sites and image-host public URLs also need `SITES_HOST`.
 
 See also [webdav.md](./webdav.md), [sites.md](./sites.md), [API.md](./API.md).
-

--- a/docs/deploy.zh-CN.md
+++ b/docs/deploy.zh-CN.md
@@ -4,13 +4,35 @@
 
 ← [README](../README.zh-CN.md)
 
-## 一键部署
+## 本项目是 Cloudflare Pages
 
-[![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/fanchenggang/Davflare)
+Davflare 以 **Cloudflare Pages** 方式部署（静态 UI 在 `build/`，后端在 `functions/`，即 Pages Functions）。
+
+仓库内依据：
+
+- `wrangler.toml` 有 `pages_build_output_dir = "build"`
+- **没有** Worker `main` 入口——不要为了迁就 Workers 工具而伪造一个
+- 正确 CLI：`npx wrangler pages deploy build`
+- **错误** CLI：`npx wrangler deploy`（Workers）→ «Missing entry-point / entry point not configured»
+- **错误** 按钮：[Deploy to Cloudflare Workers](https://deploy.workers.cloudflare.com/?url=https://github.com/fanchenggang/Davflare) —— 同样会踩坑
 
 你需要一个已绑定支付方式、并已开通 R2 的 [Cloudflare](https://dash.cloudflare.com/) 账号（至少创建一个 bucket）。
 
-首次部署之后：
+## 用 Cloudflare 控制台部署（推荐）
+
+Cloudflare **没有**与 Workers「一键 Deploy」对等的官方 Pages 按钮。请走控制台：
+
+1. 打开 [Workers & Pages → Create](https://dash.cloudflare.com/?to=/:account/workers-and-pages/create)
+2. 选择 **Pages** → **Connect to Git** → 选 `fanchenggang/Davflare`（或你的 fork）
+3. 构建设置：
+   - 框架预设：**None**（React/Vite，不是 Docusaurus）
+   - 构建命令：`npm run build`
+   - 输出目录：`build`
+4. 先部署，再配置绑定 / 环境变量（下一节），并**重新部署**使配置生效
+
+官方说明：[Pages Git 集成](https://developers.cloudflare.com/pages/get-started/git-integration/)。
+
+## 首次部署之后
 
 1. 将 R2 bucket 绑定到 `BUCKET` 变量
 2. 设置 `WEBDAV_USERNAME` 和 `WEBDAV_PASSWORD`
@@ -19,19 +41,22 @@
 5. 重新部署，使绑定和环境变量生效
 6. 可选：给网盘界面绑自定义域名
 
-## 手动部署 Cloudflare Pages
-
-- 框架预设：**None（React/Vite，不是 Docusaurus）**
-- 输出目录：`build`
-- 然后绑定 `BUCKET`、设置上述环境变量，并重新部署
-
-## Wrangler CLI
+## Wrangler CLI（Pages）
 
 `wrangler.toml` 将 R2 绑定为 `BUCKET`（默认 bucket 名为 `webdav`）。如有需要，把 `bucket_name` 改成你的 bucket。
 
 ```bash
 npm run build
 npx wrangler pages deploy build
+```
+
+**不要**对本仓库执行 `npx wrangler deploy`——那是 Workers 路径，会报没有配置 entry point。
+
+本地预览（Pages + Functions）：
+
+```bash
+npm run build
+npx wrangler pages dev build
 ```
 
 ## 功能开关
@@ -55,4 +80,3 @@ npx wrangler pages deploy build
 3. MCP 依赖 API Key：Key 关闭时，即使 MCP 打开，`/mcp` 也是 404。站点和图床的公开地址还需要 `SITES_HOST`。
 
 另见 [webdav.zh-CN.md](./webdav.zh-CN.md)、[sites.zh-CN.md](./sites.zh-CN.md)、[API.zh-CN.md](./API.zh-CN.md)。
-


### PR DESCRIPTION
## Summary
- Issue #91: README / deploy docs used the **Workers** Deploy button (`deploy.workers.cloudflare.com`), but this repo is **Pages** (`pages_build_output_dir`, no `main`) → Wrangler «entry point not configured».
- Replace the button with a **Pages** Dashboard Create link + explicit warning not to use Workers Deploy / `wrangler deploy`.
- Expand `docs/deploy.md` + `deploy.zh-CN.md`: Pages vs Workers, Dashboard Git connect settings, `wrangler pages deploy` / `pages dev`, and the wrong Workers paths.
- **Does not** add a fake Worker `main` to silence the old button. No API-key-scope / extension / WebDAV / R2 / dark-mode product changes.

## Test plan
- [ ] README (EN/ZH): no Workers Deploy badge; badge/link goes to Workers & Pages Create; callout mentions Pages + entry-point pitfall
- [ ] `docs/deploy*`: states Pages-only; documents Dashboard + `wrangler pages deploy`; warns against `wrangler deploy` / Workers button
- [ ] `wrangler.toml` still has `pages_build_output_dir` and no `main`
- [ ] CI green (docs-only)

Fixes #91