### PR TITLE
feat(api/mcp): authenticated folder zip without public share

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Share (expiry + extract code):
 - Share links with expiry or forever, extract code, folder zip, and a zero-JS landing page
 - Recycle bin with configurable retention (`TRASH_RETENTION_DAYS`)
 - WebDAV Class 1/2 at `/webdav` (toggleable without affecting the web UI)
-- API keys for scripted upload / download / sync, plus remote MCP at `/mcp` (24 tools)
+- API keys for scripted upload / download / sync, plus remote MCP at `/mcp` (25 tools)
 - Static sites and image host on a separate hostname (`SITES_HOST`)
 - Owner Settings with five persistent feature switches
 - `davflare-cli`, optional Chrome MV3 extension, and agent layouts on R2
@@ -54,7 +54,7 @@ Full Pages / Wrangler steps and the five feature switches: [docs/deploy.md](docs
 | --- | --- |
 | Deploy, env vars, feature switches, post-deploy `#/setup` checklist | [docs/deploy.md](docs/deploy.md) |
 | WebDAV clients & limits | [docs/webdav.md](docs/webdav.md) |
-| Open API & MCP (incl. chat share example) | [docs/API.md](docs/API.md) |
+| Open API & MCP (incl. chat share / zip folder examples) | [docs/API.md](docs/API.md) |
 | Static sites & image host | [docs/sites.md](docs/sites.md) |
 | Agent layouts (`pull` / `push`) | [docs/agents.md](docs/agents.md) |
 | CLI (`davflare-cli`) | [cli/README.md](cli/README.md) |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -32,7 +32,7 @@
 - 分享链接（限时或永久）、提取码、文件夹 zip，以及零脚本落地页
 - 回收站，保留天数可配（`TRASH_RETENTION_DAYS`）
 - WebDAV Class 1/2，路径 `/webdav`（可关闭，不影响网页端）
-- API Key 支持脚本上传 / 下载 / 同步，远程 MCP 在 `/mcp`（24 个工具）
+- API Key 支持脚本上传 / 下载 / 同步，远程 MCP 在 `/mcp`（25 个工具）
 - 静态站点与图床走单独域名（`SITES_HOST`）
 - 拥有者设置页五个持久化功能开关
 - `davflare-cli`、可选 Chrome MV3 扩展，以及 R2 上的 Agent 目录约定
@@ -54,7 +54,7 @@
 | --- | --- |
 | 部署、环境变量、功能开关、部署后 `#/setup` 检查清单 | [docs/deploy.zh-CN.md](docs/deploy.zh-CN.md) |
 | WebDAV 客户端与限制 | [docs/webdav.zh-CN.md](docs/webdav.zh-CN.md) |
-| 开放接口与 MCP（含对话分享示例） | [docs/API.zh-CN.md](docs/API.zh-CN.md) |
+| 开放接口与 MCP（含对话分享 / 目录打 zip 示例） | [docs/API.zh-CN.md](docs/API.zh-CN.md) |
 | 静态站点与图床 | [docs/sites.zh-CN.md](docs/sites.zh-CN.md) |
 | Agent 目录（`pull` / `push`） | [docs/agents.zh-CN.md](docs/agents.zh-CN.md) |
 | 命令行（`davflare-cli`） | [cli/README.md](cli/README.md) |

--- a/docs/API.md
+++ b/docs/API.md
@@ -63,7 +63,7 @@ curl -X DELETE "https://<your-domain.com>/api/upload?path=folder/big.bin&uploadI
 
 ### List, download, mkdir
 
-The same keys can list a folder and download each file (folders are not a zip via `/api/download`; use a directory share for zip).
+The same keys can list a folder and download each file. Single-file download stays on `/api/download`. To zip a folder **without** creating a public share link, use authenticated `/api/archive` (or the MCP `zip` tool). Directory shares still work when you want a link.
 
 ```bash
 # Depth-1 list (empty path = root). Does not recurse.
@@ -79,11 +79,25 @@ curl -L "https://<your-domain.com>/api/download?path=folder/notes.txt" \
 curl -L "https://<your-domain.com>/api/download?path=folder/notes.txt" \
   -H "X-Api-Key: <apiKey>" \
   -o notes.txt
+
+# zip a folder (or single file) — streams application/zip; no public share link
+curl -L "https://<your-domain.com>/api/archive?path=folder/" \
+  -H "Authorization: Bearer <apiKey>" \
+  -o folder.zip
+
+# multi-select zip (same body the web UI uses); Basic session or API key
+curl -X POST "https://<your-domain.com>/api/archive" \
+  -H "Authorization: Bearer <apiKey>" \
+  -H "Content-Type: application/json" \
+  -d '{"keys":["folder/a.txt","folder/sub/"]}' \
+  -o archive.zip
 ```
 
 `GET /api/list` returns `{ items: [{ key, name, size, isDir, uploaded, etag }] }` for the current folder only. Files always include numeric `size`, ISO `uploaded` (and alias `updated`), and R2 `etag`. Delimited-prefix folders have `isDir: true`, `size: 0`, and `uploaded: null` (unknown; no fake mtime). Nested folders: call `/api/list` again with that item's `key`. If `path` is a file, the list API returns **400** and tells you to use `/api/download`. Missing folder: **404**. Bad/expired key: **401**. Large folders: add `limit=1..1000` (plus `cursor` from the previous response) for paged reads — the response then carries `nextCursor` while more pages remain.
 
 `GET /api/download` `path` is the object key. **HTTP 200** streams the file (`Content-Type` from R2 or `application/octet-stream`, `Content-Disposition: attachment`). Missing/empty path or a directory/prefix folder returns **400**; unknown object **404**; bad/expired key **401**. Internal `_$flaredrive$/` keys are rejected.
+
+`GET /api/archive?path=` zips one folder or file with the same Bearer / `X-Api-Key` (or web Basic session). **HTTP 200** streams `application/zip`. Folder keys strip the folder prefix inside the zip (same as directory shares). Missing path **400**; unknown path **404**; bad/expired key **401**. Internal `_$flaredrive$/` keys are rejected. `POST /api/archive` with `{ "keys": [...] }` packs multiple selections (web UI multi-download); same auth and internal-key rules.
 
 Create folders from scripts (parents are auto-created):
 
@@ -189,7 +203,7 @@ Public URL: `https://<SITES_HOST>/i/{id}`. SVG responses use `Content-Dispositio
 
 ### MCP
 
-Same-origin Streamable HTTP MCP at `POST /mcp` (JSON-RPC 2.0). Auth is the same `Authorization: Bearer <apiKey>` or `X-Api-Key` as the rest of this API (no web session, no OAuth). **MCP depends on the API Key switch** — if API Key is off (or MCP is off), `/mcp` returns **404**. Missing or invalid keys return **HTTP 401**. Tools: `list`, `upload`, `download`, `mkdir`, `delete`, `search`, `move`, `copy`, `stat`, `share_create`, `share_list`, `share_revoke`, `trash_list`, `trash_restore`, `trash_empty`, `sites_list`, `sites_config`, `sites_delete`, `pull`, `push`, `publish_site`, `image_upload`, `image_list`, `image_delete` (they wrap the Open API handlers above). Uploads over 1 MiB are automatically sent in multipart chunks (cap **25 MB**; larger returns a tool error — use the web UI or scripts). Downloads over 1 MiB page with `part` / `partSize` (base64 slices). Default `delete` is soft-delete to trash; pass `hard=true` to permanently delete. Recover with `trash_list` / `trash_restore`; permanently clear with `trash_empty`. `sites_*` manage the static sites under `sites/` (see [sites.md](./sites.md)); `upload`/`delete` also work directly on `sites/<slug>/` keys. `pull` walks `agents/{global|agent|agent/project}/{skills|rules|mcp}/` and returns layered files (merge: project > agent > global); large files page like `download`. `push` writes that tree (`mcp.json` must use `${env:...}`, not raw keys). `publish_site` copies a drive folder onto `sites/{slug}/` (overwrite same names; SPA config is kept; 404 if the Sites switch is off). `image_upload` / `image_list` / `image_delete` wrap `/api/images` (public `https://<SITES_HOST>/i/{id}` + Markdown; 20 MB cap; 404 if Image Host is off).
+Same-origin Streamable HTTP MCP at `POST /mcp` (JSON-RPC 2.0). Auth is the same `Authorization: Bearer <apiKey>` or `X-Api-Key` as the rest of this API (no web session, no OAuth). **MCP depends on the API Key switch** — if API Key is off (or MCP is off), `/mcp` returns **404**. Missing or invalid keys return **HTTP 401**. Tools: `list`, `upload`, `download`, `zip`, `mkdir`, `delete`, `search`, `move`, `copy`, `stat`, `share_create`, `share_list`, `share_revoke`, `trash_list`, `trash_restore`, `trash_empty`, `sites_list`, `sites_config`, `sites_delete`, `pull`, `push`, `publish_site`, `image_upload`, `image_list`, `image_delete` (they wrap the Open API handlers above). Uploads over 1 MiB are automatically sent in multipart chunks (cap **25 MB**; larger returns a tool error — use the web UI or scripts). Downloads over 1 MiB page with `part` / `partSize` (base64 slices). `zip` packs a folder via `/api/archive` (base64; same 1 MiB / `part` paging; hard cap 25 MB — larger use curl on `/api/archive`). Default `delete` is soft-delete to trash; pass `hard=true` to permanently delete. Recover with `trash_list` / `trash_restore`; permanently clear with `trash_empty`. `sites_*` manage the static sites under `sites/` (see [sites.md](./sites.md)); `upload`/`delete` also work directly on `sites/<slug>/` keys. `pull` walks `agents/{global|agent|agent/project}/{skills|rules|mcp}/` and returns layered files (merge: project > agent > global); large files page like `download`. `push` writes that tree (`mcp.json` must use `${env:...}`, not raw keys). `publish_site` copies a drive folder onto `sites/{slug}/` (overwrite same names; SPA config is kept; 404 if the Sites switch is off). `image_upload` / `image_list` / `image_delete` wrap `/api/images` (public `https://<SITES_HOST>/i/{id}` + Markdown; 20 MB cap; 404 if Image Host is off).
 
 ```bash
 # initialize
@@ -225,6 +239,12 @@ Cursor (`mcp.json`):
 1. Ask the agent to call `share_create` on a file or folder path, with `expiresInHours=24` (optional `extractCode`).
 2. Forward the returned share `url` (path `/share/{token}`).
 3. Manage with `share_list` / `share_revoke` (pass the `token`).
+
+### Zip a folder from chat (pull back locally)
+
+1. Ask the agent to call `zip` on a folder path (no `share_create`, no public link).
+2. Small archives (≤ 1 MiB) come back as base64 — decode and save as `.zip`.
+3. Larger ones: pass `part=1`, `part=2`, … (optional `partSize`) and concatenate the base64 slices; or curl `GET /api/archive?path=` with your API key.
 
 ### Recover a mistaken delete from chat
 

--- a/docs/API.zh-CN.md
+++ b/docs/API.zh-CN.md
@@ -63,7 +63,7 @@ curl -X DELETE "https://<your-domain.com>/api/upload?path=folder/big.bin&uploadI
 
 ### 列出、下载、创建目录
 
-同一把密钥可以列出文件夹并逐个下载文件（`/api/download` 不会把文件夹打成 zip；目录 zip 请走目录分享）。
+同一把密钥可以列出文件夹并逐个下载文件。单文件仍用 `/api/download`。要把目录打成 zip **且不**创建公开分享链接，用已鉴权的 `/api/archive`（或 MCP `zip` 工具）。需要外链时目录分享照旧可用。
 
 ```bash
 # Depth-1 list (empty path = root). Does not recurse.
@@ -79,11 +79,25 @@ curl -L "https://<your-domain.com>/api/download?path=folder/notes.txt" \
 curl -L "https://<your-domain.com>/api/download?path=folder/notes.txt" \
   -H "X-Api-Key: <apiKey>" \
   -o notes.txt
+
+# 把目录（或单文件）打成 zip 流式下载；无公开分享链接
+curl -L "https://<your-domain.com>/api/archive?path=folder/" \
+  -H "Authorization: Bearer <apiKey>" \
+  -o folder.zip
+
+# 多选打包（与网页多选下载同一 body）；Basic 会话或 API Key
+curl -X POST "https://<your-domain.com>/api/archive" \
+  -H "Authorization: Bearer <apiKey>" \
+  -H "Content-Type: application/json" \
+  -d '{"keys":["folder/a.txt","folder/sub/"]}' \
+  -o archive.zip
 ```
 
 `GET /api/list` 只返回当前文件夹的 `{ items: [{ key, name, size, isDir, uploaded, etag }] }`。文件始终包含数值 `size`、ISO `uploaded`（以及别名 `updated`）和 R2 `etag`。前缀分隔出来的文件夹为 `isDir: true`、`size: 0`、`uploaded: null`（未知；不会伪造 mtime）。嵌套目录：再用该项的 `key` 调用一次 `/api/list`。若 `path` 指向文件，列表接口返回 **400** 并提示改用 `/api/download`。目录不存在：**404**。密钥无效或过期：**401**。大目录可加 `limit=1..1000`（以及上一页返回的 `cursor`）做分页 —— 还有下一页时响应会带 `nextCursor`。
 
 `GET /api/download` 的 `path` 是对象 key。**HTTP 200** 会流式返回文件（`Content-Type` 来自 R2，否则为 `application/octet-stream`，`Content-Disposition: attachment`）。`path` 缺失/为空，或指向目录/前缀文件夹，返回 **400**；对象不存在 **404**；密钥无效或过期 **401**。内部 `_$flaredrive$/` 路径会被拒绝。
+
+`GET /api/archive?path=` 把单个目录或文件打成 zip，鉴权与其它开放接口相同（Bearer / `X-Api-Key`，或网页 Basic 会话）。**HTTP 200** 流式返回 `application/zip`。目录键会剥掉文件夹前缀（与目录分享一致）。缺 path **400**；路径不存在 **404**；密钥无效或过期 **401**。内部 `_$flaredrive$/` 路径会被拒绝。`POST /api/archive` 传 `{ "keys": [...] }` 可多选打包（网页多选下载）；鉴权与内部路径规则相同。
 
 脚本创建文件夹（父目录会自动创建）：
 
@@ -177,7 +191,7 @@ curl -X DELETE "https://<your-domain.com>/api/images?id=<id>" \
 
 ### MCP
 
-同源 Streamable HTTP MCP：`POST /mcp`（JSON-RPC 2.0）。鉴权与其它开放接口相同（`Authorization: Bearer <apiKey>` 或 `X-Api-Key`；不走网页会话，无 OAuth）。**MCP 依赖 API Key 开关** —— API Key 关闭（或 MCP 关闭）时 `/mcp` 返回 **404**。密钥缺失或无效返回 **HTTP 401**。工具：`list`、`upload`、`download`、`mkdir`、`delete`、`search`、`move`、`copy`、`stat`、`share_create`、`share_list`、`share_revoke`、`trash_list`、`trash_restore`、`trash_empty`、`sites_list`、`sites_config`、`sites_delete`、`pull`、`push`、`publish_site`、`image_upload`、`image_list`、`image_delete`（包装上方 Open API）。超过 1 MiB 的上传自动改走分块（上限 **25 MB**；再大返回工具错误，请用网页端或 davflare-cli）。下载超过 1 MiB 用 `part` / `partSize` 分页。`delete` 默认进回收站；`hard=true` 为永久删除。可用 `trash_list` / `trash_restore` 捞回；`trash_empty` 永久清空回收站。`sites_*` 管理 `sites/` 下的静态站；`upload` / `delete` 也可以直接操作 `sites/<slug>/`。`pull` 走 `agents/{global|agent|agent/project}/{skills|rules|mcp}/` 并返回分层文件（合并：project 覆盖 agent 覆盖 global）；大文件与 `download` 一样分页。`push` 写入该树（`mcp.json` 只能用 `${env:...}`，不要明文密钥）。`publish_site` 把网盘目录同步到 `sites/{slug}/`（同名覆盖，不删 SPA 配置；站点开关关闭时 404）。 `image_upload` / `image_list` / `image_delete` 包装 `/api/images`（公开地址 `https://<SITES_HOST>/i/{id}` 和 Markdown；上限 20 MB；图床开关关闭时 404）。
+同源 Streamable HTTP MCP：`POST /mcp`（JSON-RPC 2.0）。鉴权与其它开放接口相同（`Authorization: Bearer <apiKey>` 或 `X-Api-Key`；不走网页会话，无 OAuth）。**MCP 依赖 API Key 开关** —— API Key 关闭（或 MCP 关闭）时 `/mcp` 返回 **404**。密钥缺失或无效返回 **HTTP 401**。工具：`list`、`upload`、`download`、`zip`、`mkdir`、`delete`、`search`、`move`、`copy`、`stat`、`share_create`、`share_list`、`share_revoke`、`trash_list`、`trash_restore`、`trash_empty`、`sites_list`、`sites_config`、`sites_delete`、`pull`、`push`、`publish_site`、`image_upload`、`image_list`、`image_delete`（包装上方 Open API）。超过 1 MiB 的上传自动改走分块（上限 **25 MB**；再大返回工具错误，请用网页端或 davflare-cli）。下载超过 1 MiB 用 `part` / `partSize` 分页。`zip` 走 `/api/archive` 打包目录（base64；同样 1 MiB / `part` 分页；硬上限 25 MB —— 再大请用 curl 调 `/api/archive`）。`delete` 默认进回收站；`hard=true` 为永久删除。可用 `trash_list` / `trash_restore` 捞回；`trash_empty` 永久清空回收站。`sites_*` 管理 `sites/` 下的静态站；`upload` / `delete` 也可以直接操作 `sites/<slug>/`。`pull` 走 `agents/{global|agent|agent/project}/{skills|rules|mcp}/` 并返回分层文件（合并：project 覆盖 agent 覆盖 global）；大文件与 `download` 一样分页。`push` 写入该树（`mcp.json` 只能用 `${env:...}`，不要明文密钥）。`publish_site` 把网盘目录同步到 `sites/{slug}/`（同名覆盖，不删 SPA 配置；站点开关关闭时 404）。 `image_upload` / `image_list` / `image_delete` 包装 `/api/images`（公开地址 `https://<SITES_HOST>/i/{id}` 和 Markdown；上限 20 MB；图床开关关闭时 404）。
 
 ```bash
 # initialize
@@ -213,6 +227,12 @@ Cursor（`mcp.json`）：
 1. 让助手对某个文件/目录调用 `share_create`，并设 `expiresInHours=24`（可选 `extractCode`）。
 2. 把返回的分享 `url`（路径 `/share/{token}`）转发出去即可。
 3. 用 `share_list` / `share_revoke`（传入 `token`）查看与撤销。
+
+### 对话里把某目录打成 zip 拉回本地
+
+1. 让助手对某个目录路径调用 `zip`（不必 `share_create`，无公开链接）。
+2. 小包（≤ 1 MiB）以 base64 返回 —— 解码后存成 `.zip`。
+3. 更大时传 `part=1`、`part=2`…（可选 `partSize`）拼接各片；或用 API Key curl `GET /api/archive?path=`。
 
 ### 对话里误删再捞回来
 

--- a/functions/_mcp.ts
+++ b/functions/_mcp.ts
@@ -62,6 +62,8 @@ export type ToolCallApis = {
     overwrite?: boolean;
   }) => Promise<Response>;
   download: (query: { path: string }) => Promise<Response>;
+  /** Authenticated folder/file zip via GET /api/archive?path= */
+  zip: (query: { path: string }) => Promise<Response>;
   mkdir: (query: { path: string }) => Promise<Response>;
   delete: (query: { path: string; hard?: boolean }) => Promise<Response>;
   search: (query: {
@@ -202,6 +204,32 @@ export const MCP_TOOLS = [
           minimum: 1,
           maximum: 1048576,
           description: "Chunk size in bytes for paged download; default 1 MiB",
+        },
+      },
+      required: ["path"],
+    },
+  },
+  {
+    name: "zip",
+    description:
+      "Zip a folder (or single file) and return the archive. Up to 1 MiB is returned inline as base64. Larger zips: pass part (1-based) to page through the buffered archive in partSize (default 1 MiB) chunks. Cap 25 MB; beyond that use GET /api/archive with an API key (no public share link).",
+    inputSchema: {
+      type: "object",
+      properties: {
+        path: {
+          type: "string",
+          description: "Folder or file key to zip (directories strip the folder prefix)",
+        },
+        part: {
+          type: "number",
+          minimum: 1,
+          description: "1-based part index for paged download of large zips",
+        },
+        partSize: {
+          type: "number",
+          minimum: 1,
+          maximum: 1048576,
+          description: "Chunk size in bytes for paged zip download; default 1 MiB",
         },
       },
       required: ["path"],
@@ -817,6 +845,94 @@ async function downloadPartTool(
   );
 }
 
+/**
+ * Zip 流无 Content-Length / Range：整包缓冲后按 part 分页返回 base64。
+ * 超过 MCP_MAX_UPLOAD_BYTES 时建议改走 HTTP /api/archive。
+ */
+async function zipTool(
+  apis: ToolCallApis,
+  path: string,
+  part?: number,
+  partSize?: number
+): Promise<McpToolResult> {
+  const response = await apis.zip({ path });
+  if (response.status >= 400) return wrapApiResponse(response);
+  const bytes = new Uint8Array(await response.arrayBuffer());
+  const contentType =
+    response.headers.get("Content-Type") || "application/zip";
+  const filename = (() => {
+    const disposition = response.headers.get("Content-Disposition") || "";
+    const star = /filename\*=UTF-8''([^;]+)/i.exec(disposition);
+    if (star?.[1]) {
+      try {
+        return decodeURIComponent(star[1]);
+      } catch {
+        return star[1];
+      }
+    }
+    const plain = /filename="([^"]+)"/i.exec(disposition);
+    return plain?.[1] || `${path.split("/").filter(Boolean).pop() || "archive"}.zip`;
+  })();
+
+  if (bytes.byteLength > MCP_MAX_UPLOAD_BYTES) {
+    return toolError(
+      `Zip larger than ${Math.floor(MCP_MAX_UPLOAD_BYTES / 1000000)} MB (${bytes.byteLength} bytes). Use GET /api/archive?path= with an API key (curl -o), or zip a smaller folder.`
+    );
+  }
+
+  const wantsPaging = part !== undefined || partSize !== undefined;
+  if (!wantsPaging) {
+    if (bytes.byteLength > MCP_MAX_BYTES) {
+      return toolError(
+        `Zip larger than 1 MiB (${bytes.byteLength} bytes). Pass part=1 to page through it, or curl GET /api/archive?path=.`
+      );
+    }
+    return toolText(
+      JSON.stringify({
+        path,
+        filename,
+        size: bytes.byteLength,
+        contentType,
+        encoding: "base64",
+        content: encodeBase64(bytes),
+        note: "zip archive encoded as base64",
+      })
+    );
+  }
+
+  const chunkSize = Math.min(
+    Math.max(Math.floor(partSize ?? MCP_DOWNLOAD_PART_SIZE), 1),
+    MCP_DOWNLOAD_PART_SIZE
+  );
+  if (bytes.byteLength === 0) {
+    return toolError("空压缩包，无法分页");
+  }
+  const totalParts = Math.ceil(bytes.byteLength / chunkSize);
+  const index = Math.floor(part ?? 1);
+  if (index < 1 || index > totalParts) {
+    return toolError(`part 需在 1-${totalParts}（共 ${totalParts} 片）`);
+  }
+  const offset = (index - 1) * chunkSize;
+  const slice = bytes.subarray(offset, offset + chunkSize);
+  if (slice.byteLength > MCP_MAX_BYTES) {
+    return toolError("分片超出内联上限，请减小 partSize");
+  }
+  return toolText(
+    JSON.stringify({
+      path,
+      filename,
+      size: bytes.byteLength,
+      contentType,
+      part: index,
+      totalParts,
+      offset,
+      length: slice.byteLength,
+      encoding: "base64",
+      content: encodeBase64(slice),
+    })
+  );
+}
+
 function asString(value: unknown, fallback = ""): string {
   return typeof value === "string" ? value : fallback;
 }
@@ -1236,6 +1352,13 @@ async function callTool(
           note: "binary content encoded as base64",
         })
       );
+    }
+    case "zip": {
+      const path = asString(args.path);
+      if (!path) return toolError("path is required");
+      const part = asOptionalNumber(args.part);
+      const partSize = asOptionalNumber(args.partSize);
+      return zipTool(apis, path, part, partSize);
     }
     case "mkdir": {
       const path = asString(args.path);

--- a/functions/api/_zip.ts
+++ b/functions/api/_zip.ts
@@ -2,7 +2,7 @@ import { Zip, ZipPassThrough } from "fflate";
 import { decodeRawPath } from "./_apikey";
 
 // 把选中键（文件或目录）打包为 zip 流。目录递归收齐后代，空目录写占位条目。
-// archive（会话鉴权）与 share（目录分享）共用。
+// archive（会话 Basic + API Key）与 share（目录分享）共用。
 
 export async function listAllObjects(
   bucket: R2Bucket,

--- a/functions/api/archive.ts
+++ b/functions/api/archive.ts
@@ -1,9 +1,11 @@
 import { buildZipStream } from "./_zip";
 import {
   decodeRawPath,
+  isCollectionObject,
   isInternalKey,
+  isSessionOrKeyAuthorized,
+  normalizeDirKey,
   textResponse,
-  verifyBasicAuth,
 } from "./_apikey";
 
 interface ArchiveEnv {
@@ -12,12 +14,65 @@ interface ArchiveEnv {
   WEBDAV_PASSWORD: string;
 }
 
-export const onRequestPost: PagesFunction<ArchiveEnv> = async (context) => {
-  const { request, env } = context;
+function basename(key: string) {
+  const name = key.split("/").filter(Boolean).pop() || "archive";
+  return name.replace(/[\u0000-\u001f]/g, "");
+}
 
-  if (!verifyBasicAuth(request, env.WEBDAV_USERNAME, env.WEBDAV_PASSWORD)) {
+function attachmentDisposition(filename: string) {
+  const fallback = filename.replace(/["\\\r\n]/g, "_") || "archive.zip";
+  const encoded = encodeURIComponent(filename || "archive.zip").replace(
+    /['()]/g,
+    (ch) => `%${ch.charCodeAt(0).toString(16).toUpperCase()}`
+  );
+  return `attachment; filename="${fallback}"; filename*=UTF-8''${encoded}`;
+}
+
+async function authorizeArchive(
+  request: Request,
+  env: ArchiveEnv
+): Promise<Response | null> {
+  if (
+    !(await isSessionOrKeyAuthorized(
+      request,
+      env.BUCKET,
+      env.WEBDAV_USERNAME,
+      env.WEBDAV_PASSWORD
+    ))
+  ) {
     return textResponse("Unauthorized", 401);
   }
+  return null;
+}
+
+async function zipResponse(
+  bucket: R2Bucket,
+  selectedKeys: string[],
+  options: { stripPrefix?: string; filename?: string } = {}
+) {
+  const stream = await buildZipStream(bucket, selectedKeys, {
+    stripPrefix: options.stripPrefix,
+  });
+  const filename = options.filename || "archive.zip";
+  return new Response(stream, {
+    headers: {
+      "Content-Type": "application/zip",
+      "Content-Disposition": attachmentDisposition(filename),
+      "Cache-Control": "no-store",
+    },
+  });
+}
+
+/**
+ * Authenticated folder/file zip for Open API + web UI.
+ * - POST { keys: string[] }: multi-select (session Basic or API key); no stripPrefix.
+ * - GET ?path=: single key (folder preferred); directories strip the folder prefix
+ *   so zip roots at the folder name, matching directory shares.
+ */
+export const onRequestPost: PagesFunction<ArchiveEnv> = async (context) => {
+  const { request, env } = context;
+  const denied = await authorizeArchive(request, env);
+  if (denied) return denied;
 
   let selectedKeys: string[];
   try {
@@ -42,11 +97,39 @@ export const onRequestPost: PagesFunction<ArchiveEnv> = async (context) => {
     }
   }
 
-  const stream = await buildZipStream(env.BUCKET, selectedKeys);
-  return new Response(stream, {
-    headers: {
-      "Content-Type": "application/zip",
-      "Content-Disposition": 'attachment; filename="archive.zip"',
-    },
+  return zipResponse(env.BUCKET, selectedKeys);
+};
+
+export const onRequestGet: PagesFunction<ArchiveEnv> = async (context) => {
+  const { request, env } = context;
+  const denied = await authorizeArchive(request, env);
+  if (denied) return denied;
+
+  const rawPath = new URL(request.url).searchParams.get("path");
+  const keyOrErr = normalizeDirKey(rawPath);
+  if (keyOrErr instanceof Response) return keyOrErr;
+  const key = keyOrErr;
+
+  const head = await env.BUCKET.head(key);
+  const listing = await env.BUCKET.list({
+    prefix: `${key}/`,
+    limit: 1,
+  });
+  const hasChildren = listing.objects.length > 0;
+  const isDir =
+    isCollectionObject(head) ||
+    (rawPath || "").trim().endsWith("/") ||
+    (head === null && hasChildren);
+
+  if (head === null && !hasChildren) {
+    return textResponse("路径不存在", 404);
+  }
+
+  // 目录：去掉父前缀，zip 根即该文件夹内容（与目录分享一致）。
+  // 单文件：整键打进 zip，便于脚本对文件也走同一接口。
+  const filename = `${basename(key)}.zip`;
+  return zipResponse(env.BUCKET, [key], {
+    stripPrefix: isDir ? key : undefined,
+    filename,
   });
 };

--- a/functions/mcp.ts
+++ b/functions/mcp.ts
@@ -2,6 +2,7 @@ import { authorizeApiKey } from "./api/_apikey";
 import { featureDisabledResponse, loadFeatureFlags } from "./_flags";
 import { onRequestPost as copyOnPost } from "./api/copy";
 import { onRequestDelete as deleteOnDelete } from "./api/delete";
+import { onRequestGet as archiveOnGet } from "./api/archive";
 import { onRequestGet as downloadOnGet } from "./api/download";
 import { onRequestGet as listOnGet } from "./api/list";
 import { onRequestPost as mkdirOnPost } from "./api/mkdir";
@@ -141,6 +142,12 @@ function makeApis(context: McpContext): ToolCallApis {
       url.searchParams.set("path", path);
       const request = cloneApiRequest(context.request, "GET", url);
       return downloadOnGet(withRequest(context, request));
+    },
+    async zip({ path }) {
+      const url = new URL("/api/archive", origin);
+      url.searchParams.set("path", path);
+      const request = cloneApiRequest(context.request, "GET", url);
+      return archiveOnGet(withRequest(context, request));
     },
     async mkdir({ path }) {
       const url = new URL("/api/mkdir", origin);

--- a/src/app/__tests__/archiveApi.test.ts
+++ b/src/app/__tests__/archiveApi.test.ts
@@ -1,0 +1,249 @@
+/**
+ * functions/api/archive.ts：会话 Basic + API Key 鉴权、GET ?path= 目录 zip、
+ * POST multi-select、内部前缀拒绝、404。
+ */
+import { ReadableStream } from "stream/web";
+(globalThis as any).ReadableStream =
+  (globalThis as any).ReadableStream ?? ReadableStream;
+
+import {
+  onRequestGet,
+  onRequestPost,
+} from "../../../functions/api/archive";
+import {
+  InMemoryBucket,
+  basicAuthHeader,
+  makeContext,
+} from "../testInMemoryBucket";
+
+const HOST = "http://drive.example.com";
+const AUTH = basicAuthHeader("user", "pass");
+const API_KEY = "fd_archive_test_key";
+const KEYS_PREFIX = "_$flaredrive$/apikeys/";
+
+async function sha256Hex(value: string): Promise<string> {
+  const digest = await crypto.subtle.digest(
+    "SHA-256",
+    new TextEncoder().encode(value)
+  );
+  return Array.from(new Uint8Array(digest))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+function makeEnv(bucket: InMemoryBucket) {
+  return {
+    BUCKET: bucket.asBucket(),
+    WEBDAV_USERNAME: "user",
+    WEBDAV_PASSWORD: "pass",
+  };
+}
+
+async function seedApiKey(bucket: InMemoryBucket) {
+  bucket.seed([
+    {
+      key: `${KEYS_PREFIX}archive.json`,
+      body: JSON.stringify({
+        id: "archive",
+        name: "archive",
+        prefix: "fd_",
+        keyHash: await sha256Hex(API_KEY),
+        createdAt: "2026-01-01T00:00:00.000Z",
+        expiresAt: null,
+      }),
+      contentType: "application/json",
+    },
+  ]);
+}
+
+function seedFolder(bucket: InMemoryBucket) {
+  bucket.seed([
+    {
+      key: "docs",
+      body: "",
+      contentType: "application/x-directory",
+    },
+    { key: "docs/a.txt", body: "AAA", contentType: "text/plain" },
+    { key: "docs/sub/b.txt", body: "BBB", contentType: "text/plain" },
+  ]);
+}
+
+describe("archive auth", () => {
+  test("anonymous GET/POST are 401", async () => {
+    const bucket = new InMemoryBucket();
+    seedFolder(bucket);
+    const get = await onRequestGet(
+      makeContext(
+        new Request(`${HOST}/api/archive?path=docs`),
+        makeEnv(bucket)
+      )
+    );
+    expect(get.status).toBe(401);
+
+    const post = await onRequestPost(
+      makeContext(
+        new Request(`${HOST}/api/archive`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ keys: ["docs"] }),
+        }),
+        makeEnv(bucket)
+      )
+    );
+    expect(post.status).toBe(401);
+  });
+
+  test("Basic session POST still works (web UI)", async () => {
+    const bucket = new InMemoryBucket();
+    seedFolder(bucket);
+    const response = await onRequestPost(
+      makeContext(
+        new Request(`${HOST}/api/archive`, {
+          method: "POST",
+          headers: {
+            Authorization: AUTH,
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({ keys: ["docs"] }),
+        }),
+        makeEnv(bucket)
+      )
+    );
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Content-Type")).toBe("application/zip");
+    const bytes = new Uint8Array(await response.arrayBuffer());
+    expect(bytes.byteLength).toBeGreaterThan(0);
+  });
+
+  test("API key GET ?path= streams zip", async () => {
+    const bucket = new InMemoryBucket();
+    seedFolder(bucket);
+    await seedApiKey(bucket);
+    const response = await onRequestGet(
+      makeContext(
+        new Request(`${HOST}/api/archive?path=docs`, {
+          headers: { "X-Api-Key": API_KEY },
+        }),
+        makeEnv(bucket)
+      )
+    );
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Content-Type")).toBe("application/zip");
+    expect(response.headers.get("Content-Disposition")).toContain("docs.zip");
+    const bytes = new Uint8Array(await response.arrayBuffer());
+    expect(bytes.byteLength).toBeGreaterThan(0);
+    // ZIP local file header magic
+    expect(bytes[0]).toBe(0x50);
+    expect(bytes[1]).toBe(0x4b);
+  });
+
+  test("Bearer API key POST multi-select works", async () => {
+    const bucket = new InMemoryBucket();
+    seedFolder(bucket);
+    await seedApiKey(bucket);
+    const response = await onRequestPost(
+      makeContext(
+        new Request(`${HOST}/api/archive`, {
+          method: "POST",
+          headers: {
+            Authorization: `Bearer ${API_KEY}`,
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({ keys: ["docs/a.txt", "docs/sub/"] }),
+        }),
+        makeEnv(bucket)
+      )
+    );
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Content-Type")).toBe("application/zip");
+  });
+});
+
+describe("archive validation", () => {
+  test("rejects internal _$flaredrive$/ keys", async () => {
+    const bucket = new InMemoryBucket();
+    await seedApiKey(bucket);
+    const get = await onRequestGet(
+      makeContext(
+        new Request(`${HOST}/api/archive?path=_$flaredrive$/shares/x`, {
+          headers: { "X-Api-Key": API_KEY },
+        }),
+        makeEnv(bucket)
+      )
+    );
+    expect(get.status).toBe(400);
+    expect(await get.text()).toContain("内部");
+
+    const post = await onRequestPost(
+      makeContext(
+        new Request(`${HOST}/api/archive`, {
+          method: "POST",
+          headers: {
+            "X-Api-Key": API_KEY,
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({ keys: ["_$flaredrive$/trash/x"] }),
+        }),
+        makeEnv(bucket)
+      )
+    );
+    expect(post.status).toBe(400);
+  });
+
+  test("missing path / empty keys / unknown path", async () => {
+    const bucket = new InMemoryBucket();
+    await seedApiKey(bucket);
+
+    const missingPath = await onRequestGet(
+      makeContext(
+        new Request(`${HOST}/api/archive`, {
+          headers: { "X-Api-Key": API_KEY },
+        }),
+        makeEnv(bucket)
+      )
+    );
+    expect(missingPath.status).toBe(400);
+
+    const emptyKeys = await onRequestPost(
+      makeContext(
+        new Request(`${HOST}/api/archive`, {
+          method: "POST",
+          headers: {
+            "X-Api-Key": API_KEY,
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({ keys: [] }),
+        }),
+        makeEnv(bucket)
+      )
+    );
+    expect(emptyKeys.status).toBe(400);
+
+    const missing = await onRequestGet(
+      makeContext(
+        new Request(`${HOST}/api/archive?path=no-such-folder`, {
+          headers: { "X-Api-Key": API_KEY },
+        }),
+        makeEnv(bucket)
+      )
+    );
+    expect(missing.status).toBe(404);
+  });
+
+  test("single file path zips as application/zip", async () => {
+    const bucket = new InMemoryBucket();
+    bucket.seed([{ key: "solo.txt", body: "solo", contentType: "text/plain" }]);
+    await seedApiKey(bucket);
+    const response = await onRequestGet(
+      makeContext(
+        new Request(`${HOST}/api/archive?path=solo.txt`, {
+          headers: { Authorization: `Bearer ${API_KEY}` },
+        }),
+        makeEnv(bucket)
+      )
+    );
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Content-Type")).toBe("application/zip");
+    expect(response.headers.get("Content-Disposition")).toContain("solo.txt.zip");
+  });
+});

--- a/src/app/__tests__/mcp.test.ts
+++ b/src/app/__tests__/mcp.test.ts
@@ -28,6 +28,14 @@ function mockApis(overrides: Partial<ToolCallApis> = {}): ToolCallApis {
     list: async () => httpJsonResponse({ items: [] }),
     upload: async () => httpJsonResponse({ key: "notes.txt", overwritten: false }, 201),
     download: async () => new Response("hello", { status: 200, headers: { "Content-Type": "text/plain" } }),
+    zip: async () =>
+      new Response(new Uint8Array([0x50, 0x4b, 0x05, 0x06, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]), {
+        status: 200,
+        headers: {
+          "Content-Type": "application/zip",
+          "Content-Disposition": 'attachment; filename="folder.zip"',
+        },
+      }),
     mkdir: async () => httpJsonResponse({ key: "folder/", created: true }, 201),
     delete: async () => httpJsonResponse({ key: "notes.txt", deleted: true, soft: true }),
     search: async () => httpJsonResponse({ matches: [], nextCursor: null }),
@@ -85,11 +93,12 @@ function toolPayload(result: Awaited<ReturnType<typeof dispatchMcpRequest>>) {
 }
 
 describe("mcp protocol", () => {
-  test("tool catalog: base + search/move/copy/stat/share/trash/sites + pull/push/publish_site", () => {
+  test("tool catalog: base + zip + search/move/copy/stat/share/trash/sites + pull/push/publish_site", () => {
     expect(MCP_TOOL_NAMES).toEqual([
       "list",
       "upload",
       "download",
+      "zip",
       "mkdir",
       "delete",
       "search",
@@ -112,7 +121,7 @@ describe("mcp protocol", () => {
       "image_list",
       "image_delete",
     ]);
-    expect(MCP_TOOLS).toHaveLength(24);
+    expect(MCP_TOOLS).toHaveLength(25);
   });
 
   test("parseJsonRpcBody rejects invalid json", () => {
@@ -298,6 +307,75 @@ describe("mcp protocol", () => {
     const stat = vi.fn(async () => httpJsonResponse({ kind: "file", size: 3 }));
     await callTool("stat", { path: "a.txt" }, { stat });
     expect(stat).toHaveBeenCalledWith({ path: "a.txt" });
+  });
+
+  test("zip returns base64 archive for small folders", async () => {
+    const zipBytes = new Uint8Array([0x50, 0x4b, 0x03, 0x04, 1, 2, 3, 4]);
+    const zip = vi.fn(async () =>
+      new Response(zipBytes, {
+        status: 200,
+        headers: {
+          "Content-Type": "application/zip",
+          "Content-Disposition": 'attachment; filename="docs.zip"',
+        },
+      })
+    );
+    const result = await callTool("zip", { path: "docs" }, { zip });
+    expect(zip).toHaveBeenCalledWith({ path: "docs" });
+    const body = toolPayload(result);
+    expect(body.isError).toBeFalsy();
+    const parsed = JSON.parse(body.content[0].text);
+    expect(parsed.encoding).toBe("base64");
+    expect(parsed.filename).toBe("docs.zip");
+    expect(parsed.size).toBe(zipBytes.byteLength);
+    expect(parsed.content).toBe(Buffer.from(zipBytes).toString("base64"));
+  });
+
+  test("zip over 1 MiB without part hints paging", async () => {
+    const big = new Uint8Array(MCP_MAX_BYTES + 10);
+    const zip = vi.fn(async () =>
+      new Response(big, {
+        status: 200,
+        headers: { "Content-Type": "application/zip" },
+      })
+    );
+    const result = await callTool("zip", { path: "big" }, { zip });
+    const body = toolPayload(result);
+    expect(body.isError).toBe(true);
+    expect(body.content[0].text).toMatch(/part=1/);
+  });
+
+  test("zip with part pages buffered archive as base64", async () => {
+    const payload = new Uint8Array(12);
+    for (let i = 0; i < payload.length; i++) payload[i] = i + 1;
+    const zip = vi.fn(async () =>
+      new Response(payload, {
+        status: 200,
+        headers: {
+          "Content-Type": "application/zip",
+          "Content-Disposition": "attachment; filename*=UTF-8''pack.zip",
+        },
+      })
+    );
+    const result = await callTool(
+      "zip",
+      { path: "pack", part: 2, partSize: 5 },
+      { zip }
+    );
+    const body = toolPayload(result);
+    expect(body.isError).toBeFalsy();
+    const parsed = JSON.parse(body.content[0].text);
+    expect(parsed.part).toBe(2);
+    expect(parsed.totalParts).toBe(3);
+    expect(parsed.filename).toBe("pack.zip");
+    expect(parsed.content).toBe(Buffer.from(payload.subarray(5, 10)).toString("base64"));
+  });
+
+  test("zip rejects missing path", async () => {
+    const zip = vi.fn(async () => new Response(null, { status: 200 }));
+    const missing = await callTool("zip", {}, { zip });
+    expect(toolPayload(missing).isError).toBe(true);
+    expect(zip).not.toHaveBeenCalled();
   });
 
   test("share tools create, list, revoke", async () => {


### PR DESCRIPTION
## Summary
- Extend `/api/archive` to accept API Key (and keep web Basic): `GET ?path=` for a folder/file zip, `POST {keys}` for multi-select; reuse `buildZipStream`; reject `_$flaredrive$/`.
- Add MCP tool `zip` (tool count 24→25) returning base64 with `part`/`partSize` paging (25 MB hard cap); no `share_create` / public link.
- Bilingual docs/API + README tool count; chat example «对话里把某目录打成 zip 拉回本地»; unit tests.

## Test plan
- [x] `npm run typecheck`
- [x] `vitest` archiveApi + mcp + shareToken
- [x] `npm run test:ci` / `test:coverage` / `build`
- [ ] CI green on PR