### PR TITLE
fix(api): reject bare _$flaredrive$ after normalizeDirKey (#95)

### DIFF
--- a/functions/api/_apikey.ts
+++ b/functions/api/_apikey.ts
@@ -185,7 +185,18 @@ export async function isSessionOrKeyAuthorized(
 }
 
 export function isInternalKey(key: string) {
-  return key.startsWith(INTERNAL_PREFIX) || key.includes("/_$flaredrive$/");
+  // normalizeDirKey strips a trailing slash, so the bare internal root
+  // ("_$flaredrive$") must match exactly — startsWith(INTERNAL_PREFIX)
+  // alone requires "_$flaredrive$/". Also catch nested bare roots after
+  // the same normalize (e.g. "wrap/_$flaredrive$"). Do NOT use a bare
+  // startsWith("_$flaredrive$") — that would false-positive user folders
+  // like "_$flaredrive$backup".
+  return (
+    key === "_$flaredrive$" ||
+    key.startsWith(INTERNAL_PREFIX) ||
+    key.includes("/_$flaredrive$/") ||
+    key.endsWith("/_$flaredrive$")
+  );
 }
 
 export function isCollectionObject(

--- a/src/app/__tests__/archiveApi.test.ts
+++ b/src/app/__tests__/archiveApi.test.ts
@@ -190,6 +190,66 @@ describe("archive validation", () => {
     expect(post.status).toBe(400);
   });
 
+  // #95: normalizeDirKey strips trailing slash → bare "_$flaredrive$" must
+  // still be rejected (was HTTP 200 empty ~22B zip before the harden).
+  test("rejects internal root _$flaredrive$/ and bare _$flaredrive$ after normalize", async () => {
+    const bucket = new InMemoryBucket();
+    await seedApiKey(bucket);
+
+    for (const path of ["_$flaredrive$/", "_$flaredrive$"]) {
+      const get = await onRequestGet(
+        makeContext(
+          new Request(
+            `${HOST}/api/archive?path=${encodeURIComponent(path)}`,
+            { headers: { "X-Api-Key": API_KEY } }
+          ),
+          makeEnv(bucket)
+        )
+      );
+      expect(get.status).toBe(400);
+      expect(await get.text()).toContain("内部");
+      expect(get.headers.get("Content-Type")).not.toBe("application/zip");
+    }
+
+    for (const key of ["_$flaredrive$/", "_$flaredrive$"]) {
+      const post = await onRequestPost(
+        makeContext(
+          new Request(`${HOST}/api/archive`, {
+            method: "POST",
+            headers: {
+              "X-Api-Key": API_KEY,
+              "Content-Type": "application/json",
+            },
+            body: JSON.stringify({ keys: [key] }),
+          }),
+          makeEnv(bucket)
+        )
+      );
+      expect(post.status).toBe(400);
+      expect(await post.text()).toContain("内部");
+    }
+  });
+
+  test("isInternalKey / normalizeDirKey reject bare internal root", async () => {
+    const { isInternalKey, normalizeDirKey } = await import(
+      "../../../functions/api/_apikey"
+    );
+    expect(isInternalKey("_$flaredrive$")).toBe(true);
+    expect(isInternalKey("_$flaredrive$/")).toBe(true);
+    expect(isInternalKey("_$flaredrive$/thumbnails/x")).toBe(true);
+    expect(isInternalKey("wrap/_$flaredrive$")).toBe(true);
+    // must not false-positive similarly named user folders
+    expect(isInternalKey("_$flaredrive$backup")).toBe(false);
+    expect(isInternalKey("docs")).toBe(false);
+
+    for (const raw of ["_$flaredrive$/", "_$flaredrive$"]) {
+      const result = normalizeDirKey(raw);
+      expect(result).toBeInstanceOf(Response);
+      expect((result as Response).status).toBe(400);
+      expect(await (result as Response).text()).toContain("内部");
+    }
+  });
+
   test("missing path / empty keys / unknown path", async () => {
     const bucket = new InMemoryBucket();
     await seedApiKey(bucket);

--- a/src/app/__tests__/mcp.test.ts
+++ b/src/app/__tests__/mcp.test.ts
@@ -378,6 +378,18 @@ describe("mcp protocol", () => {
     expect(zip).not.toHaveBeenCalled();
   });
 
+  // #95: MCP zip must surface archive 400 for internal root (not empty zip).
+  test("zip rejects internal _$flaredrive$/ and bare _$flaredrive$ from archive", async () => {
+    for (const path of ["_$flaredrive$/", "_$flaredrive$"]) {
+      const zip = vi.fn(async () => new Response("禁止访问内部目录", { status: 400 }));
+      const result = await callTool("zip", { path }, { zip });
+      expect(zip).toHaveBeenCalledWith({ path });
+      const payload = toolPayload(result);
+      expect(payload.isError).toBe(true);
+      expect(payload.content[0].text).toContain("内部");
+    }
+  });
+
   test("share tools create, list, revoke", async () => {
     const shareCreate = vi.fn(async () => httpJsonResponse({ token: "tok-1" }, 201));
     const created = await callTool(


### PR DESCRIPTION
## Summary
- Harden `isInternalKey` so the bare internal root `_$flaredrive$` (and nested `…/_$flaredrive$`) is rejected after `normalizeDirKey` strips the trailing slash.
- Keep existing `_$flaredrive$/…` and `/_$flaredrive$/` checks; avoid false-positives on similarly named user folders (e.g. `_$flaredrive$backup`).
- Unit tests: archive GET/POST + `normalizeDirKey` for `_$flaredrive$/` and `_$flaredrive$`; MCP zip surfaces archive 400 instead of empty zip.

Fixes #95

## Test plan
- [x] `npm test -- src/app/__tests__/archiveApi.test.ts src/app/__tests__/mcp.test.ts`
- [ ] CI green
- [ ] Manual (optional): `GET /api/archive?path=_$flaredrive$/` → 400「禁止访问内部目录」; same for bare `_$flaredrive$`; MCP `zip` same paths → tool error